### PR TITLE
chore: rename repository references to google-adk-on-bare-metal

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -17,7 +17,7 @@ Best if you don't want to manage Python versions on the host.
 1.  **Clone & Config**
     ```bash
     git clone <your-repo-url>
-    cd open-services-agent-starter-pack
+    cd google-adk-on-bare-metal
     cp .env.example .env
     # Edit .env with your DATABASE_URL and API Keys
     ```
@@ -52,7 +52,7 @@ source $HOME/.cargo/env
 ### 2. Clone & Setup
 ```bash
 git clone <your-repo-url>
-cd open-services-agent-starter-pack
+cd google-adk-on-bare-metal
 
 # Install Python dependencies
 uv sync

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "google-adk-wo-gcp"
+name = "google-adk-on-bare-metal"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"

--- a/systemd/agent.service
+++ b/systemd/agent.service
@@ -8,18 +8,18 @@ User=ubuntu
 Group=ubuntu
 
 # Directory where the code is cloned
-WorkingDirectory=/home/ubuntu/open-services-agent-starter-pack
+WorkingDirectory=/home/ubuntu/google-adk-on-bare-metal
 
 # Environment variables
 # Option A: Load from file (Recommended)
-EnvironmentFile=/home/ubuntu/open-services-agent-starter-pack/.env
+EnvironmentFile=/home/ubuntu/google-adk-on-bare-metal/.env
 # Option B: Set explicitly
 # Environment="DATABASE_URL=postgresql://..."
 # Environment="OPENROUTER_API_KEY=sk-..."
 
 # Path to 'uv' or 'python' executable
 # Assuming 'uv sync' has been run, we use the virtualenv python
-ExecStart=/home/ubuntu/open-services-agent-starter-pack/.venv/bin/python -m server
+ExecStart=/home/ubuntu/google-adk-on-bare-metal/.venv/bin/python -m server
 
 # Restart settings
 Restart=always

--- a/uv.lock
+++ b/uv.lock
@@ -771,7 +771,7 @@ wheels = [
 ]
 
 [[package]]
-name = "google-adk-wo-gcp"
+name = "google-adk-on-bare-metal"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [


### PR DESCRIPTION
Updates all references of 'open-services-agent-starter-pack' and 'google-adk-wo-gcp' to 'google-adk-on-bare-metal'.