### PR TITLE
Fix Docker build: Use pip to install uv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@
 # ============================================================================
 FROM python:3.13-slim AS builder
 
-# Install uv from official distroless image
-COPY --from=ghcr.io/astral-sh/uv:0.9.6 /uv /uvx /bin/
+# Install uv
+RUN pip install uv==0.9.26
 
 # Set working directory
 WORKDIR /app

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   agent:
-    image: ghcr.io/queryplanner/google-adk-on-bare-metal:main
+    image: ghcr.io/queryplanner/google-adk-wo-gcp:main
     build: .
     ports:
       - "8080:8080"

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -29,7 +29,7 @@ Instead of building locally, you can pull the pre-built image from GHCR.
     ```
 2.  **Pull the latest image**:
     ```bash
-    docker pull ghcr.io/<your-org-or-username>/google-adk-on-bare-metal:main
+    docker pull ghcr.io/<your-org-or-username>/google-adk-wo-gcp:main
     ```
 
 ### Automatic Deployment
@@ -39,7 +39,7 @@ To automate deployment, update your `compose.yaml` to use the GHCR image:
 ```yaml
 services:
   agent:
-    image: ghcr.io/<your-org-or-username>/google-adk-on-bare-metal:main
+    image: ghcr.io/<your-org-or-username>/google-adk-wo-gcp:main
     # ... rest of config
 ```
 


### PR DESCRIPTION
Resolves build failure due to GHCR auth denied error by installing uv from PyPI.