### PR TITLE
chore(ci): remove stale branch from docker-publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Docker Publish
 
 on:
   push:
-    branches: [ "main", "migration/port-agent-foundation" ]
+    branches: [ "main" ]
     tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ "main" ]


### PR DESCRIPTION
Removes the  branch from the trigger list as it no longer exists.