### PR TITLE
Update return_instruction_root verbosity

### DIFF
--- a/src/agent/prompt.py
+++ b/src/agent/prompt.py
@@ -12,8 +12,18 @@ def return_description_root() -> str:
 
 def return_instruction_root() -> str:
     instruction = """
-Answer the user's question politely and factually.
-Remember important facts about the user.
+<output_verbosity_spec>
+- Default: 3–6 sentences or ≤5 bullets for typical answers.
+- For simple “yes/no + short explanation” questions: ≤2 sentences.
+- For complex multi-step or multi-file tasks:
+  - 1 short overview paragraph
+  - then ≤5 bullets tagged: What changed, Where, Risks, Next steps, Open questions.
+- Provide clear and structured responses that balance informativeness with conciseness.
+  Break down the information into digestible chunks and use formatting like lists,
+  paragraphs and tables when helpful.
+- Avoid long narrative paragraphs; prefer compact bullets and short sections.
+- Do not rephrase the user’s request unless it changes semantics.
+</output_verbosity_spec>
 """
     return instruction
 

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -4,10 +4,10 @@ import logging
 from typing import cast
 
 import pytest
-
 from conftest import MockMemoryCallbackContext
-from agent.callbacks import add_session_to_memory
 from google.adk.agents.callback_context import CallbackContext
+
+from agent.callbacks import add_session_to_memory
 
 
 def as_callback_context(context: MockMemoryCallbackContext) -> CallbackContext:

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -54,8 +54,9 @@ class TestReturnInstructionRoot:
         """Test that instruction contains expected guidance."""
         instruction = return_instruction_root()
 
-        assert "question" in instruction.lower()
-        assert "politely" in instruction.lower() or "factually" in instruction.lower()
+        assert "<output_verbosity_spec>" in instruction
+        assert "sentences" in instruction.lower()
+        assert "bullets" in instruction.lower()
 
     def test_instruction_is_consistent(self) -> None:
         """Test that function returns the same instruction on multiple calls."""


### PR DESCRIPTION
Updates the return_instruction_root function in src/agent/prompt.py to use a structured output verbosity specification. Also updates related tests and fixes linting issues.