### PR TITLE
fix: update production env vars for model and observability

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -104,6 +104,10 @@ jobs:
             DATABASE_URL=${{ secrets.DATABASE_URL }}
             OPENROUTER_API_KEY=${{ secrets.OPENROUTER_API_KEY }}
             GOOGLE_API_KEY=${{ secrets.GOOGLE_API_KEY }}
+            ROOT_AGENT_MODEL=${{ secrets.ROOT_AGENT_MODEL }}
+            LANGFUSE_PUBLIC_KEY=${{ secrets.LANGFUSE_PUBLIC_KEY }}
+            LANGFUSE_SECRET_KEY=${{ secrets.LANGFUSE_SECRET_KEY }}
+            LANGFUSE_HOST=${{ secrets.LANGFUSE_HOST }}
             LOG_LEVEL=INFO
             PORT=8080
             HOST=0.0.0.0


### PR DESCRIPTION
## What
- Added 'ROOT_AGENT_MODEL', 'LANGFUSE_PUBLIC_KEY', 'LANGFUSE_SECRET_KEY', and 'LANGFUSE_HOST' to the automated .env generation in GitHub Actions.

## Why
- The previous deployment failed because the application requires these variables to authenticate with the LLM provider (Google) and the observability platform (Langfuse).
- Specifically, the 'ValueError: Missing key inputs argument!' was caused by missing API configuration.

## How
- Updated '.github/workflows/docker-publish.yml' to inject these secrets into the container runtime environment.

## Tests
- [x] Local CI passed.
- [ ] Needs verification on the next deployment (ensure GitHub Secrets are set).