### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-03-28
+
+### Added
+- Integrate mem0ai memory with LiteLLM and OpenRouter support (#29).
+
+### Changed
+- Refactor mem0 integration into a dedicated package layout (#31).
+- Upgrade google-adk to 1.25.1 (#27).
+
+### Fixed
+- Use dynamic image name in Docker Compose and deploy flow (#28).
+
 ## [0.1.1] - 2026-02-20
 
 ### Fixed
@@ -33,4 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Resolved `ValueError: Missing key inputs argument` by ensuring API keys are properly injected into the container environment.
 - Addressed interactive prompt issues in `setup.sh` by setting `DEBIAN_FRONTEND=noninteractive`.
-\n[Unreleased]: https://github.com/QueryPlanner/google-adk-wo-gcp/compare/v0.1.1...HEAD\n[0.1.1]: https://github.com/QueryPlanner/google-adk-wo-gcp/compare/v0.1.0...v0.1.1\n[0.1.0]: https://github.com/QueryPlanner/google-adk-wo-gcp/releases/tag/v0.1.0
+
+[Unreleased]: https://github.com/QueryPlanner/google-adk-wo-gcp/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/QueryPlanner/google-adk-wo-gcp/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/QueryPlanner/google-adk-wo-gcp/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/QueryPlanner/google-adk-wo-gcp/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resolved `ValueError: Missing key inputs argument` by ensuring API keys are properly injected into the container environment.
 - Addressed interactive prompt issues in `setup.sh` by setting `DEBIAN_FRONTEND=noninteractive`.
 
-[Unreleased]: https://github.com/QueryPlanner/google-adk-wo-gcp/compare/v0.2.0...HEAD
-[0.2.0]: https://github.com/QueryPlanner/google-adk-wo-gcp/compare/v0.1.1...v0.2.0
-[0.1.1]: https://github.com/QueryPlanner/google-adk-wo-gcp/compare/v0.1.0...v0.1.1
-[0.1.0]: https://github.com/QueryPlanner/google-adk-wo-gcp/releases/tag/v0.1.0
+[Unreleased]: https://github.com/QueryPlanner/google-adk-on-bare-metal/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/QueryPlanner/google-adk-on-bare-metal/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/QueryPlanner/google-adk-on-bare-metal/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/QueryPlanner/google-adk-on-bare-metal/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "google-adk-on-bare-metal"
-version = "0.1.1"
+version = "0.2.0"
 description = "Production-ready template for building and deploying AI agents using Google ADK, LiteLLM, and Postgres on self-hosted infrastructure"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -575,7 +575,7 @@ wheels = [
 
 [[package]]
 name = "google-adk-on-bare-metal"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
## What

Prepare the **v0.2.0** release: version metadata, changelog, and lockfile aligned with `origin` (QueryPlanner/google-adk-wo-gcp).

## Why

Commits merged since **v0.1.1** include new memory integration and related fixes. Per semantic versioning (pre-1.0), this is a **minor** bump.

## How

- Set `version` to `0.2.0` in `pyproject.toml`
- Add `[0.2.0]` to `CHANGELOG.md` (Keep a Changelog) and update comparison links using `origin` (`github.com/QueryPlanner/google-adk-wo-gcp`)
- Run `uv lock` so the workspace package version matches

## Tests

- [ ] CI passes on this PR (lint, typecheck, tests)

After merge, **Phase 2**: tag `v0.2.0` on `main` and `git push origin v0.2.0`.

Made with [Cursor](https://cursor.com)