### PR TITLE
chore: release v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-03-28
+
+### Changed
+- Bump package version to 0.20.0.
+
 ## [0.2.0] - 2026-03-28
 
 ### Added
@@ -46,7 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resolved `ValueError: Missing key inputs argument` by ensuring API keys are properly injected into the container environment.
 - Addressed interactive prompt issues in `setup.sh` by setting `DEBIAN_FRONTEND=noninteractive`.
 
-[Unreleased]: https://github.com/QueryPlanner/google-adk-on-bare-metal/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/QueryPlanner/google-adk-on-bare-metal/compare/v0.20.0...HEAD
+[0.20.0]: https://github.com/QueryPlanner/google-adk-on-bare-metal/compare/v0.2.0...v0.20.0
 [0.2.0]: https://github.com/QueryPlanner/google-adk-on-bare-metal/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/QueryPlanner/google-adk-on-bare-metal/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/QueryPlanner/google-adk-on-bare-metal/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "google-adk-on-bare-metal"
-version = "0.2.0"
+version = "0.20.0"
 description = "Production-ready template for building and deploying AI agents using Google ADK, LiteLLM, and Postgres on self-hosted infrastructure"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -575,7 +575,7 @@ wheels = [
 
 [[package]]
 name = "google-adk-on-bare-metal"
-version = "0.2.0"
+version = "0.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
## What

Release **v0.20.0**: version metadata, changelog, and lockfile.

## Why

Requested release for version **0.20.0** (semver minor 20 on the 0.x line). No code changes since v0.2.0; this is a version alignment release.

## How

- Set `version` to `0.20.0` in `pyproject.toml`
- Add `[0.20.0]` to `CHANGELOG.md` and update comparison links
- Run `uv lock`

## Tests

- [x] `uv run ruff format`, `ruff check`, `mypy .`, `pytest --cov=src`

Made with [Cursor](https://cursor.com)