### PR TITLE
docs: preserve Agent Foundation license

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,10 @@ To change the backend, simply update the OTel exporter configuration in your `.e
 - [Development Guide](docs/development.md)
 - [Architecture](docs/architecture.md)
 - [Observability Setup](docs/base-infra/observability.md)
+
+## Provenance
+
+This template includes material derived from
+[Agent Foundation](https://github.com/doughayden/agent-foundation). See
+[Third-Party Notices](THIRD_PARTY_NOTICES.md) for the pinned source and
+preserved upstream license.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,18 @@
+# Third-Party Notices
+
+## Agent Foundation
+
+Repository history records that application logic and supporting features were
+ported from [doughayden/agent-foundation][agent-foundation].
+
+- Pinned upstream revision:
+  `c4f1db9218f265ff10c7212363b8d72e4b59e2d7`
+- Upstream license: MIT
+- Preserved license text:
+  [`licenses/agent-foundation-MIT.txt`](licenses/agent-foundation-MIT.txt)
+
+The preserved MIT notice applies to material derived from Agent Foundation.
+This third-party notice does not select or grant a license for the remaining
+portions of Google ADK on Bare Metal.
+
+[agent-foundation]: https://github.com/doughayden/agent-foundation/tree/c4f1db9218f265ff10c7212363b8d72e4b59e2d7

--- a/licenses/agent-foundation-MIT.txt
+++ b/licenses/agent-foundation-MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 doughayden
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tests/test_third_party_notices.py
+++ b/tests/test_third_party_notices.py
@@ -1,0 +1,33 @@
+"""Third-party provenance contract tests."""
+
+from hashlib import sha256
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+NOTICE_PATH = REPOSITORY_ROOT / "THIRD_PARTY_NOTICES.md"
+UPSTREAM_LICENSE_PATH = REPOSITORY_ROOT / "licenses" / "agent-foundation-MIT.txt"
+UPSTREAM_COMMIT = "c4f1db9218f265ff10c7212363b8d72e4b59e2d7"
+UPSTREAM_LICENSE_SHA256 = (
+    "747962afcb950b95594bca26cb893dd071f9ea3b7c72b1f8e1e8805091156573"
+)
+
+
+def test_agent_foundation_license_matches_pinned_upstream() -> None:
+    license_digest = sha256(UPSTREAM_LICENSE_PATH.read_bytes()).hexdigest()
+
+    assert license_digest == UPSTREAM_LICENSE_SHA256
+
+
+def test_third_party_notice_records_source_and_license_scope() -> None:
+    notice = NOTICE_PATH.read_text(encoding="utf-8")
+
+    assert "doughayden/agent-foundation" in notice
+    assert UPSTREAM_COMMIT in notice
+    assert "licenses/agent-foundation-MIT.txt" in notice
+    assert "does not select or grant a license" in notice
+
+
+def test_readme_links_third_party_notice() -> None:
+    readme = (REPOSITORY_ROOT / "README.md").read_text(encoding="utf-8")
+
+    assert "[Third-Party Notices](THIRD_PARTY_NOTICES.md)" in readme


### PR DESCRIPTION
## What

Preserve the exact MIT notice for Agent Foundation-derived material and document its pinned provenance.

## Why

Repository history explicitly records that application logic and supporting features were ported from doughayden/agent-foundation. Its MIT notice must remain with copies or substantial portions of that material.

## How

- Preserve the exact upstream MIT license under licenses/.
- Record the pinned upstream revision in THIRD_PARTY_NOTICES.md.
- Link the notice from README.md.
- Add an integrity contract for the upstream license hash and provenance links.
- State explicitly that the notice does not license the rest of this repository.

## Tests

- [x] uv run ruff format --check
- [x] uv run ruff check
- [x] uv run mypy .
- [x] uv run pytest --cov=src --cov-report=term-missing (174 passed; 100% of the configured source set)
- [x] Verify upstream and local license SHA-256: 747962afcb950b95594bca26cb893dd071f9ea3b7c72b1f8e1e8805091156573
- [x] Independent adversarial review

Agent evaluation is not applicable because this pull request does not alter the ADK runtime, prompts, tools, or model behavior. Selecting a license for original Google ADK on Bare Metal code remains a separate repository-owner decision.

## Related Issues

Closes #66