### PR TITLE
ci: make quality checks fail closed

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -2,20 +2,10 @@ name: Code Quality
 
 on:
   push:
-    branches: [ "main", "migration/port-agent-foundation" ]
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - 'uv.lock'
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - 'uv.lock'
-  workflow_call: # Allow other workflows to call this
+  workflow_call:
 
 jobs:
   test:
@@ -45,7 +35,7 @@ jobs:
         run: uv run ruff format --check
 
       - name: Run Ruff linting
-        run: uv run ruff check --output-format=github
+        run: uv run ruff check --no-fix --output-format=github
 
       - name: Run MyPy type checking
         run: uv run mypy .

--- a/tests/test_quality_workflow.py
+++ b/tests/test_quality_workflow.py
@@ -1,0 +1,41 @@
+"""Code-quality workflow contract tests."""
+
+from pathlib import Path
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[1] / ".github" / "workflows" / "code-quality.yml"
+)
+
+
+def _indented_block(document: str, heading: str, indentation: int) -> str:
+    """Return the lines nested beneath an exact YAML heading."""
+    lines = document.splitlines()
+    start = lines.index(f"{' ' * indentation}{heading}") + 1
+    block: list[str] = []
+
+    for line in lines[start:]:
+        if line and not line.startswith(" " * (indentation + 1)):
+            break
+        block.append(line)
+
+    return "\n".join(block)
+
+
+def test_quality_workflow_runs_for_every_main_change() -> None:
+    document = WORKFLOW_PATH.read_text(encoding="utf-8")
+    trigger_block = _indented_block(document, "on:", 0)
+    push_block = _indented_block(trigger_block, "push:", 2)
+    pull_request_block = _indented_block(trigger_block, "pull_request:", 2)
+
+    assert '    branches: [ "main" ]' in push_block
+    assert '    branches: [ "main" ]' in pull_request_block
+    assert "  workflow_call:" in trigger_block
+    assert "paths:" not in trigger_block
+    assert "paths-ignore:" not in trigger_block
+    assert "migration/port-agent-foundation" not in trigger_block
+
+
+def test_quality_workflow_disables_ruff_mutation() -> None:
+    document = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "run: uv run ruff check --no-fix --output-format=github" in document


### PR DESCRIPTION
## What

Make the Code Quality workflow run for every main-branch change and enforce check-only Ruff linting.

## Why

The existing path filters skip infrastructure, workflow, deployment, security, and documentation-only pull requests. Project configuration also enables Ruff fixes globally, so CI must explicitly disable mutation to remain a reliable gate.

## How

- Remove push and pull-request path filters.
- Limit direct push validation to main and remove the stale migration branch.
- Preserve workflow_call for Docker Publish.
- Add --no-fix to the CI Ruff command.
- Add workflow trigger and lint-command contract tests.

## Tests

- [x] uv run ruff format --check
- [x] uv run ruff check
- [x] uv run mypy .
- [x] uv run pytest --cov=src --cov-report=term-missing (176 passed; 100% of the configured source set)
- [x] Parse code-quality.yml with Ruby YAML
- [x] Independent adversarial review

Agent evaluation is not applicable because this pull request does not alter the ADK runtime, prompts, tools, or model behavior. Action-version upgrades, the alls-green sentinel, branch protection, and coverage-scope expansion remain separate work.

## Related Issues

Closes #68