### PR TITLE
feat: add Compose healthcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,19 @@ Since we include CI/CD, every push to `main` builds a fresh image. On your serve
 docker pull ghcr.io/queryplanner/google-adk-on-bare-metal:main
 
 # 2. Start the service
-docker compose up -d
+docker compose up --wait --wait-timeout 180
 ```
 
 ### Option 2: Build Yourself
 
 ```bash
 git pull
-docker compose up --build -d
+docker compose up --build --wait --wait-timeout 180
 ```
+
+The bounded `--wait` command returns only after the agent's container
+healthcheck passes, so scripts can distinguish a healthy startup from a
+container that merely started.
 
 👉 **[Read the Full Deployment Guide](docs/DEPLOYMENT.md)**
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -19,6 +19,20 @@ services:
     # Volumes are for hot-reloading and persisting artifacts.
     volumes:
       - agent_artifacts:/app/src/.adk
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - >-
+          import urllib.request;
+          urllib.request.build_opener(
+          urllib.request.ProxyHandler({})).open(
+          "http://127.0.0.1:8080/health", timeout=3).read()
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
     restart: always
     command: python -m agent.server
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -67,7 +67,8 @@ services:
 
 Then your update command becomes:
 ```bash
-docker compose pull && docker compose up -d
+docker compose pull
+docker compose up --wait --wait-timeout 180
 ```
 
 ---
@@ -86,14 +87,19 @@ Best if you don't want to manage Python versions on the host.
 
 2.  **Run**
     ```bash
-    docker compose up --build -d
+    docker compose up --build --wait --wait-timeout 180
     ```
 
 3.  **Update**
     ```bash
     git pull
-    docker compose up --build -d
+    docker compose up --build --wait --wait-timeout 180
     ```
+
+The Compose healthcheck calls the agent's process-level `/health` endpoint from
+inside the container. `--wait` exits successfully only after the service becomes
+healthy; `--wait-timeout` prevents an unhealthy startup from hanging automation
+indefinitely. Database-aware readiness is tracked separately in issue #37.
 
 ---
 

--- a/docs/base-infra/docker-compose-workflow.md
+++ b/docs/base-infra/docker-compose-workflow.md
@@ -57,6 +57,15 @@ docker compose build
 docker compose up --build
 ```
 
+### Start in the background and wait for health
+```bash
+docker compose up --build --wait --wait-timeout 180
+```
+
+The healthcheck uses Python's standard HTTP client inside the container to call
+`/health`. It reports process liveness; database-aware readiness is a separate
+startup contract.
+
 ---
 
 ## How Watch Mode Works

--- a/tests/test_compose_healthcheck.py
+++ b/tests/test_compose_healthcheck.py
@@ -1,0 +1,58 @@
+"""Docker Compose healthcheck contract tests."""
+
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+COMPOSE_PATH = REPOSITORY_ROOT / "compose.yaml"
+DEPLOYMENT_GUIDE_PATH = REPOSITORY_ROOT / "docs" / "DEPLOYMENT.md"
+COMPOSE_GUIDE_PATH = (
+    REPOSITORY_ROOT / "docs" / "base-infra" / "docker-compose-workflow.md"
+)
+README_PATH = REPOSITORY_ROOT / "README.md"
+EXPECTED_HEALTHCHECK_BLOCK = """\
+      test:
+        - CMD
+        - python
+        - -c
+        - >-
+          import urllib.request;
+          urllib.request.build_opener(
+          urllib.request.ProxyHandler({})).open(
+          "http://127.0.0.1:8080/health", timeout=3).read()
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 60s"""
+
+
+def _indented_block(document: str, heading: str, indentation: int) -> str:
+    """Return lines nested beneath an exact YAML heading."""
+    lines = document.splitlines()
+    start = lines.index(f"{' ' * indentation}{heading}") + 1
+    block: list[str] = []
+
+    for line in lines[start:]:
+        if line and not line.startswith(" " * (indentation + 1)):
+            break
+        block.append(line)
+
+    return "\n".join(block)
+
+
+def test_agent_healthcheck_has_exact_process_liveness_contract() -> None:
+    """Keep one exec-form Python probe with an explicit small-VM timing policy."""
+    document = COMPOSE_PATH.read_text(encoding="utf-8")
+    agent_block = _indented_block(document, "agent:", 2)
+    healthcheck_block = _indented_block(agent_block, "healthcheck:", 4)
+
+    assert agent_block.splitlines().count("    healthcheck:") == 1
+    assert healthcheck_block == EXPECTED_HEALTHCHECK_BLOCK
+
+
+def test_operator_guides_wait_for_container_health() -> None:
+    """Document a bounded startup command wherever operators start Compose."""
+    guide_paths = [DEPLOYMENT_GUIDE_PATH, COMPOSE_GUIDE_PATH, README_PATH]
+
+    for guide_path in guide_paths:
+        guide = guide_path.read_text(encoding="utf-8")
+        assert "docker compose up --build --wait --wait-timeout 180" in guide

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -8,6 +8,9 @@ from unittest.mock import create_autospec, patch
 
 import pytest
 from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from google.adk.cli.fast_api import get_fast_api_app
+from openinference.instrumentation.google_adk import GoogleADKInstrumentor
 
 
 @pytest.mark.parametrize("configured_agent_dir", [None, "/srv/test-agents"])
@@ -25,16 +28,24 @@ def test_server_bootstrap_uses_typed_settings_before_instrumentation(
         monkeypatch.setenv("AGENT_DIR", configured_agent_dir)
 
     mock_app = create_autospec(FastAPI, instance=True, spec_set=True)
+    mock_get_app = create_autospec(
+        get_fast_api_app,
+        spec_set=True,
+        return_value=mock_app,
+    )
+    mock_instrumentor_class = create_autospec(
+        GoogleADKInstrumentor,
+        spec_set=True,
+    )
     with (
         patch(
             "google.adk.cli.fast_api.get_fast_api_app",
-            autospec=True,
-            return_value=mock_app,
-        ) as mock_get_app,
+            new=mock_get_app,
+        ),
         patch(
             "openinference.instrumentation.google_adk.GoogleADKInstrumentor",
-            autospec=True,
-        ) as mock_instrumentor_class,
+            new=mock_instrumentor_class,
+        ),
     ):
 
         def assert_otel_is_ready() -> None:
@@ -72,3 +83,43 @@ def test_server_bootstrap_uses_typed_settings_before_instrumentation(
     assert expected_agent_dir == server.AGENT_DIR
 
     sys.modules.pop("agent.server", None)
+
+
+def test_health_endpoint_reports_process_liveness(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Verify the registered health route serves the container liveness contract."""
+    monkeypatch.chdir(tmp_path)
+    test_app = FastAPI()
+    mock_get_app = create_autospec(
+        get_fast_api_app,
+        spec_set=True,
+        return_value=test_app,
+    )
+    mock_instrumentor_class = create_autospec(
+        GoogleADKInstrumentor,
+        spec_set=True,
+    )
+
+    with (
+        patch.dict(os.environ, {"AGENT_NAME": "health-test-agent"}, clear=True),
+        patch(
+            "google.adk.cli.fast_api.get_fast_api_app",
+            new=mock_get_app,
+        ),
+        patch(
+            "openinference.instrumentation.google_adk.GoogleADKInstrumentor",
+            new=mock_instrumentor_class,
+        ),
+    ):
+        sys.modules.pop("agent.server", None)
+        try:
+            server = importlib.import_module("agent.server")
+            with TestClient(server.app) as client:
+                response = client.get("/health")
+        finally:
+            sys.modules.pop("agent.server", None)
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## What

Add a deterministic process-liveness healthcheck to the Compose agent service
and document the bounded startup workflow it enables.

## Why

The application already served `/health`, but Compose could only tell that the
container had started. Operators and the upcoming Compose smoke lane need a
real health contract for `docker compose up --wait`.

## How

- Probe loopback `/health` with exec-form Python and no added runtime package.
- Disable environment proxies for the container-local request.
- Protect small-VM cold starts with explicit timeout, retry, and grace settings.
- Exercise the real FastAPI route with strict external-boundary doubles.
- Lock the exact Compose contract and bounded operator commands in tests.

## Tests

- [x] `uv sync --locked`
- [x] `uv run ruff format --check`
- [x] `uv run ruff check --no-fix --output-format=github`
- [x] `uv run mypy .`
- [x] `uv run pytest --cov=src --cov-report=xml --cov-report=term-missing`
      (225 passed; 100% statement and branch coverage)
- [x] Parse the Compose YAML and compile the folded Python probe.
- [x] Build and start an isolated key-free container with
      `docker compose up --wait`; Docker reported `healthy`.
- [x] Repeat the in-container probe with broken `HTTP_PROXY` and `http_proxy`
      values; `/health` still returned `{"status":"ok"}`.
- [x] Real LLM evaluation is not applicable because this change does not alter
      prompts, tools, routing, or model behavior.

## Related Issues

Closes #38
