### PR TITLE
feat: add PostgreSQL readiness gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,12 @@ OPENROUTER_API_KEY=your-openrouter-key-here
 GITHUB_TOKEN=your-github-token-here
 
 # Database Configuration
-# asyncpg requires ssl=require instead of sslmode=require
+# Standard and SQLAlchemy TLS options are normalized for their asyncpg consumer
 DATABASE_URL=postgresql://user:pass@host:port/dbname?ssl=require
+# Bound database startup waits and individual connection/query attempts (seconds)
+DB_READY_TIMEOUT=60
+DB_READY_RETRY_INTERVAL=1
+DB_READY_ATTEMPT_TIMEOUT=5
 DB_POOL_PRE_PING=true
 DB_POOL_RECYCLE=1800
 DB_POOL_SIZE=5

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,12 +36,6 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # ============================================================================
 FROM python:3.13-slim AS runtime
 
-# Install system dependencies
-# - netcat-openbsd: for checking DB readiness (used in entrypoint.sh)
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    netcat-openbsd \
-    && rm -rf /var/lib/apt/lists/*
-
 # Create non-root user for security (matching common host UID 1000)
 RUN groupadd -g 1000 app && \
     useradd -u 1000 -g app -s /bin/sh -m app

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -99,7 +99,8 @@ Best if you don't want to manage Python versions on the host.
 The Compose healthcheck calls the agent's process-level `/health` endpoint from
 inside the container. `--wait` exits successfully only after the service becomes
 healthy; `--wait-timeout` prevents an unhealthy startup from hanging automation
-indefinitely. Database-aware readiness is tracked separately in issue #37.
+indefinitely. When `DATABASE_URL` is configured, the entrypoint first runs a
+bounded `SELECT 1` readiness check before starting the server.
 
 ---
 

--- a/docs/base-infra/docker-compose-workflow.md
+++ b/docs/base-infra/docker-compose-workflow.md
@@ -63,8 +63,8 @@ docker compose up --build --wait --wait-timeout 180
 ```
 
 The healthcheck uses Python's standard HTTP client inside the container to call
-`/health`. It reports process liveness; database-aware readiness is a separate
-startup contract.
+`/health`. It reports process liveness after the container entrypoint has
+completed its bounded database readiness check when `DATABASE_URL` is configured.
 
 ---
 

--- a/docs/base-infra/environment-variables.md
+++ b/docs/base-infra/environment-variables.md
@@ -11,6 +11,34 @@ Complete reference for all environment variables used in this project.
 - **Value:** Postgres connection string (e.g., `postgresql://user:pass@localhost:5432/dbname`)
 - **Purpose:** Persistent storage for agent sessions and memory
 
+Both `ssl=...` and standard `sslmode=...` query options are normalized for the
+consumer that receives the URL. The shared direct-asyncpg and SQLAlchemy path
+also accepts `target_session_attrs`, `krbsrvname`, `gsslib`, and `passfile`.
+The `host` query option is accepted only when the URL authority has no hostname,
+and `port` only when the authority has no port. This supports credentialed
+Unix-socket URLs without allowing query options to override an address. Other
+query keys fail closed because direct asyncpg and SQLAlchemy otherwise interpret
+them differently.
+`channel_binding=require` is accepted for compatibility but is removed because
+the current asyncpg stack does not support that option.
+
+When `DATABASE_URL` is set in the container, the entrypoint verifies a real
+`SELECT 1` before starting the server. Authentication and database-selection
+errors fail immediately; transient connection failures are retried within the
+following bounds:
+
+**DB_READY_TIMEOUT**
+- **Default:** `60`
+- **Purpose:** Maximum total number of seconds spent retrying startup readiness
+
+**DB_READY_RETRY_INTERVAL**
+- **Default:** `1`
+- **Purpose:** Seconds between transient readiness failures
+
+**DB_READY_ATTEMPT_TIMEOUT**
+- **Default:** `5`
+- **Purpose:** Maximum seconds for one connection, query, and close attempt
+
 ### API Keys
 
 **GOOGLE_API_KEY**

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,25 +1,5 @@
 #!/bin/sh
-set -e
+set -eu
 
-# Wait for the database if DATABASE_URL is set and looks like a postgres url
-if echo "$DATABASE_URL" | grep -q "postgresql://"; then
-    echo "Waiting for database..."
-    # Extract host and port from DATABASE_URL
-    # Assumes format postgresql://user:pass@host:port/dbname
-    # This is a basic extraction and might need adjustment for complex URLs
-    DB_HOST=$(echo $DATABASE_URL | sed -e 's|^.*@||' -e 's|/.*$||' -e 's|:.*$||')
-    DB_PORT=$(echo $DATABASE_URL | sed -e 's|^.*@||' -e 's|/.*$||' -e 's|^.*:||')
-    
-    # Default port if not specified
-    if [ "$DB_HOST" = "$DB_PORT" ]; then
-        DB_PORT=5432
-    fi
-
-    # Loop until the database is ready
-    while ! nc -z $DB_HOST $DB_PORT; do
-      sleep 1
-    done
-    echo "Database started"
-fi
-
-exec "$@"
+python_bin="${VIRTUAL_ENV:-$(dirname "$0")/.venv}/bin/python"
+exec "$python_bin" -m agent.pre_start "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "opentelemetry-instrumentation-logging>=0.58b0,<0.59",
     "pydantic>=2.11.0,<3.0.0",
     "pydantic-settings>=2.12.0,<3.0.0",
+    "tenacity>=9.1.2,<10.0.0",
     "litellm>=1.60.0",
     "asyncpg>=0.30.0",
     "greenlet>=3.0.0",

--- a/src/agent/pre_start.py
+++ b/src/agent/pre_start.py
@@ -1,0 +1,197 @@
+"""Bounded PostgreSQL readiness gate and container process wrapper."""
+
+from __future__ import annotations
+
+import asyncio
+import errno
+import math
+import os
+import signal
+import socket
+import sys
+from contextlib import suppress
+from types import FrameType
+from typing import NoReturn
+
+import asyncpg  # type: ignore[import-untyped]
+from tenacity import (
+    AsyncRetrying,
+    retry_if_exception,
+    stop_after_delay,
+    wait_fixed,
+)
+
+from .utils import DatabaseReadinessEnv
+from .utils.config import _normalize_asyncpg_database_url
+
+_TRANSIENT_DATABASE_ERROR_TYPES = (
+    ConnectionError,
+    TimeoutError,
+    socket.gaierror,
+    asyncpg.PostgresConnectionError,
+    asyncpg.CannotConnectNowError,
+    asyncpg.AdminShutdownError,
+    asyncpg.CrashShutdownError,
+    asyncpg.TooManyConnectionsError,
+)
+_TRANSIENT_NETWORK_ERRNOS = frozenset(
+    code
+    for code in (
+        errno.EADDRNOTAVAIL,
+        errno.ECONNABORTED,
+        errno.ECONNREFUSED,
+        errno.ECONNRESET,
+        getattr(errno, "EHOSTDOWN", None),
+        errno.EHOSTUNREACH,
+        errno.ENETDOWN,
+        errno.ENETUNREACH,
+        errno.ETIMEDOUT,
+    )
+    if code is not None
+)
+
+
+def _require_positive_finite(name: str, value: float) -> None:
+    """Reject invalid retry timing without including the supplied value."""
+    if not math.isfinite(value) or value <= 0:
+        msg = f"{name} must be a positive finite number"
+        raise ValueError(msg)
+
+
+def _is_transient_database_error(error: BaseException) -> bool:
+    """Return whether a failure can plausibly recover during VM startup."""
+    if isinstance(error, _TRANSIENT_DATABASE_ERROR_TYPES):
+        return True
+    return type(error) is OSError and (
+        error.errno is None or error.errno in _TRANSIENT_NETWORK_ERRNOS
+    )
+
+
+def normalize_database_url(database_url: str) -> str:
+    """Normalize a supported PostgreSQL URL for direct asyncpg use."""
+    return _normalize_asyncpg_database_url(database_url)
+
+
+async def check_database(
+    database_url: str,
+    *,
+    attempt_timeout: float,
+) -> None:
+    """Connect, run the readiness query, and close within one bounded attempt."""
+    _require_positive_finite("attempt_timeout", attempt_timeout)
+
+    connection: asyncpg.Connection | None = None
+    try:
+        async with asyncio.timeout(attempt_timeout):
+            connection = await asyncpg.connect(
+                database_url,
+                timeout=attempt_timeout,
+                command_timeout=attempt_timeout,
+            )
+            result = await connection.fetchval("SELECT 1", timeout=attempt_timeout)
+            if result != 1:
+                msg = "Database readiness query returned an unexpected result"
+                raise RuntimeError(msg)
+            await connection.close(timeout=attempt_timeout)
+            connection = None
+    except BaseException:
+        if connection is not None:
+            with suppress(Exception):
+                connection.terminate()
+        raise
+
+
+async def wait_for_database(
+    database_url: str,
+    *,
+    timeout: float,
+    retry_interval: float,
+    attempt_timeout: float,
+) -> int:
+    """Wait for PostgreSQL readiness and return the number of attempts used."""
+    _require_positive_finite("timeout", timeout)
+    _require_positive_finite("retry_interval", retry_interval)
+    _require_positive_finite("attempt_timeout", attempt_timeout)
+    normalized_database_url = normalize_database_url(database_url)
+    attempts = 0
+
+    async with asyncio.timeout(timeout):
+        async for attempt in AsyncRetrying(
+            retry=retry_if_exception(_is_transient_database_error),
+            wait=wait_fixed(retry_interval),
+            stop=stop_after_delay(timeout),
+            reraise=True,
+        ):
+            with attempt:
+                attempts += 1
+                await check_database(
+                    normalized_database_url,
+                    attempt_timeout=attempt_timeout,
+                )
+
+    return attempts
+
+
+def _exit_on_termination_signal(
+    signum: int,
+    _frame: FrameType | None,
+) -> NoReturn:
+    """Exit promptly with the conventional status for a termination signal."""
+    raise SystemExit(128 + signum)
+
+
+def main() -> NoReturn:
+    """Run readiness when configured, then replace this process with the command."""
+    command = sys.argv[1:]
+    if not command:
+        print("No application command configured.", file=sys.stderr, flush=True)
+        raise SystemExit(1)
+
+    previous_sigterm = signal.signal(
+        signal.SIGTERM,
+        _exit_on_termination_signal,
+    )
+    try:
+        previous_sigint = signal.signal(
+            signal.SIGINT,
+            _exit_on_termination_signal,
+        )
+        try:
+            try:
+                env = DatabaseReadinessEnv()
+                if env.database_url is not None:
+                    print("Waiting for database readiness...", flush=True)
+                    asyncio.run(
+                        wait_for_database(
+                            env.database_url.get_secret_value(),
+                            timeout=env.db_ready_timeout,
+                            retry_interval=env.retry_interval,
+                            attempt_timeout=env.attempt_timeout,
+                        )
+                    )
+                    print("Database is ready.", flush=True)
+            except Exception:
+                print(
+                    "Database readiness check failed.",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                raise SystemExit(1) from None
+
+            try:
+                os.execvp(command[0], command)  # noqa: S606 - preserve container CMD
+            except OSError:
+                print(
+                    "Application command could not start.",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                raise SystemExit(1) from None
+        finally:
+            signal.signal(signal.SIGINT, previous_sigint)
+    finally:
+        signal.signal(signal.SIGTERM, previous_sigterm)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agent/utils/__init__.py
+++ b/src/agent/utils/__init__.py
@@ -2,6 +2,7 @@
 
 from .config import (
     AgentRuntimeEnv,
+    DatabaseReadinessEnv,
     ObservabilityEnv,
     ServerEnv,
     SettingsConfigurationError,
@@ -11,6 +12,7 @@ from .observability import configure_otel_resource, setup_logging
 
 __all__ = [
     "AgentRuntimeEnv",
+    "DatabaseReadinessEnv",
     "ObservabilityEnv",
     "ServerEnv",
     "SettingsConfigurationError",

--- a/src/agent/utils/config.py
+++ b/src/agent/utils/config.py
@@ -7,6 +7,7 @@ and configuration management.
 import json
 import warnings
 from typing import Any, Literal, Self, cast
+from urllib.parse import SplitResult, unquote_plus, urlsplit, urlunsplit
 
 from pydantic import (
     Field,
@@ -32,6 +33,160 @@ _EXAMPLE_SECRET_VALUES = {
         }
     ),
 }
+_DATABASE_READINESS_MAX_TIMEOUT = 3600.0
+_DATABASE_READINESS_MAX_INTERVAL = 60.0
+_SHARED_ASYNCPG_QUERY_KEYS = frozenset(
+    {
+        "gsslib",
+        "host",
+        "krbsrvname",
+        "passfile",
+        "port",
+        "target_session_attrs",
+    }
+)
+_TARGETED_ASYNCPG_QUERY_KEYS = frozenset(
+    {
+        "channel_binding",
+        "ssl",
+        "sslmode",
+    }
+)
+
+
+def _parse_postgresql_url(database_url: str) -> tuple[SplitResult, str]:
+    """Parse a supported PostgreSQL URL without including its value in errors."""
+    if not database_url or database_url != database_url.strip():
+        msg = "DATABASE_URL must be a non-blank PostgreSQL URL"
+        raise ValueError(msg)
+
+    try:
+        parsed = urlsplit(database_url)
+        _ = parsed.port
+    except ValueError:
+        msg = "DATABASE_URL must be a valid PostgreSQL URL"
+        raise ValueError(msg) from None
+
+    scheme = parsed.scheme.casefold()
+    supported_schemes = {"postgres", "postgresql", "postgresql+asyncpg"}
+    scheme_separator = database_url.find(":")
+    has_url_authority_marker = scheme_separator >= 0 and database_url[
+        scheme_separator + 1 :
+    ].startswith("//")
+    if (
+        scheme not in supported_schemes
+        or not has_url_authority_marker
+        or parsed.fragment
+    ):
+        msg = "DATABASE_URL must use a supported PostgreSQL URL"
+        raise ValueError(msg)
+
+    return parsed, scheme
+
+
+def _normalize_postgresql_query(
+    query: str,
+    *,
+    allow_host_option: bool,
+    allow_port_option: bool,
+    ssl_key: Literal["ssl", "sslmode"],
+) -> str:
+    """Return query options with identical direct and SQLAlchemy semantics."""
+    query_parts = query.split("&") if query else []
+    seen_keys: set[str] = set()
+    has_ssl = False
+    has_sslmode = False
+    normalized_query_parts: list[str] = []
+
+    for query_part in query_parts:
+        raw_key, separator, raw_value = query_part.partition("=")
+        key = unquote_plus(raw_key)
+
+        if key not in _SHARED_ASYNCPG_QUERY_KEYS | _TARGETED_ASYNCPG_QUERY_KEYS:
+            msg = "DATABASE_URL contains an unsupported PostgreSQL option"
+            raise ValueError(msg)
+        if key in seen_keys:
+            msg = "DATABASE_URL contains an ambiguous PostgreSQL option"
+            raise ValueError(msg)
+        seen_keys.add(key)
+        if not separator:
+            msg = "DATABASE_URL contains an invalid PostgreSQL option"
+            raise ValueError(msg)
+        if (key == "host" and not allow_host_option) or (
+            key == "port" and not allow_port_option
+        ):
+            msg = "DATABASE_URL contains an ambiguous PostgreSQL address option"
+            raise ValueError(msg)
+
+        if key not in _TARGETED_ASYNCPG_QUERY_KEYS:
+            normalized_query_parts.append(query_part)
+            continue
+
+        if key == "ssl":
+            has_ssl = True
+            normalized_query_parts.append(
+                query_part if ssl_key == "ssl" else f"sslmode={raw_value}"
+            )
+        elif key == "sslmode":
+            has_sslmode = True
+            normalized_query_parts.append(
+                query_part if ssl_key == "sslmode" else f"ssl={raw_value}"
+            )
+        elif unquote_plus(raw_value) != "require":
+            msg = "DATABASE_URL contains an unsupported channel_binding option"
+            raise ValueError(msg)
+
+    if has_ssl and has_sslmode:
+        msg = "DATABASE_URL must not set both ssl and sslmode"
+        raise ValueError(msg)
+
+    return "&".join(normalized_query_parts)
+
+
+def _rebuild_postgresql_url(
+    parsed: SplitResult,
+    *,
+    query: str,
+    scheme: str,
+) -> str:
+    """Rebuild a URL without collapsing an empty authority used for sockets."""
+    if parsed.netloc:
+        return urlunsplit((scheme, parsed.netloc, parsed.path, query, ""))
+
+    normalized_url = f"{scheme}://{parsed.path}"
+    return f"{normalized_url}?{query}" if query else normalized_url
+
+
+def _normalize_asyncpg_database_url(database_url: str) -> str:
+    """Normalize a supported PostgreSQL URL for a direct asyncpg connection."""
+    parsed, scheme = _parse_postgresql_url(database_url)
+    normalized_scheme = "postgresql" if scheme == "postgresql+asyncpg" else scheme
+    return _rebuild_postgresql_url(
+        parsed,
+        query=_normalize_postgresql_query(
+            parsed.query,
+            allow_host_option=parsed.hostname is None,
+            allow_port_option=parsed.port is None,
+            ssl_key="sslmode",
+        ),
+        scheme=normalized_scheme,
+    )
+
+
+def _normalize_sqlalchemy_database_url(database_url: str) -> str:
+    """Normalize a PostgreSQL URL for SQLAlchemy's asyncpg dialect."""
+    parsed, scheme = _parse_postgresql_url(database_url)
+    normalized_scheme = "postgresql" if scheme == "postgres" else scheme
+    return _rebuild_postgresql_url(
+        parsed,
+        query=_normalize_postgresql_query(
+            parsed.query,
+            allow_host_option=parsed.hostname is None,
+            allow_port_option=parsed.port is None,
+            ssl_key="ssl",
+        ),
+        scheme=normalized_scheme,
+    )
 
 
 class SettingsConfigurationError(Exception):
@@ -180,6 +335,56 @@ class AgentRuntimeEnv(RedactedBaseSettings):
     def _reject_example_secrets(self) -> Self:
         """Reject known provider-key placeholders."""
         _check_example_secret("OPENROUTER_API_KEY", self.openrouter_api_key)
+        return self
+
+
+class DatabaseReadinessEnv(RedactedBaseSettings):
+    """Process-only settings for the container database readiness gate."""
+
+    database_url: SecretStr | None = Field(
+        default=None,
+        alias="DATABASE_URL",
+        description="PostgreSQL URL checked before the application starts",
+    )
+    db_ready_timeout: float = Field(
+        default=60.0,
+        alias="DB_READY_TIMEOUT",
+        gt=0,
+        le=_DATABASE_READINESS_MAX_TIMEOUT,
+        description="Maximum total seconds to wait for database readiness",
+    )
+    retry_interval: float = Field(
+        default=1.0,
+        alias="DB_READY_RETRY_INTERVAL",
+        gt=0,
+        le=_DATABASE_READINESS_MAX_INTERVAL,
+        description="Seconds between transient database readiness failures",
+    )
+    attempt_timeout: float = Field(
+        default=5.0,
+        alias="DB_READY_ATTEMPT_TIMEOUT",
+        gt=0,
+        le=_DATABASE_READINESS_MAX_INTERVAL,
+        description="Maximum seconds for one database readiness attempt",
+    )
+
+    model_config = SettingsConfigDict(
+        env_file=None,
+        populate_by_name=True,
+        extra="ignore",
+        hide_input_in_errors=True,
+    )
+
+    @field_validator("database_url", mode="before")
+    @classmethod
+    def _normalize_blank_database_url(cls, value: Any) -> Any:
+        """Treat a blank process value as an intentionally unconfigured database."""
+        return _blank_optional_value(value)
+
+    @model_validator(mode="after")
+    def _reject_example_database_url(self) -> Self:
+        """Reject the documented database placeholder before any connection attempt."""
+        _check_example_secret("DATABASE_URL", self.database_url)
         return self
 
 
@@ -438,12 +643,7 @@ class ServerEnv(RedactedBaseSettings):
         """Session service URI (Database or Agent Engine)."""
         if self.database_url:
             database_url = self.database_url.get_secret_value()
-            # asyncpg requires 'ssl=require' instead of 'sslmode=require'
-            # Also removing channel_binding as it causes TypeError with current
-            # sqlalchemy/asyncpg setup
-            return database_url.replace("sslmode=require", "ssl=require").replace(
-                "&channel_binding=require", ""
-            )
+            return _normalize_sqlalchemy_database_url(database_url)
         return self.agent_engine_uri
 
     @property

--- a/tests/postgres/test_session_persistence.py
+++ b/tests/postgres/test_session_persistence.py
@@ -8,15 +8,19 @@ import secrets
 import subprocess
 import sys
 import textwrap
+import time
 import uuid
 from collections.abc import Iterator
 from contextlib import suppress
 from pathlib import Path
 from typing import Any, cast
+from unittest.mock import create_autospec
 from urllib.parse import parse_qsl, quote, unquote, urlsplit, urlunsplit
 
 import asyncpg  # type: ignore[import-untyped]
 import pytest
+
+from agent import pre_start
 
 _ADMIN_URL_ENV = "TEST_POSTGRES_ADMIN_URL"
 _DATABASE_NAME_PATTERN = re.compile(r"\Aadk_test_[0-9a-f]{32}\Z")
@@ -664,3 +668,115 @@ def test_session_persists_across_server_processes(
     assert restart_result["delete_status"] == 200
     assert restart_result["missing_status"] == 404
     assert _inspect_persisted_row(postgres_database_url) == (0, None)
+
+
+@pytest.mark.asyncio
+async def test_database_readiness_succeeds_with_real_postgres(
+    postgres_database_url: str,
+) -> None:
+    """Prove the production readiness query succeeds against PostgreSQL."""
+    await pre_start.check_database(
+        postgres_database_url,
+        attempt_timeout=5,
+    )
+
+
+@pytest.mark.asyncio
+async def test_database_readiness_retries_then_uses_real_driver(
+    postgres_database_url: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prove one transient boundary failure retries into a real query."""
+    real_connect = asyncpg.connect
+    connect = create_autospec(real_connect, spec_set=True)
+    simulated_attempts = 0
+
+    async def fail_once_then_connect(*args: Any, **kwargs: Any) -> asyncpg.Connection:
+        nonlocal simulated_attempts
+        simulated_attempts += 1
+        if simulated_attempts == 1:
+            raise ConnectionRefusedError("synthetic transient connection failure")
+        return await real_connect(*args, **kwargs)
+
+    connect.side_effect = fail_once_then_connect
+    monkeypatch.setattr(pre_start.asyncpg, "connect", connect)
+
+    attempts = await pre_start.wait_for_database(
+        postgres_database_url,
+        timeout=10,
+        retry_interval=0.01,
+        attempt_timeout=5,
+    )
+
+    assert attempts == 2
+    assert connect.await_count == 2
+
+
+def _wrong_password_database_url(database_url: str) -> str:
+    """Replace only the restricted test role password with another safe value."""
+    parsed = urlsplit(database_url)
+    if parsed.username is None or parsed.password is None:
+        msg = "Isolated PostgreSQL URL must contain role credentials"
+        raise ValueError(msg)
+    database_name = parsed.path.removeprefix("/")
+    wrong_password = "0" * 64
+    if unquote(parsed.password) == wrong_password:
+        wrong_password = "1" * 64
+    return _database_url(
+        database_url,
+        database_name,
+        unquote(parsed.username),
+        wrong_password,
+    )
+
+
+def test_database_readiness_real_auth_failure_is_fast_and_redacted(
+    postgres_database_url: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Prove a real permanent auth error is not retried or disclosed."""
+    wrong_password_url = _wrong_password_database_url(postgres_database_url)
+    parsed = urlsplit(wrong_password_url)
+    assert parsed.username is not None
+    assert parsed.password is not None
+
+    real_connect = asyncpg.connect
+    connect = create_autospec(real_connect, spec_set=True)
+
+    async def real_connect_boundary(
+        *args: Any,
+        **kwargs: Any,
+    ) -> asyncpg.Connection:
+        return await real_connect(*args, **kwargs)
+
+    connect.side_effect = real_connect_boundary
+    monkeypatch.setattr(pre_start.asyncpg, "connect", connect)
+    execvp = create_autospec(os.execvp, spec_set=True)
+    monkeypatch.setattr(pre_start.os, "execvp", execvp)
+    monkeypatch.setattr(
+        pre_start.sys,
+        "argv",
+        ["agent.pre_start", "synthetic-command"],
+    )
+    monkeypatch.setenv("DATABASE_URL", wrong_password_url)
+    monkeypatch.setenv("DB_READY_TIMEOUT", "20")
+    monkeypatch.setenv("DB_READY_RETRY_INTERVAL", "0.01")
+    monkeypatch.setenv("DB_READY_ATTEMPT_TIMEOUT", "3")
+
+    started = time.monotonic()
+    with pytest.raises(SystemExit) as error:
+        pre_start.main()
+    elapsed = time.monotonic() - started
+
+    captured = capsys.readouterr()
+    output = captured.out + captured.err
+    assert error.value.code != 0
+    assert connect.await_count == 1
+    execvp.assert_not_called()
+    assert elapsed < 10
+    assert wrong_password_url not in output
+    assert parsed.username not in output
+    assert parsed.password not in output
+    assert unquote(parsed.username) not in output
+    assert unquote(parsed.password) not in output

--- a/tests/test_docker_context.py
+++ b/tests/test_docker_context.py
@@ -141,3 +141,10 @@ def test_local_only_root_paths_are_not_allowlisted(path: str) -> None:
 
 def test_dockerfile_specific_ignore_cannot_override_policy() -> None:
     assert not (REPOSITORY_ROOT / "Dockerfile.dockerignore").exists()
+
+
+def test_runtime_image_has_no_netcat_database_readiness_dependency() -> None:
+    """Keep database readiness independent of the netcat package."""
+    dockerfile = DOCKERFILE_PATH.read_text(encoding="utf-8").casefold()
+
+    assert "netcat" not in dockerfile

--- a/tests/test_pre_start.py
+++ b/tests/test_pre_start.py
@@ -1,0 +1,1039 @@
+"""Database readiness and PID 1 entrypoint contract tests."""
+
+from __future__ import annotations
+
+import asyncio
+import errno
+import os
+import runpy
+import select
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import MagicMock, call, create_autospec
+from urllib.parse import parse_qsl, urlsplit
+
+import asyncpg  # type: ignore[import-untyped]
+import pytest
+from pydantic import ValidationError
+
+from agent import pre_start
+from agent.utils import DatabaseReadinessEnv, ServerEnv, SettingsConfigurationError
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+SOURCE_ROOT = REPOSITORY_ROOT / "src"
+ENTRYPOINT_PATH = REPOSITORY_ROOT / "entrypoint.sh"
+DATABASE_URL = (
+    "postgresql://synthetic-user:encoded%40password@[2001:db8::1]:5432/"
+    "agent%2Fdatabase?target_session_attrs=any"
+)
+READINESS_ENVIRONMENT_KEYS = (
+    "DATABASE_URL",
+    "DB_READY_TIMEOUT",
+    "DB_READY_RETRY_INTERVAL",
+    "DB_READY_ATTEMPT_TIMEOUT",
+)
+
+
+class _ExecRequested(BaseException):
+    """Stop a unit test where a real process replacement would occur."""
+
+
+def _mock_connection(
+    *,
+    query_result: int = 1,
+) -> Any:
+    """Return a strict asyncpg connection double."""
+    connection = create_autospec(
+        asyncpg.Connection,
+        instance=True,
+        spec_set=True,
+    )
+    connection.fetchval.return_value = query_result
+    return connection
+
+
+def _mock_connect(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    connection: Any | None = None,
+    side_effect: Any = None,
+) -> Any:
+    """Replace only the asyncpg network boundary with a strict double."""
+    connect = create_autospec(asyncpg.connect, spec_set=True)
+    if side_effect is not None:
+        connect.side_effect = side_effect
+    else:
+        connect.return_value = connection or _mock_connection()
+    monkeypatch.setattr(pre_start.asyncpg, "connect", connect)
+    return connect
+
+
+def _mock_execvp(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Replace only the operating-system process boundary."""
+    execvp = cast(MagicMock, create_autospec(os.execvp, spec_set=True))
+    execvp.side_effect = _ExecRequested
+    monkeypatch.setattr(pre_start.os, "execvp", execvp)
+    return execvp
+
+
+def _clear_readiness_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove only environment variables consumed by the readiness process."""
+    for key in READINESS_ENVIRONMENT_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+def _subprocess_environment(
+    tmp_path: Path,
+    **overrides: str,
+) -> dict[str, str]:
+    """Build a minimal child environment without inherited credentials."""
+    home_dir = tmp_path / "home"
+    temp_dir = tmp_path / "tmp"
+    home_dir.mkdir()
+    temp_dir.mkdir()
+    environment = {
+        "HOME": str(home_dir),
+        "PATH": os.environ.get("PATH", ""),
+        "PYTHONNOUSERSITE": "1",
+        "PYTHONPATH": str(SOURCE_ROOT),
+        "PYTHONUNBUFFERED": "1",
+        "TMPDIR": str(temp_dir),
+    }
+    environment.update(overrides)
+    return environment
+
+
+@pytest.mark.parametrize(
+    ("database_url", "expected"),
+    [
+        (
+            "postgresql://user:encoded%40pass@[2001:db8::1]:5432/db%2Fname"
+            "?target_session_attrs=any",
+            "postgresql://user:encoded%40pass@[2001:db8::1]:5432/db%2Fname"
+            "?target_session_attrs=any",
+        ),
+        (
+            "postgres://user:pass@localhost/database",
+            "postgres://user:pass@localhost/database",
+        ),
+        (
+            "postgresql+asyncpg://user:pass@localhost/database",
+            "postgresql://user:pass@localhost/database",
+        ),
+        (
+            "postgresql:///database?host=%2Fvar%2Frun%2Fpostgresql"
+            "&port=5432&target_session_attrs=any",
+            "postgresql:///database?host=%2Fvar%2Frun%2Fpostgresql"
+            "&port=5432&target_session_attrs=any",
+        ),
+        (
+            "postgresql://user:encoded%40pass@/database"
+            "?host=%2Fvar%2Frun%2Fpostgresql&port=5432",
+            "postgresql://user:encoded%40pass@/database"
+            "?host=%2Fvar%2Frun%2Fpostgresql&port=5432",
+        ),
+        (
+            "postgresql://user:pass@localhost/database"
+            "?port=5432&target_session_attrs=any",
+            "postgresql://user:pass@localhost/database"
+            "?port=5432&target_session_attrs=any",
+        ),
+    ],
+)
+def test_normalize_database_url_preserves_connection_identity(
+    database_url: str,
+    expected: str,
+) -> None:
+    """Normalize only the driver suffix, not connection identity details."""
+    assert pre_start.normalize_database_url(database_url) == expected
+
+
+def test_normalize_database_url_removes_required_channel_binding_only() -> None:
+    database_url = (
+        "postgresql://user:pass@localhost/database"
+        "?target_session_attrs=any&channel_binding=require&krbsrvname=postgres"
+    )
+
+    normalized = pre_start.normalize_database_url(database_url)
+
+    assert parse_qsl(urlsplit(normalized).query, keep_blank_values=True) == [
+        ("target_session_attrs", "any"),
+        ("krbsrvname", "postgres"),
+    ]
+
+
+def test_normalize_database_url_maps_ssl_for_direct_asyncpg() -> None:
+    database_url = (
+        "postgresql://user:pass@localhost/database?ssl=require&target_session_attrs=any"
+    )
+
+    normalized = pre_start.normalize_database_url(database_url)
+
+    assert parse_qsl(urlsplit(normalized).query, keep_blank_values=True) == [
+        ("sslmode", "require"),
+        ("target_session_attrs", "any"),
+    ]
+
+
+def test_normalize_database_url_preserves_sslmode() -> None:
+    database_url = (
+        "postgresql://user:pass@localhost/database"
+        "?sslmode=verify-full&target_session_attrs=any"
+    )
+
+    assert pre_start.normalize_database_url(database_url) == database_url
+
+
+def test_server_database_url_preserves_sqlalchemy_ssl_parameter() -> None:
+    database_url = (
+        "postgresql://user:pass@localhost/database"
+        "?ssl=require&channel_binding=require&target_session_attrs=any"
+    )
+
+    environment = ServerEnv.model_validate(
+        {
+            "AGENT_NAME": "test-agent",
+            "DATABASE_URL": database_url,
+        }
+    )
+
+    assert environment.session_uri == (
+        "postgresql://user:pass@localhost/database?ssl=require&target_session_attrs=any"
+    )
+
+
+def test_server_database_url_normalizes_postgres_scheme_for_sqlalchemy() -> None:
+    environment = ServerEnv.model_validate(
+        {
+            "AGENT_NAME": "test-agent",
+            "DATABASE_URL": "postgres://user:pass@localhost/database",
+        }
+    )
+
+    assert environment.session_uri == ("postgresql://user:pass@localhost/database")
+
+
+@pytest.mark.parametrize(
+    "database_url",
+    [
+        "   ",
+        "mysql://synthetic-user:synthetic-password@localhost/database",
+        "postgresql:/database",
+        "postgresql://user:pass@[broken/database",
+        "postgresql://user:pass@localhost/database#fragment",
+        "postgresql://user:pass@localhost/database?channel_binding=prefer",
+        "postgresql://user:pass@localhost/database?sslmode",
+        "postgresql://user:pass@localhost/database?sslmode=require&sslmode=disable",
+        "postgresql://user:pass@localhost/database?ssl=require&sslmode=require",
+        "postgresql://user:pass@localhost/database?application_name=worker",
+        (
+            "postgresql://user:pass@localhost/database"
+            "?host=%2Fvar%2Frun%2Fpostgresql&port=5432"
+        ),
+        "postgresql://user:pass@localhost:5432/database?port=6543",
+        "postgresql://user:pass@localhost:not-a-port/database",
+    ],
+)
+def test_normalize_database_url_rejects_unsupported_configuration_safely(
+    database_url: str,
+) -> None:
+    """Reject ambiguous or unsupported inputs without echoing their values."""
+    with pytest.raises(ValueError) as error:
+        pre_start.normalize_database_url(database_url)
+
+    rendered_error = str(error.value)
+    assert database_url not in rendered_error
+    assert "synthetic-password" not in rendered_error
+
+
+def test_database_readiness_settings_use_bounded_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_readiness_environment(monkeypatch)
+
+    environment = DatabaseReadinessEnv()
+
+    assert environment.database_url is None
+    assert environment.db_ready_timeout == 60
+    assert environment.retry_interval == 1
+    assert environment.attempt_timeout == 5
+
+
+def test_database_readiness_settings_accept_documented_upper_bounds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_readiness_environment(monkeypatch)
+    environment = DatabaseReadinessEnv.model_validate(
+        {
+            "DATABASE_URL": "postgresql://user:pass@localhost/database",
+            "DB_READY_TIMEOUT": 3600,
+            "DB_READY_RETRY_INTERVAL": 60,
+            "DB_READY_ATTEMPT_TIMEOUT": 60,
+        }
+    )
+
+    assert environment.database_url is not None
+    assert (
+        environment.database_url.get_secret_value()
+        == "postgresql://user:pass@localhost/database"
+    )
+    assert environment.db_ready_timeout == 3600
+    assert environment.retry_interval == 60
+    assert environment.attempt_timeout == 60
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("DB_READY_TIMEOUT", 0),
+        ("DB_READY_TIMEOUT", 3600.1),
+        ("DB_READY_RETRY_INTERVAL", 0),
+        ("DB_READY_RETRY_INTERVAL", 60.1),
+        ("DB_READY_ATTEMPT_TIMEOUT", 0),
+        ("DB_READY_ATTEMPT_TIMEOUT", 60.1),
+    ],
+)
+def test_database_readiness_settings_reject_out_of_bounds_values(
+    monkeypatch: pytest.MonkeyPatch,
+    field_name: str,
+    value: float,
+) -> None:
+    _clear_readiness_environment(monkeypatch)
+
+    with pytest.raises(ValidationError):
+        DatabaseReadinessEnv.model_validate({field_name: value})
+
+
+def test_database_readiness_settings_normalize_blank_database_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_readiness_environment(monkeypatch)
+
+    environment = DatabaseReadinessEnv.model_validate({"DATABASE_URL": "   "})
+
+    assert environment.database_url is None
+
+
+def test_database_readiness_settings_do_not_read_dotenv(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _clear_readiness_environment(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").write_text(
+        "DATABASE_URL=postgresql://dotenv-user:dotenv-pass@localhost/database\n"
+        "DB_READY_TIMEOUT=100\n",
+        encoding="utf-8",
+    )
+
+    environment = DatabaseReadinessEnv()
+
+    assert environment.database_url is None
+    assert environment.db_ready_timeout == 60
+
+
+@pytest.mark.parametrize(
+    "database_url",
+    [
+        "changethis",
+        "postgresql://user:pass@host:port/dbname?ssl=require",
+    ],
+)
+def test_database_readiness_settings_reject_example_database_urls(
+    monkeypatch: pytest.MonkeyPatch,
+    database_url: str,
+) -> None:
+    _clear_readiness_environment(monkeypatch)
+
+    with pytest.raises(SettingsConfigurationError) as error:
+        DatabaseReadinessEnv.model_validate({"DATABASE_URL": database_url})
+
+    assert database_url not in str(error.value)
+
+
+def test_database_readiness_validation_errors_redact_all_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_readiness_environment(monkeypatch)
+    database_url = (
+        "postgresql://private-user:encoded%40password@localhost/private-database"
+    )
+    invalid_timeout = "not-a-number-secret-canary"
+
+    with pytest.raises(ValidationError) as error:
+        DatabaseReadinessEnv.model_validate(
+            {
+                "DATABASE_URL": database_url,
+                "DB_READY_TIMEOUT": invalid_timeout,
+            }
+        )
+
+    rendered_error = repr(error.value.errors(include_input=True))
+    assert database_url not in rendered_error
+    assert invalid_timeout not in rendered_error
+    assert "private-user" not in rendered_error
+    assert "encoded%40password" not in rendered_error
+
+
+@pytest.mark.asyncio
+async def test_check_database_runs_exact_probe_and_closes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection = _mock_connection()
+    connect = _mock_connect(monkeypatch, connection=connection)
+
+    await pre_start.check_database(DATABASE_URL, attempt_timeout=0.5)
+
+    connect.assert_awaited_once_with(
+        DATABASE_URL,
+        timeout=0.5,
+        command_timeout=0.5,
+    )
+    connection.fetchval.assert_awaited_once_with("SELECT 1", timeout=0.5)
+    connection.close.assert_awaited_once_with(timeout=0.5)
+    connection.terminate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_check_database_rejects_unexpected_probe_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection = _mock_connection(query_result=0)
+    _mock_connect(monkeypatch, connection=connection)
+
+    with pytest.raises(RuntimeError, match="readiness query"):
+        await pre_start.check_database(DATABASE_URL, attempt_timeout=0.5)
+
+    connection.close.assert_not_awaited()
+    connection.terminate.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_check_database_terminates_after_query_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection = _mock_connection()
+    connection.fetchval.side_effect = asyncpg.PostgresConnectionError(
+        "synthetic query failure"
+    )
+    _mock_connect(monkeypatch, connection=connection)
+
+    with pytest.raises(
+        asyncpg.PostgresConnectionError,
+        match="synthetic query failure",
+    ):
+        await pre_start.check_database(DATABASE_URL, attempt_timeout=0.5)
+
+    connection.close.assert_not_awaited()
+    connection.terminate.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_check_database_closes_when_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection = _mock_connection()
+    connection.fetchval.side_effect = asyncio.CancelledError
+    _mock_connect(monkeypatch, connection=connection)
+
+    with pytest.raises(asyncio.CancelledError):
+        await pre_start.check_database(DATABASE_URL, attempt_timeout=0.5)
+
+    connection.close.assert_not_awaited()
+    connection.terminate.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_check_database_bounds_a_hung_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection = _mock_connection()
+
+    async def never_return(*_args: Any, **_kwargs: Any) -> None:
+        await asyncio.Event().wait()
+
+    connection.fetchval.side_effect = never_return
+    _mock_connect(monkeypatch, connection=connection)
+
+    started = time.monotonic()
+    with pytest.raises(TimeoutError):
+        await pre_start.check_database(DATABASE_URL, attempt_timeout=0.05)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 1
+    connection.close.assert_not_awaited()
+    connection.terminate.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_check_database_bounds_a_hung_close(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection = _mock_connection()
+
+    async def never_return(*_args: Any, **_kwargs: Any) -> None:
+        await asyncio.Event().wait()
+
+    connection.close.side_effect = never_return
+    _mock_connect(monkeypatch, connection=connection)
+
+    started = time.monotonic()
+    with pytest.raises(TimeoutError):
+        await pre_start.check_database(DATABASE_URL, attempt_timeout=0.05)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 1
+    connection.close.assert_awaited_once_with(timeout=0.05)
+    connection.terminate.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_check_database_terminates_when_close_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection = _mock_connection()
+    connection.close.side_effect = OSError("synthetic close failure")
+    _mock_connect(monkeypatch, connection=connection)
+
+    with pytest.raises(OSError, match="synthetic close failure"):
+        await pre_start.check_database(DATABASE_URL, attempt_timeout=0.5)
+
+    connection.close.assert_awaited_once_with(timeout=0.5)
+    connection.terminate.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_check_database_terminates_when_close_is_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection = _mock_connection()
+    connection.close.side_effect = asyncio.CancelledError
+    _mock_connect(monkeypatch, connection=connection)
+
+    with pytest.raises(asyncio.CancelledError):
+        await pre_start.check_database(DATABASE_URL, attempt_timeout=0.5)
+
+    connection.close.assert_awaited_once_with(timeout=0.5)
+    connection.terminate.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    ("invalid_field", "invalid_value"),
+    [
+        ("timeout", 0),
+        ("timeout", float("inf")),
+        ("retry_interval", 0),
+        ("retry_interval", float("nan")),
+        ("attempt_timeout", 0),
+        ("attempt_timeout", float("inf")),
+    ],
+)
+@pytest.mark.asyncio
+async def test_wait_for_database_rejects_invalid_timing(
+    monkeypatch: pytest.MonkeyPatch,
+    invalid_field: str,
+    invalid_value: float,
+) -> None:
+    connect = _mock_connect(monkeypatch)
+    timing = {
+        "timeout": 1.0,
+        "retry_interval": 0.01,
+        "attempt_timeout": 0.1,
+    }
+    timing[invalid_field] = invalid_value
+
+    with pytest.raises(ValueError, match=invalid_field):
+        await pre_start.wait_for_database(
+            DATABASE_URL,
+            timeout=timing["timeout"],
+            retry_interval=timing["retry_interval"],
+            attempt_timeout=timing["attempt_timeout"],
+        )
+
+    connect.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "transient_error",
+    [
+        ConnectionRefusedError("synthetic"),
+        TimeoutError("synthetic"),
+        OSError("synthetic aggregate network failure"),
+        OSError(errno.ENETUNREACH, "synthetic"),
+        asyncpg.PostgresConnectionError("synthetic"),
+        asyncpg.CannotConnectNowError("synthetic"),
+        asyncpg.AdminShutdownError("synthetic"),
+        asyncpg.CrashShutdownError("synthetic"),
+        asyncpg.TooManyConnectionsError("synthetic"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_wait_for_database_retries_only_transient_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    transient_error: BaseException,
+) -> None:
+    connection = _mock_connection()
+    connect = _mock_connect(
+        monkeypatch,
+        side_effect=[transient_error, connection],
+    )
+
+    attempts = await pre_start.wait_for_database(
+        DATABASE_URL,
+        timeout=0.5,
+        retry_interval=0.001,
+        attempt_timeout=0.1,
+    )
+
+    assert attempts == 2
+    assert connect.await_count == 2
+    connection.fetchval.assert_awaited_once_with("SELECT 1", timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_database_exhaustion_is_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connect = _mock_connect(
+        monkeypatch,
+        side_effect=ConnectionRefusedError("synthetic transient failure"),
+    )
+
+    started = time.monotonic()
+    with pytest.raises(TimeoutError):
+        await pre_start.wait_for_database(
+            DATABASE_URL,
+            timeout=0.03,
+            retry_interval=0.01,
+            attempt_timeout=0.01,
+        )
+    elapsed = time.monotonic() - started
+
+    assert 2 <= connect.await_count < 20
+    assert elapsed < 0.5
+
+
+@pytest.mark.asyncio
+async def test_wait_for_database_bounds_retry_sleep_by_total_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connect = _mock_connect(
+        monkeypatch,
+        side_effect=ConnectionRefusedError("synthetic transient failure"),
+    )
+
+    started = time.monotonic()
+    with pytest.raises(TimeoutError):
+        await pre_start.wait_for_database(
+            DATABASE_URL,
+            timeout=0.02,
+            retry_interval=0.5,
+            attempt_timeout=0.01,
+        )
+    elapsed = time.monotonic() - started
+
+    assert connect.await_count == 1
+    assert elapsed < 0.25
+
+
+@pytest.mark.parametrize(
+    "permanent_error",
+    [
+        asyncpg.InvalidPasswordError("synthetic"),
+        asyncpg.InvalidCatalogNameError("synthetic"),
+        FileNotFoundError("synthetic"),
+        PermissionError("synthetic"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_wait_for_database_fails_fast_on_permanent_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    permanent_error: Exception,
+) -> None:
+    connect = _mock_connect(monkeypatch, side_effect=permanent_error)
+
+    with pytest.raises(type(permanent_error), match="synthetic"):
+        await pre_start.wait_for_database(
+            DATABASE_URL,
+            timeout=0.5,
+            retry_interval=0.01,
+            attempt_timeout=0.1,
+        )
+
+    assert connect.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_wait_for_database_does_not_retry_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connect = _mock_connect(monkeypatch, side_effect=asyncio.CancelledError)
+
+    with pytest.raises(asyncio.CancelledError):
+        await pre_start.wait_for_database(
+            DATABASE_URL,
+            timeout=0.5,
+            retry_interval=0.01,
+            attempt_timeout=0.1,
+        )
+
+    assert connect.await_count == 1
+
+
+@pytest.mark.parametrize("termination_signal", [signal.SIGTERM, signal.SIGINT])
+def test_termination_signal_handler_uses_conventional_exit_status(
+    termination_signal: signal.Signals,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as error:
+        pre_start._exit_on_termination_signal(termination_signal, None)
+
+    assert error.value.code == 128 + termination_signal
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_main_installs_and_restores_termination_signal_handlers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_readiness_environment(monkeypatch)
+    monkeypatch.setattr(
+        pre_start.sys,
+        "argv",
+        ["agent.pre_start", "synthetic-command"],
+    )
+    execvp = _mock_execvp(monkeypatch)
+    previous_handlers = {
+        signal.SIGTERM: signal.SIG_DFL,
+        signal.SIGINT: signal.SIG_IGN,
+    }
+    set_signal_handler = create_autospec(signal.signal, spec_set=True)
+
+    def remember_previous_handler(
+        termination_signal: signal.Signals,
+        handler: Any,
+    ) -> Any:
+        if handler is pre_start._exit_on_termination_signal:
+            return previous_handlers[termination_signal]
+        return signal.SIG_DFL
+
+    set_signal_handler.side_effect = remember_previous_handler
+    monkeypatch.setattr(pre_start.signal, "signal", set_signal_handler)
+
+    with pytest.raises(_ExecRequested):
+        pre_start.main()
+
+    execvp.assert_called_once_with("synthetic-command", ["synthetic-command"])
+    assert set_signal_handler.call_count == 4
+    set_signal_handler.assert_has_calls(
+        [
+            call(signal.SIGTERM, pre_start._exit_on_termination_signal),
+            call(signal.SIGINT, pre_start._exit_on_termination_signal),
+            call(signal.SIGTERM, signal.SIG_DFL),
+            call(signal.SIGINT, signal.SIG_IGN),
+        ],
+        any_order=True,
+    )
+
+
+@pytest.mark.parametrize("database_url", [None, "   "])
+def test_main_executes_command_without_configured_database(
+    monkeypatch: pytest.MonkeyPatch,
+    database_url: str | None,
+) -> None:
+    _clear_readiness_environment(monkeypatch)
+    if database_url is not None:
+        monkeypatch.setenv("DATABASE_URL", database_url)
+    monkeypatch.setattr(
+        pre_start.sys,
+        "argv",
+        ["agent.pre_start", "synthetic-command", "--flag"],
+    )
+    execvp = _mock_execvp(monkeypatch)
+
+    with pytest.raises(_ExecRequested):
+        pre_start.main()
+
+    execvp.assert_called_once_with(
+        "synthetic-command",
+        ["synthetic-command", "--flag"],
+    )
+
+
+def test_main_executes_command_only_after_database_is_ready(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _clear_readiness_environment(monkeypatch)
+    monkeypatch.setenv("DATABASE_URL", DATABASE_URL)
+    monkeypatch.setenv("DB_READY_TIMEOUT", "0.5")
+    monkeypatch.setenv("DB_READY_RETRY_INTERVAL", "0.01")
+    monkeypatch.setenv("DB_READY_ATTEMPT_TIMEOUT", "0.1")
+    monkeypatch.setattr(
+        pre_start.sys,
+        "argv",
+        ["agent.pre_start", "synthetic-command", "--flag"],
+    )
+    connection = _mock_connection()
+    connect = _mock_connect(monkeypatch, connection=connection)
+    execvp = _mock_execvp(monkeypatch)
+
+    with pytest.raises(_ExecRequested):
+        pre_start.main()
+
+    assert connect.await_count == 1
+    execvp.assert_called_once_with(
+        "synthetic-command",
+        ["synthetic-command", "--flag"],
+    )
+    captured = capsys.readouterr()
+    output = captured.out + captured.err
+    assert DATABASE_URL not in output
+    assert "encoded%40password" not in output
+    assert "encoded@password" not in output
+
+
+@pytest.mark.parametrize(
+    ("environment_key", "environment_value"),
+    [
+        (
+            "DATABASE_URL",
+            "mysql://private-user:encoded%40password@localhost/private",
+        ),
+        ("DB_READY_TIMEOUT", "not-a-number-secret-canary"),
+    ],
+)
+def test_main_fails_closed_without_disclosing_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    environment_key: str,
+    environment_value: str,
+) -> None:
+    _clear_readiness_environment(monkeypatch)
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        "postgresql://private-user:encoded%40password@localhost/private",
+    )
+    monkeypatch.setenv(environment_key, environment_value)
+    monkeypatch.setattr(
+        pre_start.sys,
+        "argv",
+        ["agent.pre_start", "synthetic-command"],
+    )
+    execvp = _mock_execvp(monkeypatch)
+
+    with pytest.raises(SystemExit) as error:
+        pre_start.main()
+
+    assert error.value.code != 0
+    execvp.assert_not_called()
+    captured = capsys.readouterr()
+    output = captured.out + captured.err
+    assert environment_value not in output
+    assert "private-user" not in output
+    assert "encoded%40password" not in output
+    assert "encoded@password" not in output
+
+
+def test_main_requires_a_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_readiness_environment(monkeypatch)
+    monkeypatch.setattr(pre_start.sys, "argv", ["agent.pre_start"])
+    execvp = _mock_execvp(monkeypatch)
+
+    with pytest.raises(SystemExit) as error:
+        pre_start.main()
+
+    assert error.value.code != 0
+    execvp.assert_not_called()
+
+
+def test_main_reports_application_exec_failure_safely(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _clear_readiness_environment(monkeypatch)
+    monkeypatch.setattr(
+        pre_start.sys,
+        "argv",
+        ["agent.pre_start", "private-command-canary"],
+    )
+    execvp = create_autospec(os.execvp, spec_set=True)
+    execvp.side_effect = OSError("private-command-canary could not execute")
+    monkeypatch.setattr(pre_start.os, "execvp", execvp)
+
+    with pytest.raises(SystemExit) as error:
+        pre_start.main()
+
+    captured = capsys.readouterr()
+    output = captured.out + captured.err
+    assert error.value.code != 0
+    execvp.assert_called_once_with(
+        "private-command-canary",
+        ["private-command-canary"],
+    )
+    assert "private-command-canary" not in output
+
+
+def test_module_execution_invokes_main(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _clear_readiness_environment(monkeypatch)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["agent.pre_start", "synthetic-command"],
+    )
+    execvp = create_autospec(os.execvp, spec_set=True)
+    execvp.side_effect = _ExecRequested
+    monkeypatch.setattr(os, "execvp", execvp)
+    monkeypatch.delitem(sys.modules, "agent.pre_start")
+
+    with pytest.raises(_ExecRequested):
+        runpy.run_module("agent.pre_start", run_name="__main__")
+
+    execvp.assert_called_once_with(
+        "synthetic-command",
+        ["synthetic-command"],
+    )
+
+
+def test_entrypoint_is_valid_posix_shell() -> None:
+    completed = subprocess.run(  # noqa: S603
+        ["/bin/sh", "-n", str(ENTRYPOINT_PATH)],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_entrypoint_delegates_readiness_without_parsing_database_url() -> None:
+    entrypoint = ENTRYPOINT_PATH.read_text(encoding="utf-8")
+
+    assert 'exec "$python_bin" -m agent.pre_start "$@"' in entrypoint
+    assert "DATABASE_URL" not in entrypoint
+    assert "grep" not in entrypoint
+    assert "sed" not in entrypoint
+    assert "nc " not in entrypoint
+    assert "while " not in entrypoint
+
+
+def test_entrypoint_forwards_command_output_and_exit_code(tmp_path: Path) -> None:
+    completed = subprocess.run(  # noqa: S603
+        [
+            "/bin/sh",
+            str(ENTRYPOINT_PATH),
+            sys.executable,
+            "-c",
+            "print('ENTRYPOINT_COMMAND_RAN'); raise SystemExit(23)",
+        ],
+        cwd=tmp_path,
+        env=_subprocess_environment(tmp_path),
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert completed.returncode == 23
+    assert "ENTRYPOINT_COMMAND_RAN" in completed.stdout
+
+
+def test_entrypoint_readiness_failure_blocks_command_and_redacts(
+    tmp_path: Path,
+) -> None:
+    marker_path = tmp_path / "command-ran"
+    database_url = "mysql://private-user:encoded%40password@localhost/private-database"
+    completed = subprocess.run(  # noqa: S603
+        [
+            "/bin/sh",
+            str(ENTRYPOINT_PATH),
+            sys.executable,
+            "-c",
+            "from pathlib import Path; Path(__import__('sys').argv[1]).touch()",
+            str(marker_path),
+        ],
+        cwd=tmp_path,
+        env=_subprocess_environment(tmp_path, DATABASE_URL=database_url),
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    output = completed.stdout + completed.stderr
+    assert completed.returncode != 0
+    assert not marker_path.exists()
+    assert database_url not in output
+    assert "private-user" not in output
+    assert "encoded%40password" not in output
+    assert "encoded@password" not in output
+
+
+def test_entrypoint_term_during_readiness_exits_promptly(tmp_path: Path) -> None:
+    marker_path = tmp_path / "command-ran"
+    process = subprocess.Popen(  # noqa: S603
+        [
+            "/bin/sh",
+            str(ENTRYPOINT_PATH),
+            sys.executable,
+            "-c",
+            "from pathlib import Path; Path(__import__('sys').argv[1]).touch()",
+            str(marker_path),
+        ],
+        cwd=tmp_path,
+        env=_subprocess_environment(
+            tmp_path,
+            DATABASE_URL="postgresql://user:pass@127.0.0.1:1/database",
+            DB_READY_TIMEOUT="30",
+            DB_READY_RETRY_INTERVAL="0.1",
+            DB_READY_ATTEMPT_TIMEOUT="0.2",
+        ),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    try:
+        assert process.stdout is not None
+        readiness_output: list[str] = []
+        readiness_deadline = time.monotonic() + 5
+        while time.monotonic() < readiness_deadline:
+            readable, _, _ = select.select(
+                [process.stdout],
+                [],
+                [],
+                max(0, readiness_deadline - time.monotonic()),
+            )
+            if not readable:
+                break
+            line = process.stdout.readline()
+            if not line:
+                break
+            readiness_output.append(line)
+            if "Waiting for database readiness..." in line:
+                break
+
+        assert "Waiting for database readiness..." in "".join(readiness_output)
+        assert process.poll() is None
+        started = time.monotonic()
+        process.terminate()
+        process.communicate(timeout=5)
+        elapsed = time.monotonic() - started
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.communicate(timeout=5)
+
+    assert process.returncode == 128 + signal.SIGTERM
+    assert elapsed < 3
+    assert not marker_path.exists()

--- a/uv.lock
+++ b/uv.lock
@@ -594,6 +594,7 @@ dependencies = [
     { name = "opentelemetry-instrumentation-logging" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "tenacity" },
 ]
 
 [package.dev-dependencies]
@@ -625,6 +626,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-logging", specifier = ">=0.58b0,<0.59" },
     { name = "pydantic", specifier = ">=2.11.0,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.12.0,<3.0.0" },
+    { name = "tenacity", specifier = ">=9.1.2,<10.0.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## What

Add a bounded PostgreSQL readiness gate that runs before the container starts the ADK server.

## Why

The existing shell entrypoint only checked whether a TCP port opened, parsed database URLs unsafely, and could wait forever. A VM deployment needs a fail-closed startup contract that proves the configured database can authenticate and execute a query without leaking credentials.

## How

- Replace shell URL parsing and netcat polling with a Python PID 1 wrapper
- Execute `SELECT 1` through asyncpg with bounded attempts and total timeout
- Retry transient connection failures while failing fast on permanent configuration and authentication errors
- Normalize PostgreSQL URLs consistently for direct asyncpg and SQLAlchemy consumers
- Preserve SIGTERM and SIGINT behavior and redact startup failure diagnostics
- Document readiness settings and remove the netcat runtime dependency
- Add unit, subprocess, Docker-contract, and real PostgreSQL integration coverage

## Tests

- [x] `uv sync --locked`
- [x] `uv run ruff format --check`
- [x] `uv run ruff check --no-fix --output-format=github`
- [x] `uv run mypy .`
- [x] `uv run pytest --cov=src --cov-report=xml --cov-report=term-missing` (347 passed, 4 environment-gated skips, 100% statement and branch coverage)
- [x] Real PostgreSQL integration suite against isolated PostgreSQL 17 (33 passed)
- [x] Built the production image and verified runtime imports and no-database health
- [x] Verified a container retries an unavailable endpoint, then becomes healthy after PostgreSQL starts
- [x] Confirmed Blacki remained running and disposable test containers were removed
- [x] No LLM evaluation required because this is a deterministic process-startup and database contract with no prompt or model behavior changes

## Related Issues

Closes #37