### PR TITLE
build: share Python base across stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
 # syntax=docker/dockerfile:1
 
 # ============================================================================
+# Shared Base: Single external Python image reference
+# ============================================================================
+FROM python:3.13-slim AS python-base
+
+# ============================================================================
 # Builder Stage: Install dependencies with optimal caching
 # ============================================================================
-FROM python:3.13-slim AS builder
+FROM python-base AS builder
 
 # Install uv
 RUN pip install uv==0.9.26
@@ -34,7 +39,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # ============================================================================
 # Runtime Stage: Minimal production image
 # ============================================================================
-FROM python:3.13-slim AS runtime
+FROM python-base AS runtime
 
 # Create non-root user for security (matching common host UID 1000)
 RUN groupadd -g 1000 app && \

--- a/tests/test_docker_context.py
+++ b/tests/test_docker_context.py
@@ -2,6 +2,7 @@
 
 import shlex
 from pathlib import Path
+from typing import NamedTuple
 
 import pytest
 
@@ -33,6 +34,143 @@ EXPECTED_NESTED_EXCLUSIONS = {
     "**/*.py[cod]",
     "**/.DS_Store",
 }
+
+
+class _DockerStage(NamedTuple):
+    """A named Docker build stage and its logical instructions."""
+
+    source: str
+    name: str
+    instructions: tuple[tuple[str, str], ...]
+
+
+def _logical_dockerfile_instructions(contents: str) -> list[tuple[str, str]]:
+    """Parse logical Dockerfile instructions without matching comments or values."""
+    instructions: list[tuple[str, str]] = []
+    continuation: list[str] = []
+
+    for raw_line in contents.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        continues = line.endswith("\\")
+        continuation.append(line[:-1].rstrip() if continues else line)
+        if continues:
+            continue
+
+        logical_line = " ".join(continuation)
+        keyword, separator, arguments = logical_line.partition(" ")
+        assert separator, f"Instruction has no arguments: {logical_line}"
+        instructions.append((keyword.upper(), arguments.strip()))
+        continuation = []
+
+    assert not continuation, "Dockerfile ends with an incomplete instruction"
+    return instructions
+
+
+def _parse_from(arguments: str) -> tuple[str, str]:
+    """Parse the supported named FROM form, including an optional platform flag."""
+    tokens = shlex.split(arguments)
+    while tokens and tokens[0].startswith("--"):
+        option = tokens.pop(0)
+        assert option.startswith("--platform="), f"Unsupported FROM option: {option}"
+
+    assert len(tokens) == 3 and tokens[1].casefold() == "as", (
+        f"FROM stages must use a named source: {arguments}"
+    )
+    return tokens[0], tokens[2].casefold()
+
+
+def _dockerfile_stages(contents: str) -> list[_DockerStage]:
+    """Build a stage-aware representation of the Dockerfile."""
+    stages: list[_DockerStage] = []
+    current_source: str | None = None
+    current_name: str | None = None
+    current_instructions: list[tuple[str, str]] = []
+
+    for keyword, arguments in _logical_dockerfile_instructions(contents):
+        if keyword != "FROM":
+            if current_name is not None:
+                current_instructions.append((keyword, arguments))
+            continue
+
+        if current_source is not None and current_name is not None:
+            stages.append(
+                _DockerStage(
+                    current_source,
+                    current_name,
+                    tuple(current_instructions),
+                )
+            )
+
+        current_source, current_name = _parse_from(arguments)
+        current_instructions = []
+
+    assert current_source is not None and current_name is not None, (
+        "Dockerfile must contain a named FROM stage"
+    )
+    stages.append(
+        _DockerStage(current_source, current_name, tuple(current_instructions))
+    )
+    return stages
+
+
+def _is_official_python_image(source: str) -> bool:
+    """Return whether a literal image source is the official Python repository."""
+    repository = source.partition("@")[0].rsplit(":", maxsplit=1)[0].casefold()
+    return repository in {"python", "docker.io/library/python"}
+
+
+def _assert_shared_python_base_contract(contents: str) -> None:
+    """Assert Python stage inheritance and final runtime security invariants."""
+    stages = _dockerfile_stages(contents)
+    stages_by_name: dict[str, _DockerStage] = {}
+    external_stages: list[_DockerStage] = []
+
+    for stage in stages:
+        assert stage.name not in stages_by_name, (
+            f"Duplicate Docker stage alias: {stage.name}"
+        )
+        if stage.source.casefold() not in stages_by_name:
+            external_stages.append(stage)
+        stages_by_name[stage.name] = stage
+
+    external_python_stages = [
+        stage for stage in external_stages if _is_official_python_image(stage.source)
+    ]
+    assert len(external_python_stages) == 1, (
+        "Dockerfile must contain exactly one external official Python image"
+    )
+
+    python_base = stages_by_name.get("python-base")
+    assert python_base is external_python_stages[0]
+    assert stages[0] is python_base, "The shared Python base must be the first stage"
+
+    for stage_name in ("builder", "runtime"):
+        required_stage = stages_by_name.get(stage_name)
+        assert required_stage is not None, f"Missing {stage_name} stage"
+        assert required_stage.source.casefold() == python_base.name, (
+            f"{stage_name} must derive directly from {python_base.name}"
+        )
+
+    runtime = stages_by_name["runtime"]
+    assert stages[-1] is runtime, "Runtime must remain the final Docker stage"
+
+    runtime_users = [
+        arguments for keyword, arguments in runtime.instructions if keyword == "USER"
+    ]
+    assert runtime_users and shlex.split(runtime_users[-1]) == ["app"], (
+        "Runtime must end as the non-root app user"
+    )
+
+    assert any(
+        keyword == "COPY"
+        and any(
+            token.casefold() == "--from=builder" for token in shlex.split(arguments)
+        )
+        for keyword, arguments in runtime.instructions
+    ), "Runtime must copy the built application from builder"
 
 
 def _effective_patterns() -> list[str]:
@@ -148,3 +286,65 @@ def test_runtime_image_has_no_netcat_database_readiness_dependency() -> None:
     dockerfile = DOCKERFILE_PATH.read_text(encoding="utf-8").casefold()
 
     assert "netcat" not in dockerfile
+
+
+def test_docker_stages_share_one_external_python_base() -> None:
+    _assert_shared_python_base_contract(DOCKERFILE_PATH.read_text(encoding="utf-8"))
+
+
+def test_docker_stage_parser_ignores_from_text_outside_instructions() -> None:
+    contents = """
+    # FROM python:3.12-slim AS stale-example
+    FROM --platform=linux/amd64 python:3.13-slim AS python-base
+    RUN echo "FROM python:3.11-slim AS not-a-stage"
+    FROM python-base AS builder
+    FROM python-base AS runtime
+    COPY --from=builder /app /app
+    USER app
+    """
+
+    _assert_shared_python_base_contract(contents)
+
+
+@pytest.mark.parametrize(
+    ("contents", "message"),
+    [
+        (
+            """
+            FROM python:3.13-slim AS python-base
+            FROM python:3.12-slim AS builder
+            FROM python-base AS runtime
+            COPY --from=builder /app /app
+            USER app
+            """,
+            "exactly one external official Python image",
+        ),
+        (
+            """
+            FROM python:3.13-slim AS python-base
+            FROM python-base AS builder
+            FROM builder AS runtime
+            COPY --from=builder /app /app
+            USER app
+            """,
+            "runtime must derive directly from python-base",
+        ),
+        (
+            """
+            FROM python:3.13-slim AS python-base
+            FROM python-base AS builder
+            FROM python-base AS runtime
+            COPY --from=builder /app /app
+            USER app
+            USER root
+            """,
+            "Runtime must end as the non-root app user",
+        ),
+    ],
+)
+def test_docker_stage_contract_rejects_unsafe_inheritance(
+    contents: str,
+    message: str,
+) -> None:
+    with pytest.raises(AssertionError, match=message):
+        _assert_shared_python_base_contract(contents)


### PR DESCRIPTION
## What

Make the Docker builder and runtime derive from one named external Python base stage.

## Why

GitHub only guarantees Dependabot updates for the first `FROM` instruction in a multi-stage Dockerfile. Repeating the external Python image could leave builder and runtime on different versions, producing an incompatible copied virtual environment. This prerequisite makes Docker dependency updates safe before enabling issue #35.

## How

- Add one external `python-base` stage
- Derive both `builder` and `runtime` directly from that shared stage
- Preserve all existing build, ownership, entrypoint, and non-root runtime behavior
- Add a stage-aware Dockerfile contract that rejects duplicate Python bases, inheritance bypasses, false-positive `FROM` text, and root runtime regressions

## Tests

- [x] `uv sync --locked`
- [x] `uv run ruff format --check`
- [x] `uv run ruff check --no-fix --output-format=github`
- [x] `uv run mypy .`
- [x] `uv run pytest --cov=src --cov-report=xml --cov-report=term-missing` (352 passed, 4 environment-gated skips, 100% statement and branch coverage)
- [x] Built the real `builder` and `runtime` Docker targets
- [x] Verified both targets resolve to Python 3.13.14
- [x] Verified the runtime image declares `USER app`
- [x] Verified the real runtime entrypoint imports `agent.pre_start`
- [x] `docker compose config --quiet`
- [x] No LLM evaluation required because this changes deterministic container stage inheritance only

## Related Issues

Closes #75

Unblocks #35