### PR TITLE
fix: align GHCR deployment contract

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -93,10 +93,12 @@ jobs:
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
+            set -eu
+
             # 1. Set dynamic project directory based on repository name
             PROJECT_NAME="${{ github.event.repository.name }}"
-            PROJECT_DIR="\$HOME/$PROJECT_NAME"
-            IMAGE_NAME="ghcr.io/${{ github.repository }}:main"
+            PROJECT_DIR="$HOME/$PROJECT_NAME"
+            IMAGE_NAME="$(printf '%s' "ghcr.io/${{ github.repository }}:main" | tr '[:upper:]' '[:lower:]')"
 
             # 2. Ensure project directory exists
             if [ ! -d "$PROJECT_DIR" ]; then
@@ -110,7 +112,7 @@ jobs:
 
             # 4. Inject Secrets into .env (Automated Configuration)
             echo "Generating .env file from GitHub Secrets..."
-            cat <<EOF > .env
+            cat <<'ENV_FILE' > .env
             AGENT_NAME=production-agent
             DATABASE_URL=${{ secrets.DATABASE_URL }}
             OPENROUTER_API_KEY=${{ secrets.OPENROUTER_API_KEY }}
@@ -122,10 +124,10 @@ jobs:
             LOG_LEVEL=INFO
             PORT=8080
             HOST=0.0.0.0
-            EOF
+            ENV_FILE
 
             # 5. Deploy with dynamic image
             export IMAGE="$IMAGE_NAME"
             docker compose pull
-            docker compose up -d
+            docker compose up --no-build --wait --wait-timeout 180
             docker image prune -f

--- a/.github/workflows/test-docker-compose.yml
+++ b/.github/workflows/test-docker-compose.yml
@@ -29,7 +29,7 @@ jobs:
         shell: bash
         env:
           COMPOSE_DISABLE_ENV_FILE: "1"
-          IMAGE: google-adk-bare-metal:compose-${{ github.sha }}
+          IMAGE: ghcr.io/example/agent:compose-${{ github.sha }}
           SMOKE_PROJECT: adk-smoke-${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           set -Eeuo pipefail
@@ -107,6 +107,12 @@ jobs:
             -f compose.yaml
             -f "$OVERRIDE_FILE"
           )
+
+          resolved_images="$("${compose[@]}" config --images)"
+          if [ "$resolved_images" != "$IMAGE" ]; then
+            printf 'Unexpected Compose image: %s\n' "$resolved_images" >&2
+            exit 1
+          fi
 
           "${compose[@]}" config --quiet
           "${compose[@]}" build

--- a/README.md
+++ b/README.md
@@ -50,15 +50,19 @@ We've simplified deployment to the absolute basics. No Kubernetes required.
 
 ### Option 1: Using the Pre-built Image (Recommended)
 
-Since we include CI/CD, every push to `main` builds a fresh image. On your server:
+Every successful Docker Publish workflow on `main` publishes an image for that
+repository. From the cloned repository on your server, create `.env`, then
+replace both placeholders below with the lowercase owner and repository that
+published the image. The export is session-scoped, so repeat it in each new
+deployment shell.
 
 ```bash
-# 1. Pull the latest image
-docker pull ghcr.io/queryplanner/google-adk-on-bare-metal:main
-
-# 2. Start the service
-docker compose up --wait --wait-timeout 180
+export IMAGE="ghcr.io/<your-org-or-username>/<your-repository>:main"
+docker compose pull && docker compose up --no-build --wait --wait-timeout 180
 ```
+
+Public GHCR packages can be pulled anonymously. Private packages require the
+least-privilege login described in the full deployment guide.
 
 ### Option 2: Build Yourself
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -43,32 +43,27 @@ This repository includes a GitHub Actions workflow that automatically:
 
 ### Using GHCR Images
 
-Instead of building locally, you can pull the pre-built image from GHCR.
+Instead of building locally, you can run the image published by your
+repository's successful Docker Publish workflow. Run these commands from the
+cloned repository after creating `.env`.
 
-1.  **Login to GHCR** (on your server):
-    ```bash
-    echo $GITHUB_TOKEN | docker login ghcr.io -u YOUR_GITHUB_USERNAME --password-stdin
-    ```
-2.  **Pull the latest image**:
-    ```bash
-    docker pull ghcr.io/<your-org-or-username>/google-adk-on-bare-metal:main
-    ```
+Public GHCR packages can be pulled anonymously. For a private package, create a
+classic personal access token with only `read:packages`, load it into
+`GHCR_TOKEN` from your secret manager, and authenticate without placing the
+token in this repository or the command itself:
 
-### Automatic Deployment
-
-To automate deployment, update your `compose.yaml` to use the GHCR image:
-
-```yaml
-services:
-  agent:
-    image: ghcr.io/<your-org-or-username>/google-adk-on-bare-metal:main
-    # ... rest of config
+```bash
+printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u YOUR_GITHUB_USERNAME --password-stdin
 ```
 
-Then your update command becomes:
+Replace both placeholders below with the lowercase GitHub owner and repository
+whose workflow published the image. `IMAGE` selects the existing
+`${IMAGE:-agent}` Compose image contract; do not edit `compose.yaml`. The export
+is session-scoped, so repeat it in each new deployment shell.
+
 ```bash
-docker compose pull
-docker compose up --wait --wait-timeout 180
+export IMAGE="ghcr.io/<your-org-or-username>/<your-repository>:main"
+docker compose pull && docker compose up --no-build --wait --wait-timeout 180
 ```
 
 ---

--- a/tests/test_compose_workflow.py
+++ b/tests/test_compose_workflow.py
@@ -78,6 +78,10 @@ set -eu
 printf '%s\\n' "$*" >> "$FAKE_DOCKER_LOG"
 
 case " $* " in
+  *" config --images "*)
+    printf '%s\\n' "$IMAGE"
+    exit 0
+    ;;
   *" config --quiet "*|*" build "*)
     exit 0
     ;;
@@ -230,6 +234,7 @@ def test_smoke_script_is_secret_free_bounded_and_self_cleaning() -> None:
         "trap 'exit 130' INT",
         "trap 'exit 143' TERM",
         "umask 077",
+        "IMAGE: ghcr.io/example/agent:compose-${{ github.sha }}",
         'mktemp "${RUNNER_TEMP}/compose-smoke-env.XXXXXX"',
         'mktemp "${RUNNER_TEMP}/compose-smoke-override.XXXXXX.yaml"',
         "export ENV_FILE",
@@ -238,6 +243,9 @@ def test_smoke_script_is_secret_free_bounded_and_self_cleaning() -> None:
         '"127.0.0.1:8080:8080"',
         'restart: "no"',
         'OTEL_SDK_DISABLED: "true"',
+        '"${compose[@]}" config --images',
+        'if [ "$resolved_images" != "$IMAGE" ]; then',
+        "Unexpected Compose image:",
         '"${compose[@]}" config --quiet',
         '"${compose[@]}" build',
         "--detach --no-build --wait --wait-timeout 180",
@@ -261,6 +269,7 @@ def test_smoke_script_is_secret_free_bounded_and_self_cleaning() -> None:
     ordered_fragments = (
         "trap cleanup EXIT",
         "umask 077",
+        '"${compose[@]}" config --images',
         '"${compose[@]}" config --quiet',
         '"${compose[@]}" build',
         '"${compose[@]}" up',
@@ -299,6 +308,7 @@ def test_smoke_script_success_probes_and_cleans_up(
     assert "Compose startup and health checks passed." in result.stdout
     calls = _docker_calls(smoke_harness)
     ordered_fragments = (
+        " config --images",
         " config --quiet",
         " build",
         " up --detach",

--- a/tests/test_deployment_docs.py
+++ b/tests/test_deployment_docs.py
@@ -1,0 +1,83 @@
+"""Manual GHCR deployment documentation contract tests."""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+README_PATH = REPOSITORY_ROOT / "README.md"
+DEPLOYMENT_GUIDE_PATH = REPOSITORY_ROOT / "docs" / "DEPLOYMENT.md"
+IMAGE_EXPORT = 'export IMAGE="ghcr.io/<your-org-or-username>/<your-repository>:main"'
+PREBUILT_DEPLOY_COMMAND = (
+    "docker compose pull && docker compose up --no-build --wait --wait-timeout 180"
+)
+LOCAL_BUILD_COMMAND = "docker compose up --build --wait --wait-timeout 180"
+
+
+def _bash_blocks(document: str) -> list[str]:
+    """Return the contents of each fenced Bash block."""
+    return re.findall(r"(?ms)^```bash[ \t]*\n(.*?)^```[ \t]*$", document)
+
+
+def _commands(block: str) -> list[str]:
+    """Return non-comment commands from one Bash block."""
+    return [
+        line.strip()
+        for line in block.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+@pytest.mark.parametrize("guide_path", (README_PATH, DEPLOYMENT_GUIDE_PATH))
+def test_prebuilt_image_workflow_uses_configurable_compose_contract(
+    guide_path: Path,
+) -> None:
+    """Select, pull, and start one fork-owned image in a fail-closed sequence."""
+    document = guide_path.read_text(encoding="utf-8")
+    deployment_blocks = [
+        block for block in _bash_blocks(document) if "docker compose pull" in block
+    ]
+
+    assert len(deployment_blocks) == 1
+    assert _commands(deployment_blocks[0]) == [
+        IMAGE_EXPORT,
+        PREBUILT_DEPLOY_COMMAND,
+    ]
+    assert "cloned repository" in document
+    assert "`.env`" in document
+    assert "lowercase" in document
+    assert "session-scoped" in document
+    assert LOCAL_BUILD_COMMAND in document
+
+
+def test_guides_remove_stale_registry_and_compose_edit_instructions() -> None:
+    """Keep forks away from the template image and disconnected manual pulls."""
+    readme = README_PATH.read_text(encoding="utf-8")
+    deployment_guide = DEPLOYMENT_GUIDE_PATH.read_text(encoding="utf-8")
+    combined = f"{readme}\n{deployment_guide}".casefold()
+
+    assert "ghcr.io/queryplanner/google-adk-on-bare-metal" not in combined
+    assert "docker pull " not in combined
+    assert "update your `compose.yaml`" not in deployment_guide.casefold()
+    assert "image: ghcr.io/" not in deployment_guide.casefold()
+
+
+def test_private_registry_login_uses_least_privilege_stdin_contract() -> None:
+    """Document optional private-package auth without embedding a credential."""
+    document = DEPLOYMENT_GUIDE_PATH.read_text(encoding="utf-8")
+    login_blocks = [
+        block for block in _bash_blocks(document) if "docker login ghcr.io" in block
+    ]
+
+    assert len(login_blocks) == 1
+    assert _commands(login_blocks[0]) == [
+        (
+            """printf '%s' "$GHCR_TOKEN" | docker login ghcr.io """
+            """-u YOUR_GITHUB_USERNAME --password-stdin"""
+        )
+    ]
+    assert "Public GHCR packages can be pulled anonymously." in document
+    assert "classic personal access token with only `read:packages`" in document
+    assert "$GITHUB_TOKEN" not in document
+    assert "echo " not in login_blocks[0]

--- a/tests/test_deployment_workflow.py
+++ b/tests/test_deployment_workflow.py
@@ -1,6 +1,8 @@
 """Deployment workflow safety contract tests."""
 
+import subprocess
 from pathlib import Path
+from typing import NamedTuple
 
 import pytest
 
@@ -17,6 +19,24 @@ EXPECTED_DEPLOY_CLAUSES = {
     "github.ref == 'refs/heads/main'",
     "inputs.deploy",
 }
+SECRET_CANARIES = {
+    "DATABASE_URL": "postgresql://user:p$UNSET@database/agent",
+    "OPENROUTER_API_KEY": "$(printf command-substitution)",
+    "GOOGLE_API_KEY": "`printf backtick-substitution`",
+    "ROOT_AGENT_MODEL": "openrouter/provider/model",
+    "LANGFUSE_PUBLIC_KEY": "public-key",
+    "LANGFUSE_SECRET_KEY": "secret-key",
+    "LANGFUSE_HOST": "https://observability.example",
+}
+
+
+class DeployHarness(NamedTuple):
+    """Synthetic remote host boundaries for the tracked deployment script."""
+
+    environment: dict[str, str]
+    docker_log: Path
+    git_log: Path
+    home: Path
 
 
 def _indented_block(document: str, heading: str, indentation: int) -> str:
@@ -46,6 +66,119 @@ def _deploy_guard(document: str) -> str:
         condition_lines.append(line.strip())
 
     return " ".join(condition_lines)
+
+
+def _deploy_script(document: str) -> str:
+    """Extract the remote shell program from the deployment action."""
+    deploy_block = _indented_block(document, "deploy:", 2)
+    lines = deploy_block.splitlines()
+    script_start = lines.index("          script: |") + 1
+    script_lines: list[str] = []
+
+    for line in lines[script_start:]:
+        if line and not line.startswith("            "):
+            break
+        script_lines.append(line[12:] if line else "")
+
+    return "\n".join(script_lines)
+
+
+def _materialize_deploy_script(script: str) -> str:
+    """Replace GitHub expressions with deterministic non-secret values."""
+    replacements = {
+        "${{ github.event.repository.name }}": "Mixed-Repository",
+        "${{ github.repository }}": "MixedOwner/Mixed-Repository",
+    }
+    replacements.update(
+        {
+            "${{ secrets." + secret_name + " }}": secret_value
+            for secret_name, secret_value in SECRET_CANARIES.items()
+        }
+    )
+
+    for expression, value in replacements.items():
+        script = script.replace(expression, value)
+
+    assert "${{" not in script
+    return script
+
+
+@pytest.fixture
+def deploy_harness(tmp_path: Path) -> DeployHarness:
+    """Provide fake Git and Docker executables on an isolated remote home."""
+    bin_directory = tmp_path / "bin"
+    home = tmp_path / "home"
+    docker_log = tmp_path / "docker.log"
+    git_log = tmp_path / "git.log"
+    bin_directory.mkdir()
+    home.mkdir()
+    docker_log.touch()
+    git_log.touch()
+
+    git_path = bin_directory / "git"
+    git_path.write_text(
+        """#!/bin/sh
+set -eu
+
+printf '%s\\n' "$*" >> "$FAKE_GIT_LOG"
+
+case "$1" in
+  clone)
+    mkdir -p "$3"
+    ;;
+  pull)
+    ;;
+  *)
+    exit 99
+    ;;
+esac
+""",
+        encoding="utf-8",
+    )
+    git_path.chmod(0o755)
+
+    docker_path = bin_directory / "docker"
+    docker_path.write_text(
+        """#!/bin/sh
+set -eu
+
+printf 'IMAGE=%s|%s\\n' "${IMAGE:-}" "$*" >> "$FAKE_DOCKER_LOG"
+
+if [ "$1" = "compose" ] && [ "$2" = "pull" ]; then
+  exit "${FAKE_DOCKER_PULL_EXIT:-0}"
+fi
+""",
+        encoding="utf-8",
+    )
+    docker_path.chmod(0o755)
+
+    environment = {
+        "FAKE_DOCKER_LOG": str(docker_log),
+        "FAKE_DOCKER_PULL_EXIT": "0",
+        "FAKE_GIT_LOG": str(git_log),
+        "HOME": str(home),
+        "LANG": "C",
+        "PATH": f"{bin_directory}:/usr/bin:/bin",
+    }
+    return DeployHarness(environment, docker_log, git_log, home)
+
+
+def _run_deploy_script(
+    script: str,
+    harness: DeployHarness,
+    **environment_overrides: str,
+) -> subprocess.CompletedProcess[str]:
+    """Execute the materialized remote program against synthetic boundaries."""
+    environment = harness.environment | environment_overrides
+    return subprocess.run(  # noqa: S603 - execute the tracked trusted script
+        ["/bin/sh"],
+        input=_materialize_deploy_script(script),
+        cwd=WORKFLOW_PATH.parents[2],
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
 
 
 def _evaluate_guard(
@@ -82,6 +215,73 @@ def test_workflow_exposes_explicit_deploy_confirmation() -> None:
     assert "        type: boolean" in dispatch_block
     assert "        default: false" in dispatch_block
     assert "    needs: build" in deploy_block
+
+
+def test_remote_deploy_uses_lowercase_literal_secret_contract(
+    deploy_harness: DeployHarness,
+) -> None:
+    """Clone under HOME and deploy one lowercase image without expanding secrets."""
+    document = WORKFLOW_PATH.read_text(encoding="utf-8")
+    script = _deploy_script(document)
+    image_assignment = next(
+        line for line in script.splitlines() if line.startswith("IMAGE_NAME=")
+    )
+    expected_assignment = (
+        "IMAGE_NAME=\"$(printf '%s' "
+        '"ghcr.io/${{ github.repository }}:main" '
+        "| tr '[:upper:]' '[:lower:]')\""
+    )
+
+    assert image_assignment == expected_assignment
+    assert script.splitlines()[0] == "set -eu"
+    assert script.index('export IMAGE="$IMAGE_NAME"') < script.index(
+        "docker compose pull"
+    )
+    assert script.index("docker compose pull") < script.index(
+        "docker compose up --no-build --wait --wait-timeout 180"
+    )
+    assert 'PROJECT_DIR="$HOME/$PROJECT_NAME"' in script
+    assert "cat <<'ENV_FILE' > .env" in script
+
+    result = _run_deploy_script(script, deploy_harness)
+
+    assert result.returncode == 0, result.stderr
+    project_directory = deploy_harness.home / "Mixed-Repository"
+    assert project_directory.is_dir()
+    assert deploy_harness.git_log.read_text(encoding="utf-8").splitlines() == [
+        (f"clone https://github.com/MixedOwner/Mixed-Repository {project_directory}"),
+        "pull",
+    ]
+    assert deploy_harness.docker_log.read_text(encoding="utf-8").splitlines() == [
+        ("IMAGE=ghcr.io/mixedowner/mixed-repository:main|compose pull"),
+        (
+            "IMAGE=ghcr.io/mixedowner/mixed-repository:main|"
+            "compose up --no-build --wait --wait-timeout 180"
+        ),
+        ("IMAGE=ghcr.io/mixedowner/mixed-repository:main|image prune -f"),
+    ]
+    environment_document = (project_directory / ".env").read_text(encoding="utf-8")
+    for secret_value in SECRET_CANARIES.values():
+        assert secret_value in environment_document
+
+
+def test_remote_deploy_stops_after_failed_pull(
+    deploy_harness: DeployHarness,
+) -> None:
+    """Propagate a pull failure without starting a stale image or pruning."""
+    document = WORKFLOW_PATH.read_text(encoding="utf-8")
+    script = _deploy_script(document)
+
+    result = _run_deploy_script(
+        script,
+        deploy_harness,
+        FAKE_DOCKER_PULL_EXIT="23",
+    )
+
+    assert result.returncode == 23
+    assert deploy_harness.docker_log.read_text(encoding="utf-8").splitlines() == [
+        ("IMAGE=ghcr.io/mixedowner/mixed-repository:main|compose pull")
+    ]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What

Make fork-owned GHCR images the single, tested image contract for manual and
workflow-driven Compose deployments.

## Why

The manual docs pulled the template owner's image without setting Compose's
`IMAGE` variable, so Compose could start its local `agent` fallback instead.
The remote deploy script also escaped `$HOME`, rebuilt the GHCR path without
lowercasing it, and passed substituted secrets through an expanding heredoc.

## How

- Document one lowercase, fork-configurable `IMAGE` export for pre-built
  deployments.
- Pull and start that image fail-closed with `--no-build` and bounded health
  waiting.
- Distinguish anonymous public pulls from least-privilege private GHCR login.
- Normalize the remote workflow image, use the real home directory, preserve
  secret special characters literally, and stop on command failures.
- Execute the tracked remote script against fake Git and Docker boundaries for
  fresh-clone, success, and failed-pull behavior.
- Require real Compose smoke CI to prove its resolved image equals `IMAGE`
  before building or starting.

## Tests

- [x] `uv sync --locked`
- [x] `uv run ruff format`
- [x] `uv run ruff format --check`
- [x] `uv run ruff check --no-fix --output-format=github`
- [x] `uv run mypy .`
- [x] `uv run pytest --cov=src --cov-report=xml --cov-report=term-missing`
  (`364 passed`, `4 skipped`, `100%` statement and branch coverage)
- [x] `IMAGE=ghcr.io/example/agent:test docker compose config --images`
  (exact output: `ghcr.io/example/agent:test`)
- [x] `docker compose config --quiet`
- [x] Two independent adversarial reviews with no remaining findings

No production deployment was triggered. Real LLM evaluation is not applicable
because this change does not modify agent prompts, models, tools, or runtime
responses.

## Related Issues

Closes #23
