### PR TITLE
fix: default ADK ingress to loopback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,12 +24,15 @@ DB_POOL_TIMEOUT=30
 
 # Server Configuration
 LOG_LEVEL=INFO
-HOST=0.0.0.0
+# Bare-metal process bind. Compose overrides HOST inside the container.
+HOST=127.0.0.1
 PORT=8080
+# Compose publishes to loopback unless this host-side address is overridden.
+AGENT_PUBLISH_HOST=127.0.0.1
 
 # Feature Flags
-SERVE_WEB_INTERFACE=true
-RELOAD_AGENTS=true
+SERVE_WEB_INTERFACE=false
+RELOAD_AGENTS=false
 OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=false
 
 # ---------------------------------------------------------------------------

--- a/.github/workflows/test-docker-compose.yml
+++ b/.github/workflows/test-docker-compose.yml
@@ -93,10 +93,6 @@ jobs:
                 - ${ENV_FILE:?Set ENV_FILE to the smoke environment}
               environment:
                 OTEL_SDK_DISABLED: "true"
-                RELOAD_AGENTS: "false"
-                SERVE_WEB_INTERFACE: "false"
-              ports: !override
-                - "127.0.0.1:8080:8080"
               restart: "no"
           YAML
 
@@ -122,6 +118,13 @@ jobs:
           container_id="$("${compose[@]}" ps --all -q agent)"
           if [ -z "$container_id" ]; then
             echo "Compose did not create the agent container." >&2
+            exit 1
+          fi
+
+          published_address="$("${compose[@]}" port agent 8080)"
+          if [ "$published_address" != "127.0.0.1:8080" ]; then
+            printf 'Unexpected published address: %s\n' \
+              "$published_address" >&2
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,15 @@ uv sync
 ```bash
 uv run python -m agent.server
 ```
-Visit `http://127.0.0.1:8080`.
+Visit `http://127.0.0.1:8080/docs` for the API documentation. The ADK
+development UI is disabled by default; enable it only for local or SSH-tunneled
+development:
+
+```bash
+SERVE_WEB_INTERFACE=true uv run python -m agent.server
+```
+
+Then visit `http://127.0.0.1:8080`.
 
 ## Deployment: It's Just One Command
 
@@ -74,6 +82,18 @@ docker compose up --build --wait --wait-timeout 180
 The bounded `--wait` command returns only after the agent's container
 healthcheck passes, so scripts can distinguish a healthy startup from a
 container that merely started.
+
+## Secure access
+
+Compose publishes the agent only on `127.0.0.1:8080` by default, and the ADK
+development web interface and agent reload are disabled. Google ADK's HTTP,
+streaming, WebSocket, session, and artifact routes do not gain application
+authentication from those settings. Do not open or publicly publish port 8080.
+
+Use an SSH tunnel for temporary development access, or place an authenticated
+HTTPS reverse proxy in front of the entire upstream on port 443. The
+[deployment guide](docs/DEPLOYMENT.md#network-security-boundary) documents the
+requirements and the migration checks for existing VMs.
 
 👉 **[Read the Full Deployment Guide](docs/DEPLOYMENT.md)**
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,14 +5,17 @@ services:
     image: ${IMAGE:-agent}
     build: .
     ports:
-      - "8080:8080"
+      - target: 8080
+        published: "8080"
+        host_ip: "${AGENT_PUBLISH_HOST:-127.0.0.1}"
+        protocol: tcp
     environment:
       - HOST=0.0.0.0
       - PORT=8080
       - AGENT_NAME=local-dev
       - LOG_LEVEL=INFO
-      - RELOAD_AGENTS=true
-      - SERVE_WEB_INTERFACE=true
+      - RELOAD_AGENTS=${RELOAD_AGENTS:-false}
+      - SERVE_WEB_INTERFACE=${SERVE_WEB_INTERFACE:-false}
       # DATABASE_URL and API Keys will be loaded from the .env file
     env_file:
       - .env

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -7,7 +7,9 @@ You can deploy this Agent Platform using **Docker** (easiest compatibility) or *
 To prepare a fresh Ubuntu/Debian server for production, run the included `setup.sh` script. This script automates:
 1.  **System Updates**: Ensures the OS is patched.
 2.  **Dependencies**: Installs Docker, Docker Compose, Git, UFW, and Fail2Ban.
-3.  **Security**: Configures a basic firewall (UFW) allowing SSH (22), HTTP (80/443), and the Agent port (8080).
+3.  **Security**: Configures a basic firewall (UFW) allowing SSH and ports
+    80/443 for an operator-supplied authenticated reverse proxy. It does not
+    configure that proxy or open the agent's unauthenticated port 8080.
 4.  **Log Rotation**: Prevents Docker logs from filling up the disk.
 5.  **Dedicated User**: Creates an `agent-runner` user for secure operation.
 
@@ -30,6 +32,9 @@ sudo ./setup.sh
 2.  **OpenRouter or Google API Key**.
 3.  **AGENT_NAME**: A unique identifier for your agent service.
 4.  **Server**: A Linux server (Ubuntu/Debian recommended).
+5.  **Docker Engine 28+ (Docker method only)**: Required when loopback port
+    publishing is the isolation boundary. Older releases had a documented
+    local-network reachability issue for localhost-published ports.
 
 ---
 
@@ -97,6 +102,66 @@ healthy; `--wait-timeout` prevents an unhealthy startup from hanging automation
 indefinitely. When `DATABASE_URL` is configured, the entrypoint first runs a
 bounded `SELECT 1` readiness check before starting the server.
 
+## Network Security Boundary
+
+The process listens on `0.0.0.0:8080` inside its container so Docker can reach
+it. Compose separately publishes that port on `127.0.0.1:8080` on the VM. The
+host-side address is the intended security boundary; verify it after every
+deployment:
+
+```bash
+docker compose port agent 8080
+```
+
+The expected output is `127.0.0.1:8080`. The default environment also disables
+the ADK development web interface and agent reload.
+
+This boundary requires Docker Engine 28+ with Docker's normal bridge/NAT packet
+filtering intact. Do not set `DOCKER_INSECURE_NO_IPTABLES_RAW=1`, enable the
+daemon's `allow-direct-routing` option, configure
+`com.docker.network.bridge.trusted_host_interfaces`, or use `routed` or
+`nat-unprotected` gateway modes. Those non-default settings can make the
+container address remotely reachable even when the host publication reports
+`127.0.0.1`. If the VM needs direct container routing, enforce the boundary with
+an independently managed host or network firewall instead of relying on this
+Compose port mapping.
+
+These settings are not application authentication. Headless ADK still exposes
+run, streaming, WebSocket, session, artifact, trace, documentation, and
+evaluation routes. For public access, terminate TLS on port 443 and authenticate
+the entire upstream—not only `/dev-ui`. The reverse proxy must support SSE
+without response buffering and WebSocket upgrades. It must overwrite
+client-supplied forwarding headers and the upstream must trust those headers
+only from the proxy. Configuring a particular proxy, DNS, and certificates is a
+separate deployment decision.
+
+For temporary browser access, enable the development UI explicitly on the VM:
+
+```bash
+SERVE_WEB_INTERFACE=true docker compose up --build --wait --wait-timeout 180
+```
+
+Then create a tunnel from your computer rather than publishing the service:
+
+```bash
+ssh -L 8080:127.0.0.1:8080 your-user@your-vm
+```
+
+Open `http://127.0.0.1:8080` on your computer.
+
+> [!CAUTION]
+> The following escape hatch publishes the unauthenticated ADK service on every
+> host interface. It is not safe for the public internet, does not provide TLS,
+> and is not made safe by UFW alone because Docker manages its own packet
+> filtering rules.
+>
+> ```bash
+> AGENT_PUBLISH_HOST=0.0.0.0 docker compose up --build --wait --wait-timeout 180
+> ```
+>
+> Prefer a specific private interface or private network when loopback cannot be
+> used.
+
 ---
 
 ## Option 2: Bare Metal (Lowest Resources)
@@ -127,6 +192,7 @@ uv sync
 # Configure Env
 cp .env.example .env
 # Edit .env with your real keys!
+# Keep HOST=127.0.0.1, SERVE_WEB_INTERFACE=false, and RELOAD_AGENTS=false.
 ```
 
 ### 3. Setup Systemd (Keep it running)
@@ -145,6 +211,74 @@ cp .env.example .env
 sudo systemctl status agent
 sudo journalctl -u agent -f
 ```
+
+## Existing VM Migration
+
+Earlier versions published port 8080 on all interfaces, enabled the development
+UI and reload, and added an allow rule for 8080 to UFW. Pulling this change does
+not rewrite an existing `.env`, recreate a running container, or remove
+operator-owned firewall policy.
+
+1. Upgrade to Docker Engine 28 or later and verify the server version. The setup
+   script fails instead of upgrading an existing Docker installation:
+
+   ```bash
+   sudo ./setup.sh --verify-docker-version
+   docker version --format '{{.Server.Version}}'
+   ```
+
+2. Audit `/etc/docker/daemon.json`, Docker's systemd unit and drop-ins, and the
+   project network. Do not rely on loopback publication when
+   `DOCKER_INSECURE_NO_IPTABLES_RAW=1`, `allow-direct-routing`, trusted host
+   interfaces, or `routed`/`nat-unprotected` gateway modes are enabled:
+
+   ```bash
+   sudo systemctl cat docker
+   sudo systemctl show docker --property=Environment
+   sudo test ! -f /etc/docker/daemon.json \
+     || sudo jq . /etc/docker/daemon.json
+   ```
+
+3. Update the existing `.env`:
+
+   ```dotenv
+   AGENT_PUBLISH_HOST=127.0.0.1
+   HOST=127.0.0.1
+   SERVE_WEB_INTERFACE=false
+   RELOAD_AGENTS=false
+   ```
+
+   Compose still overrides `HOST` to `0.0.0.0` inside its container. The
+   loopback value protects direct bare-metal/systemd runs.
+
+4. Pull and recreate the Compose service, then verify the resolved publication:
+
+   ```bash
+   git pull
+   docker compose up --build --force-recreate --wait --wait-timeout 180
+   docker compose port agent 8080
+   ```
+
+   Require the final command to report `127.0.0.1:8080`.
+
+5. For a bare-metal systemd installation, restart the service and verify the
+   listening socket:
+
+   ```bash
+   sudo systemctl restart agent
+   sudo ss -ltnp | grep '127.0.0.1:8080'
+   ```
+
+6. Inspect UFW and manually remove the legacy rule only if it belongs to this
+   deployment:
+
+   ```bash
+   sudo ufw status numbered
+   sudo ufw delete allow 8080/tcp
+   ```
+
+7. Move every remote client to the authenticated HTTPS ingress on port 443
+   before relying on the new boundary.
 
 ## Troubleshooting
 

--- a/docs/base-infra/docker-compose-workflow.md
+++ b/docs/base-infra/docker-compose-workflow.md
@@ -135,11 +135,16 @@ LANGFUSE_SECRET_KEY=sk-lf-...
 # Logging verbosity
 LOG_LEVEL=DEBUG
 
-# Enable web UI
-SERVE_WEB_INTERFACE=true
+# Safe VM defaults
+AGENT_PUBLISH_HOST=127.0.0.1
+SERVE_WEB_INTERFACE=false
+RELOAD_AGENTS=false
 ```
 
-**Note:** The container uses `HOST=0.0.0.0` to allow connections from the host machine.
+**Note:** The container uses `HOST=0.0.0.0` internally, while Compose publishes
+it only on `127.0.0.1:8080` on the host. Verify with
+`docker compose port agent 8080`. Enable the web UI only for temporary local or
+SSH-tunneled development access.
 
 ---
 
@@ -159,8 +164,7 @@ SERVE_WEB_INTERFACE=true
 # Check what's using port 8080
 lsof -i :8080
 
-# Stop the conflicting process or change PORT in .env
-PORT=8001
+# Stop the conflicting process before starting Compose
 ```
 
 ---

--- a/docs/base-infra/environment-variables.md
+++ b/docs/base-infra/environment-variables.md
@@ -85,11 +85,23 @@ following bounds:
 
 **HOST**
 - **Default:** `127.0.0.1`
-- **Purpose:** Server bind address (use `0.0.0.0` for Docker)
+- **Purpose:** Process bind address for direct and systemd runs
+
+Compose overrides `HOST` to `0.0.0.0` inside the container. That internal bind
+does not publish the service on the VM.
 
 **PORT**
 - **Default:** `8080`
 - **Purpose:** Server listening port
+
+**AGENT_PUBLISH_HOST**
+- **When:** Docker Compose only
+- **Default:** `127.0.0.1`
+- **Purpose:** Host-side address used to publish container port 8080
+
+Setting `AGENT_PUBLISH_HOST=0.0.0.0` exposes the unauthenticated ADK API on
+every host interface. It is an unsafe escape hatch, not a substitute for an
+authenticated HTTPS reverse proxy.
 
 ### Feature Flags
 
@@ -159,3 +171,7 @@ variables first when using that low-level import path.
 
 - **Never commit `.env` files** - Already gitignored
 - **Rotate credentials** - If `.env` is accidentally committed, rotate all credentials
+- **Keep port 8080 on loopback** - Authenticate the entire upstream before
+  exposing it through HTTPS
+- **Keep the ADK web interface disabled on VMs** - Enable it temporarily through
+  an SSH tunnel when needed

--- a/setup.sh
+++ b/setup.sh
@@ -9,6 +9,7 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
+MINIMUM_DOCKER_MAJOR_VERSION=28
 
 log() {
     echo -e "${GREEN}[$(date +'%Y-%m-%dT%H:%M:%S%z')] $1${NC}"
@@ -22,6 +23,32 @@ error() {
 warn() {
     echo -e "${YELLOW}[WARN] $1${NC}"
 }
+
+verify_docker_version() {
+    local server_version
+    local major_version
+
+    if ! server_version="$(docker version --format '{{.Server.Version}}' 2>/dev/null)"; then
+        error "Unable to query the Docker server version. Start Docker and retry."
+    fi
+
+    major_version="${server_version%%.*}"
+    if [[ ! "$major_version" =~ ^[0-9]+$ ]]; then
+        error "Unable to parse Docker server version: $server_version"
+    fi
+
+    if (( major_version < MINIMUM_DOCKER_MAJOR_VERSION )); then
+        error "Docker Engine 28+ is required; found $server_version. Upgrade Docker before continuing."
+    fi
+
+    log "Docker Engine $server_version meets the 28+ requirement."
+}
+
+# Allow operators and tests to run the security-critical version check alone.
+if [[ "${1:-}" == "--verify-docker-version" ]]; then
+    verify_docker_version
+    exit 0
+fi
 
 # Check if running as root
 if [[ $EUID -ne 0 ]]; then
@@ -57,6 +84,8 @@ else
     log "Docker already installed. Skipping..."
 fi
 
+verify_docker_version
+
 # 4. Configure Firewall (UFW)
 log "Configuring UFW firewall..."
 ufw default deny incoming
@@ -64,8 +93,6 @@ ufw default allow outgoing
 ufw allow ssh
 ufw allow 80/tcp
 ufw allow 443/tcp
-# Allow custom agent port if needed (default 8080 for agent)
-ufw allow 8080/tcp
 
 # Enable UFW non-interactively
 if ! ufw status | grep -q "Status: active"; then

--- a/tests/test_compose_workflow.py
+++ b/tests/test_compose_workflow.py
@@ -92,6 +92,10 @@ case " $* " in
     printf '%s\\n' "synthetic-container-id"
     exit 0
     ;;
+  *" port agent 8080 "*)
+    printf '%s\\n' "${FAKE_PUBLISHED_ADDRESS:-127.0.0.1:8080}"
+    exit 0
+    ;;
   *" ps --all "*|*" logs "*)
     exit 0
     ;;
@@ -239,8 +243,6 @@ def test_smoke_script_is_secret_free_bounded_and_self_cleaning() -> None:
         'mktemp "${RUNNER_TEMP}/compose-smoke-override.XXXXXX.yaml"',
         "export ENV_FILE",
         "env_file: !override",
-        "ports: !override",
-        '"127.0.0.1:8080:8080"',
         'restart: "no"',
         'OTEL_SDK_DISABLED: "true"',
         '"${compose[@]}" config --images',
@@ -249,6 +251,9 @@ def test_smoke_script_is_secret_free_bounded_and_self_cleaning() -> None:
         '"${compose[@]}" config --quiet',
         '"${compose[@]}" build',
         "--detach --no-build --wait --wait-timeout 180",
+        '"${compose[@]}" port agent 8080',
+        'if [ "$published_address" != "127.0.0.1:8080" ]; then',
+        "Unexpected published address:",
         "python3 -c",
         'if payload != {"status": "ok"}:',
         'raise SystemExit(f"Unexpected health payload: {payload!r}")',
@@ -263,6 +268,7 @@ def test_smoke_script_is_secret_free_bounded_and_self_cleaning() -> None:
     for fragment in required_fragments:
         assert fragment in document or fragment in script
 
+    assert "ports: !override" not in document
     assert "volumes: !reset" not in document
     assert "assert payload" not in script
 
@@ -273,6 +279,7 @@ def test_smoke_script_is_secret_free_bounded_and_self_cleaning() -> None:
         '"${compose[@]}" config --quiet',
         '"${compose[@]}" build',
         '"${compose[@]}" up',
+        '"${compose[@]}" port agent 8080',
         "python3 -c",
     )
     positions = [script.index(fragment) for fragment in ordered_fragments]
@@ -313,6 +320,7 @@ def test_smoke_script_success_probes_and_cleans_up(
         " build",
         " up --detach",
         " ps --all -q agent",
+        " port agent 8080",
         " down --volumes",
     )
     positions = [
@@ -323,6 +331,30 @@ def test_smoke_script_success_probes_and_cleans_up(
     assert not any(call.endswith(" ps --all") for call in calls)
     assert not any(" logs " in call for call in calls)
     assert smoke_harness.python_log.read_text(encoding="utf-8") == "called\n"
+    _assert_runner_temp_is_empty(smoke_harness)
+
+
+def test_smoke_script_rejects_non_loopback_publication(
+    smoke_harness: SmokeHarness,
+) -> None:
+    """Fail before probing health when Compose publishes on every interface."""
+    document = WORKFLOW_PATH.read_text(encoding="utf-8")
+    script = _workflow_step_script(document, SMOKE_STEP_NAME)
+
+    result = _run_smoke_script(
+        script,
+        smoke_harness,
+        FAKE_PUBLISHED_ADDRESS="0.0.0.0:8080",
+    )
+
+    assert result.returncode == 1
+    assert "Unexpected published address: 0.0.0.0:8080" in result.stderr
+    calls = _docker_calls(smoke_harness)
+    assert any(" port agent 8080" in call for call in calls)
+    assert any(call.endswith(" ps --all") for call in calls)
+    assert any(" logs " in call for call in calls)
+    assert any(" down --volumes" in call for call in calls)
+    assert smoke_harness.python_log.read_text(encoding="utf-8") == ""
     _assert_runner_temp_is_empty(smoke_harness)
 
 

--- a/tests/test_deployment_docs.py
+++ b/tests/test_deployment_docs.py
@@ -81,3 +81,43 @@ def test_private_registry_login_uses_least_privilege_stdin_contract() -> None:
     assert "classic personal access token with only `read:packages`" in document
     assert "$GITHUB_TOKEN" not in document
     assert "echo " not in login_blocks[0]
+
+
+def test_guides_document_authenticated_loopback_boundary_and_migration() -> None:
+    """Keep public ingress authenticated and existing-VM migration objective."""
+    readme = README_PATH.read_text(encoding="utf-8")
+    normalized_readme = " ".join(readme.split())
+    deployment_guide = DEPLOYMENT_GUIDE_PATH.read_text(encoding="utf-8")
+    normalized_guide = " ".join(deployment_guide.split())
+
+    assert "127.0.0.1:8080" in readme
+    assert "http://127.0.0.1:8080/docs" in readme
+    assert "SERVE_WEB_INTERFACE=true uv run python -m agent.server" in readme
+    assert "Do not open or publicly publish port 8080." in readme
+    assert "authenticated HTTPS reverse proxy" in normalized_readme
+
+    required_fragments = (
+        "## Network Security Boundary",
+        "docker compose port agent 8080",
+        "The expected output is `127.0.0.1:8080`.",
+        "authenticate the entire upstream",
+        "SSE without response buffering",
+        "WebSocket upgrades",
+        "AGENT_PUBLISH_HOST=0.0.0.0 docker compose up",
+        "It is not safe for the public internet",
+        "Docker Engine 28",
+        "DOCKER_INSECURE_NO_IPTABLES_RAW=1",
+        "allow-direct-routing",
+        "com.docker.network.bridge.trusted_host_interfaces",
+        "`routed` or `nat-unprotected` gateway modes",
+        "sudo ./setup.sh --verify-docker-version",
+        "sudo systemctl cat docker",
+        "sudo systemctl show docker --property=Environment",
+        "## Existing VM Migration",
+        "SERVE_WEB_INTERFACE=false",
+        "RELOAD_AGENTS=false",
+        "sudo ss -ltnp | grep '127.0.0.1:8080'",
+        "sudo ufw delete allow 8080/tcp",
+    )
+    for fragment in required_fragments:
+        assert fragment in normalized_guide

--- a/tests/test_network_exposure.py
+++ b/tests/test_network_exposure.py
@@ -1,0 +1,165 @@
+"""Single-VM network exposure and headless ADK security contracts."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml  # type: ignore[import-untyped]
+from fastapi.testclient import TestClient
+from google.adk.cli.fast_api import get_fast_api_app
+from starlette.routing import Mount, Route, WebSocketRoute
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+COMPOSE_PATH = REPOSITORY_ROOT / "compose.yaml"
+ENV_EXAMPLE_PATH = REPOSITORY_ROOT / ".env.example"
+SETUP_PATH = REPOSITORY_ROOT / "setup.sh"
+
+
+def _environment_values(document: str) -> dict[str, str]:
+    """Parse the non-secret example environment without source expansion."""
+    values: dict[str, str] = {}
+    for raw_line in document.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, separator, value = line.partition("=")
+        assert separator == "=", f"Invalid environment line: {raw_line!r}"
+        values[key] = value
+    return values
+
+
+def test_compose_defaults_to_loopback_and_headless_runtime() -> None:
+    """Keep the host boundary closed while the container listens internally."""
+    compose = yaml.safe_load(COMPOSE_PATH.read_text(encoding="utf-8"))
+    agent = compose["services"]["agent"]
+
+    assert agent["ports"] == [
+        {
+            "target": 8080,
+            "published": "8080",
+            "host_ip": "${AGENT_PUBLISH_HOST:-127.0.0.1}",
+            "protocol": "tcp",
+        }
+    ]
+    assert agent["environment"] == [
+        "HOST=0.0.0.0",
+        "PORT=8080",
+        "AGENT_NAME=local-dev",
+        "LOG_LEVEL=INFO",
+        "RELOAD_AGENTS=${RELOAD_AGENTS:-false}",
+        "SERVE_WEB_INTERFACE=${SERVE_WEB_INTERFACE:-false}",
+    ]
+
+
+def test_example_environment_uses_safe_vm_defaults() -> None:
+    """Protect both Compose and direct systemd deployments by default."""
+    values = _environment_values(ENV_EXAMPLE_PATH.read_text(encoding="utf-8"))
+
+    assert values["HOST"] == "127.0.0.1"
+    assert values["PORT"] == "8080"
+    assert values["AGENT_PUBLISH_HOST"] == "127.0.0.1"
+    assert values["SERVE_WEB_INTERFACE"] == "false"
+    assert values["RELOAD_AGENTS"] == "false"
+
+
+def test_setup_firewall_does_not_open_the_adk_port() -> None:
+    """Leave only SSH and operator-supplied proxy ingress open on fresh VMs."""
+    document = SETUP_PATH.read_text(encoding="utf-8")
+    allow_rules = [
+        line.strip()
+        for line in document.splitlines()
+        if line.strip().startswith("ufw allow ")
+    ]
+    syntax = subprocess.run(  # noqa: S603 - fixed repository script
+        ["/bin/bash", "-n", str(SETUP_PATH)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert syntax.returncode == 0, syntax.stderr
+    assert allow_rules == [
+        "ufw allow ssh",
+        "ufw allow 80/tcp",
+        "ufw allow 443/tcp",
+    ]
+    assert "ufw allow 8080" not in document
+
+
+@pytest.mark.parametrize(
+    ("server_version", "docker_exit", "expected_returncode"),
+    (
+        ("28.0.0", 0, 0),
+        ("29.1.3", 0, 0),
+        ("27.5.1", 0, 1),
+        ("not-a-version", 0, 1),
+        ("", 1, 1),
+    ),
+)
+def test_setup_enforces_minimum_docker_server_version(
+    tmp_path: Path,
+    server_version: str,
+    docker_exit: int,
+    expected_returncode: int,
+) -> None:
+    """Fail closed when an existing Docker daemon lacks loopback hardening."""
+    docker_path = tmp_path / "docker"
+    docker_path.write_text(
+        "#!/bin/bash\n"
+        "set -eu\n"
+        """[ "$*" = "version --format {{.Server.Version}}" ]\n"""
+        """if [ "$FAKE_DOCKER_EXIT" -ne 0 ]; then\n"""
+        """  exit "$FAKE_DOCKER_EXIT"\n"""
+        "fi\n"
+        "printf '%s\\n' \"$FAKE_DOCKER_SERVER_VERSION\"\n",
+        encoding="utf-8",
+    )
+    docker_path.chmod(0o755)
+    environment = {
+        "FAKE_DOCKER_EXIT": str(docker_exit),
+        "FAKE_DOCKER_SERVER_VERSION": server_version,
+        "LANG": "C",
+        "PATH": f"{tmp_path}:/usr/bin:/bin",
+    }
+
+    result = subprocess.run(  # noqa: S603 - fixed repository script
+        ["/bin/bash", str(SETUP_PATH), "--verify-docker-version"],
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == expected_returncode
+    if expected_returncode == 0:
+        assert f"Docker Engine {server_version} meets" in result.stdout
+    else:
+        assert "ERROR" in result.stdout
+
+
+def test_headless_adk_removes_builder_but_not_unauthenticated_api(
+    tmp_path: Path,
+) -> None:
+    """Prove disabling the development UI is not application authentication."""
+    app = get_fast_api_app(agents_dir=str(tmp_path), web=False)
+    paths = {
+        route.path
+        for route in app.routes
+        if isinstance(route, (Route, WebSocketRoute, Mount))
+    }
+
+    assert {"/", "/dev-ui", "/builder/save"}.isdisjoint(paths)
+    assert {
+        "/docs",
+        "/run",
+        "/run_live",
+        "/run_sse",
+        "/apps/{app_name}/users/{user_id}/sessions",
+        ("/apps/{app_name}/users/{user_id}/sessions/{session_id}/artifacts"),
+    } <= paths
+
+    client = TestClient(app)
+    assert client.get("/docs").status_code == 200
+    run_response = client.post("/run", json={})
+    assert run_response.status_code == 422
+    assert run_response.status_code not in {401, 403}


### PR DESCRIPTION
## What

Make the default single-VM ADK ingress loopback-only and disable the
development interface and agent reload by default.

This is an intentional secure-default change for Compose and direct
bare-metal deployments.

## Why

Google ADK's headless HTTP, streaming, WebSocket, session, artifact,
documentation, trace, and evaluation routes do not gain application
authentication when the development UI is disabled. Publishing port 8080 on
every VM interface and opening it in UFW therefore exposes more than a
development page.

## How

- Publish Compose port 8080 on `127.0.0.1` with an explicit unsafe override.
- Keep the container bind on `0.0.0.0` while defaulting direct runs to loopback.
- Disable the ADK development UI and reload behavior by default.
- Stop opening port 8080 in UFW and reject Docker Engine versions below 28.
- Exercise the base port mapping in Compose Smoke and reject non-loopback
  publication before the health probe.
- Document authenticated HTTPS ingress, SSH tunneling, Docker networking
  assumptions, and objective existing-VM migration checks.
- Test the real ADK 1.36.2 route and request behavior instead of treating
  headless mode as authentication.

## Tests

- [x] `uv sync --locked`
- [x] `uv run ruff format`
- [x] `uv run ruff format --check`
- [x] `uv run ruff check --no-fix --output-format=github`
- [x] `uv run mypy .`
- [x] `uv run pytest --cov=src --cov-report=xml --cov-report=term-missing`
- [x] 379 tests passed, 4 PostgreSQL integration tests skipped, 100% statement
  and branch coverage
- [x] Real local Docker Engine 29.1.3 passed the setup version preflight
- [x] Isolated synthetic Compose resolution produced the loopback default and
  the explicit `0.0.0.0` override
- [x] GitHub Code Quality
- [x] GitHub Compose Smoke

The local Docker Desktop containerd store currently returns a host metadata
I/O error, so a full local image build was not treated as verified. The remote
Compose Smoke workflow is the independent Docker build and runtime check.

## Breaking Changes

Existing VMs must update their `.env`, recreate the service, verify the
published address, and manually inspect any legacy UFW rule. Operators using
Docker direct-routing or weakened packet-filtering modes cannot rely on the
loopback mapping as their network boundary.

## Related Issues

Closes #94
