### PR TITLE
fix: authenticate Codecov uploads with OIDC

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   test:
     name: Lint & Test (Python ${{ matrix.python-version }})
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -61,8 +64,9 @@ jobs:
         run: uv run pytest --cov=src --cov-report=xml --cov-report=term-missing
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
-          fail_ci_if_error: false
+          files: ./coverage.xml
+          disable_search: true
+          use_oidc: true
+          fail_ci_if_error: true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,6 +18,9 @@ env:
 jobs:
   # 1. Run Code Quality First
   quality:
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/code-quality.yml
 
   # 2. Build and Push after Quality passes

--- a/tests/test_deployment_workflow.py
+++ b/tests/test_deployment_workflow.py
@@ -217,6 +217,21 @@ def test_workflow_exposes_explicit_deploy_confirmation() -> None:
     assert "    needs: build" in deploy_block
 
 
+def test_reusable_quality_call_grants_only_codecov_oidc_permissions() -> None:
+    """Keep the called quality workflow authenticated and least privilege."""
+    document = WORKFLOW_PATH.read_text(encoding="utf-8")
+    quality_block = _indented_block(document, "quality:", 2)
+    permissions = _indented_block(quality_block, "permissions:", 4)
+
+    assert permissions.splitlines() == [
+        "      contents: read",
+        "      id-token: write",
+    ]
+    assert "    uses: ./.github/workflows/code-quality.yml" in quality_block
+    assert "secrets:" not in quality_block
+    assert "packages: write" not in quality_block
+
+
 def test_remote_deploy_uses_lowercase_literal_secret_contract(
     deploy_harness: DeployHarness,
 ) -> None:

--- a/tests/test_quality_workflow.py
+++ b/tests/test_quality_workflow.py
@@ -5,6 +5,9 @@ from pathlib import Path
 WORKFLOW_PATH = (
     Path(__file__).resolve().parents[1] / ".github" / "workflows" / "code-quality.yml"
 )
+CODECOV_ACTION = (
+    "codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0"
+)
 
 
 def _indented_block(document: str, heading: str, indentation: int) -> str:
@@ -15,6 +18,22 @@ def _indented_block(document: str, heading: str, indentation: int) -> str:
 
     for line in lines[start:]:
         if line and not line.startswith(" " * (indentation + 1)):
+            break
+        block.append(line)
+
+    return "\n".join(block)
+
+
+def _named_step_block(document: str, step_name: str) -> str:
+    """Return one complete workflow step selected by its display name."""
+    lines = document.splitlines()
+    start = lines.index(f"      - name: {step_name}")
+    block = [lines[start]]
+
+    for line in lines[start + 1 :]:
+        if line.startswith("      - name: "):
+            break
+        if line and not line.startswith("        "):
             break
         block.append(line)
 
@@ -74,4 +93,31 @@ def test_quality_workflow_provisions_real_postgres() -> None:
     assert (
         "run: uv run pytest --cov=src --cov-report=xml "
         "--cov-report=term-missing" in test_job
+    )
+
+
+def test_quality_workflow_uploads_coverage_with_fail_closed_oidc() -> None:
+    """Authenticate one explicit report without hiding upload failures."""
+    document = WORKFLOW_PATH.read_text(encoding="utf-8")
+    test_job = _indented_block(document, "test:", 2)
+    permissions = _indented_block(test_job, "permissions:", 4)
+    codecov_step = _named_step_block(document, "Upload coverage to Codecov")
+
+    assert permissions.splitlines() == [
+        "      contents: read",
+        "      id-token: write",
+    ]
+    assert f"        uses: {CODECOV_ACTION}" in codecov_step
+    assert "          files: ./coverage.xml" in codecov_step
+    assert "          disable_search: true" in codecov_step
+    assert "          use_oidc: true" in codecov_step
+    assert "          fail_ci_if_error: true" in codecov_step
+    assert "CODECOV_TOKEN" not in document
+    assert "          token:" not in codecov_step
+    assert "          file:" not in codecov_step
+    assert "continue-on-error:" not in codecov_step
+    assert "fail_ci_if_error: false" not in document
+    assert document.count("codecov/codecov-action@") == 1
+    assert document.index("Run pytest with coverage") < document.index(
+        "Upload coverage to Codecov"
     )


### PR DESCRIPTION
## What

Authenticate Codecov coverage uploads with short-lived GitHub OIDC credentials
and fail the quality job when Codecov rejects a report.

## Why

The current workflow enforces 100% coverage locally, but its external Codecov
upload can fail without failing CI because `fail_ci_if_error: false` hides the
rejection.

Coverage generation and Codecov ingestion are separate contracts; both should
report their real status without introducing a long-lived secret.

## How

- Pin Codecov Action v7.0.0 to its verified immutable commit.
- Replace the deprecated `file` input with one explicit `files` report.
- Use GitHub OIDC and make Codecov authentication/upload errors fail CI.
- Grant only `contents: read` and `id-token: write` to the quality job.
- Grant matching permissions to Docker Publish's reusable quality caller.
- Add semantic tests for the action pin, exact permissions, OIDC inputs,
  fail-closed behavior, report ordering, and common bypasses.

## Tests

- [x] `uv sync --locked`
- [x] `uv run ruff format`
- [x] `uv run ruff format --check`
- [x] `uv run ruff check --no-fix --output-format=github`
- [x] `uv run mypy .`
- [x] `uv run pytest --cov=src --cov-report=xml --cov-report=term-missing`
- [x] 410 tests passed, 4 PostgreSQL-service tests skipped locally, 100%
      statement and branch coverage
- [x] Unchanged PR-head rerun accepted and queued the OIDC Codecov upload
- [x] Final current-main Code Quality job
- [x] Final current-main Compose Smoke job

No model evaluation applies because this changes CI authentication and
reporting, not model or prompt behavior.

## External Verification

Codecov's public repository API now reports `active: true` and
`activated: true`. The unchanged failed run was rerun after activation; Codecov
minted the short-lived OIDC credential, found only `coverage.xml`, accepted the
report, and queued it for processing:

- [Successful current-main Code Quality job](https://github.com/QueryPlanner/google-adk-on-bare-metal/actions/runs/30331089381)
- [Accepted Codecov commit upload](https://app.codecov.io/github/queryplanner/google-adk-on-bare-metal/commit/56ce0151ddebcbfda43f730eadb823da21bb4884)

## Related Issues

Closes #96
