### PR TITLE
feat: persist ADK artifacts on VM

### DIFF
--- a/.github/workflows/test-docker-compose.yml
+++ b/.github/workflows/test-docker-compose.yml
@@ -36,18 +36,27 @@ jobs:
 
           ENV_FILE=""
           OVERRIDE_FILE=""
+          READ_ONLY_OVERRIDE_FILE=""
+          READ_ONLY_ARTIFACT_PARENT=""
+          SUPPRESS_CLEANUP_AGENT_LOGS=0
           compose=()
+          readonly_compose=()
 
           cleanup() {
             exit_code=$?
             down_exit_code=0
+            temp_exit_code=0
             trap - EXIT INT TERM
 
             if [ "${#compose[@]}" -gt 0 ]; then
               if [ "$exit_code" -ne 0 ]; then
                 "${compose[@]}" ps --all || true
-                "${compose[@]}" logs \
-                  --no-color --timestamps --tail=200 agent || true
+                if [ "$SUPPRESS_CLEANUP_AGENT_LOGS" -eq 0 ]; then
+                  "${compose[@]}" logs \
+                    --no-color --timestamps --tail=200 agent || true
+                else
+                  echo "Agent logs withheld after storage failure."
+                fi
               fi
 
               "${compose[@]}" down \
@@ -60,10 +69,21 @@ jobs:
             fi
 
             if [ -n "$ENV_FILE" ]; then
-              rm -f "$ENV_FILE"
+              rm -f "$ENV_FILE" || temp_exit_code=1
             fi
             if [ -n "$OVERRIDE_FILE" ]; then
-              rm -f "$OVERRIDE_FILE"
+              rm -f "$OVERRIDE_FILE" || temp_exit_code=1
+            fi
+            if [ -n "$READ_ONLY_OVERRIDE_FILE" ]; then
+              rm -f "$READ_ONLY_OVERRIDE_FILE" || temp_exit_code=1
+            fi
+            if [ -n "$READ_ONLY_ARTIFACT_PARENT" ]; then
+              chmod 0700 "$READ_ONLY_ARTIFACT_PARENT" 2>/dev/null || true
+              rmdir "$READ_ONLY_ARTIFACT_PARENT" || temp_exit_code=1
+            fi
+
+            if [ "$exit_code" -eq 0 ] && [ "$temp_exit_code" -ne 0 ]; then
+              exit_code=$temp_exit_code
             fi
 
             exit "$exit_code"
@@ -80,7 +100,14 @@ jobs:
           OVERRIDE_FILE="$(
             mktemp "${RUNNER_TEMP}/compose-smoke-override.XXXXXX.yaml"
           )"
-          export ENV_FILE
+          READ_ONLY_OVERRIDE_FILE="$(
+            mktemp "${RUNNER_TEMP}/compose-smoke-read-only.XXXXXX.yaml"
+          )"
+          READ_ONLY_ARTIFACT_PARENT="$(
+            mktemp -d "${RUNNER_TEMP}/compose-smoke-artifacts.XXXXXX"
+          )"
+          chmod 0555 "$READ_ONLY_ARTIFACT_PARENT"
+          export ENV_FILE READ_ONLY_ARTIFACT_PARENT
 
           printf '%s\n' \
             '# Synthetic secret-free Compose smoke environment' \
@@ -96,12 +123,28 @@ jobs:
               restart: "no"
           YAML
 
+          cat > "$READ_ONLY_OVERRIDE_FILE" <<'YAML'
+          services:
+            agent:
+              volumes: !override
+                - type: bind
+                  source: ${READ_ONLY_ARTIFACT_PARENT:?Set READ_ONLY_ARTIFACT_PARENT}
+                  target: /app/src/.adk
+                  read_only: true
+                  bind:
+                    create_host_path: false
+          YAML
+
           compose=(
             docker compose
             --project-name "$SMOKE_PROJECT"
             --env-file "$ENV_FILE"
             -f compose.yaml
             -f "$OVERRIDE_FILE"
+          )
+          readonly_compose=(
+            "${compose[@]}"
+            -f "$READ_ONLY_OVERRIDE_FILE"
           )
 
           resolved_images="$("${compose[@]}" config --images)"
@@ -111,6 +154,7 @@ jobs:
           fi
 
           "${compose[@]}" config --quiet
+          "${readonly_compose[@]}" config --quiet
           "${compose[@]}" build
           "${compose[@]}" up \
             --detach --no-build --wait --wait-timeout 180
@@ -128,18 +172,160 @@ jobs:
             exit 1
           fi
 
-          python3 -c '
+          SMOKE_PHASE=save python3 - <<'PY'
           import json
           import urllib.request
 
+          artifact_text = "artifact persisted across agent recreation"
+          artifacts_path = (
+              "http://127.0.0.1:8080/apps/agent/users/"
+              "compose-smoke-user/sessions/compose-smoke-session/artifacts"
+          )
+          request = urllib.request.Request(
+              artifacts_path,
+              data=json.dumps(
+                  {
+                      "filename": "compose-smoke.txt",
+                      "artifact": {"text": artifact_text},
+                  }
+              ).encode(),
+              headers={"Content-Type": "application/json"},
+              method="POST",
+          )
           opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
-          with opener.open(
-              "http://127.0.0.1:8080/health", timeout=3
-          ) as response:
-              payload = json.load(response)
+          with opener.open(request, timeout=5) as response:
+              saved = json.load(response)
 
-          if payload != {"status": "ok"}:
-              raise SystemExit(f"Unexpected health payload: {payload!r}")
-          '
+          if saved.get("version") != 0:
+              raise SystemExit(f"Unexpected artifact version: {saved!r}")
+          PY
 
-          echo "Compose startup and health checks passed."
+          "${compose[@]}" up \
+            --detach --no-build --force-recreate --no-deps \
+            --wait --wait-timeout 180 agent
+
+          recreated_container_id="$("${compose[@]}" ps --all -q agent)"
+          if [ -z "$recreated_container_id" ]; then
+            echo "Compose did not recreate the agent container." >&2
+            exit 1
+          fi
+          if [ "$recreated_container_id" = "$container_id" ]; then
+            echo "Compose reused the original agent container." >&2
+            exit 1
+          fi
+
+          SMOKE_PHASE=load python3 - <<'PY'
+          import json
+          import urllib.request
+
+          artifact_text = "artifact persisted across agent recreation"
+          artifact_url = (
+              "http://127.0.0.1:8080/apps/agent/users/"
+              "compose-smoke-user/sessions/compose-smoke-session/artifacts/"
+              "compose-smoke.txt/versions/0"
+          )
+          opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+          with opener.open(artifact_url, timeout=5) as response:
+              loaded = json.load(response)
+
+          if loaded != {"text": artifact_text}:
+              raise SystemExit(f"Unexpected artifact payload: {loaded!r}")
+          PY
+
+          SUPPRESS_CLEANUP_AGENT_LOGS=1
+          readonly_up_exit=0
+          "${readonly_compose[@]}" up \
+            --detach --no-build --force-recreate --no-deps \
+            --wait --wait-timeout 30 agent \
+            || readonly_up_exit=$?
+
+          if [ "$readonly_up_exit" -eq 0 ]; then
+            echo "Read-only artifact storage unexpectedly became healthy." >&2
+            exit 1
+          fi
+
+          readonly_container_id="$(
+            "${readonly_compose[@]}" ps --all -q agent
+          )"
+          if [ -z "$readonly_container_id" ]; then
+            echo "Read-only case did not create the agent container." >&2
+            exit 1
+          fi
+
+          readonly_status="$(
+            docker inspect --format '{{.State.Status}}' \
+              "$readonly_container_id"
+          )"
+          readonly_exit_code="$(
+            docker inspect --format '{{.State.ExitCode}}' \
+              "$readonly_container_id"
+          )"
+          readonly_health="$(
+            docker inspect \
+              --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' \
+              "$readonly_container_id"
+          )"
+
+          if [ "$readonly_status" != "exited" ]; then
+            printf 'Read-only agent did not exit: %s.\n' \
+              "$readonly_status" >&2
+            exit 1
+          fi
+          if [ "$readonly_exit_code" -eq 0 ]; then
+            echo "Read-only agent exited successfully." >&2
+            exit 1
+          fi
+          if [ "$readonly_health" = "healthy" ]; then
+            echo "Read-only agent reported healthy." >&2
+            exit 1
+          fi
+
+          readonly_logs="$(
+            "${readonly_compose[@]}" logs \
+              --no-color --timestamps --tail=200 agent
+          )"
+
+          if ! grep -Fq 'Artifact storage is unavailable.' \
+            <<< "$readonly_logs"; then
+            echo "Read-only failure omitted the public storage message." >&2
+            exit 1
+          fi
+
+          for forbidden in \
+            'Traceback (most recent call last)' \
+            'PermissionError' \
+            'FileNotFoundError' \
+            'NotADirectoryError' \
+            'OSError' \
+            'ValueError' \
+            '[Errno' \
+            '/app/src' \
+            '.artifact-storage-probe-' \
+            '.probe-' \
+            'AGENT_DIR'
+          do
+            if grep -Fq "$forbidden" <<< "$readonly_logs"; then
+              echo "Read-only diagnostics failed sanitization." >&2
+              exit 1
+            fi
+          done
+
+          storage_message_count="$(
+            grep -Fo 'Artifact storage is unavailable.' \
+              <<< "$readonly_logs" \
+              | wc -l
+          )"
+          storage_message_line="$(
+            grep -F 'Artifact storage is unavailable.' \
+              <<< "$readonly_logs"
+          )"
+          if [ "$storage_message_count" -ne 1 ] \
+            || [[ "$storage_message_line" \
+              != *'[ERROR] agent.server: Artifact storage is unavailable.' ]]
+          then
+            echo "Read-only public storage line was not exact." >&2
+            exit 1
+          fi
+
+          echo "Artifact storage is unavailable."
+          echo "Compose artifact persistence and failure checks passed."

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ We believe you should own your agents. This template is designed to strip away t
 - 🔄 **CI/CD Included**: GitHub Actions workflow builds multi-arch images (AMD64/ARM64) and pushes to GHCR automatically.
 - 🔭 **Open Observability**: Built-in OpenTelemetry (OTel) instrumentation. Pre-configured for **Langfuse**, but easily adaptable to Jaeger, Prometheus, or any OTel-compatible backend.
 - 🚀 **Modern Stack**: Python 3.13, `uv`, `fastapi`, `asyncpg`.
-- 💾 **Production Persistence**: Postgres-backed sessions out of the box.
+- 💾 **VM Persistence**: Postgres-backed sessions and local artifacts retained
+  across normal process and container recreation.
 
 ## Quickstart
 
@@ -82,6 +83,29 @@ docker compose up --build --wait --wait-timeout 180
 The bounded `--wait` command returns only after the agent's container
 healthcheck passes, so scripts can distinguish a healthy startup from a
 container that merely started.
+
+## Artifact persistence
+
+The filesystem artifact root is fixed at `<AGENT_DIR>/.adk/artifacts`. In the
+container, `AGENT_DIR` is `/app/src`; Compose mounts the `agent_artifacts` named
+volume at `/app/src/.adk`, so artifacts survive normal agent-container
+recreation. PostgreSQL session persistence is a separate storage contract.
+
+Dedicate each artifact root to one ADK application. Run only one writer at a
+time for a given `user_id`/`session_id`/`filename` key because the local backend
+does not coordinate concurrent version allocation for the same key.
+
+This is persistence across normal process or container recreation, not
+power-loss safety or crash consistency. The template does not add application
+authentication, quotas, retention, encryption, or backup automation. ADK
+creates artifact directories and files according to the process umask, so
+ownership, permissions, umask, and backups remain operator responsibilities.
+Treat the volume as trusted application data and do not grant untrusted users
+host or volume write access.
+
+`docker compose down` retains the named volume. In contrast,
+`docker compose down --volumes` permanently deletes the artifact volume and all
+artifacts in it.
 
 ## Secure access
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,6 +12,7 @@ services:
     environment:
       - HOST=0.0.0.0
       - PORT=8080
+      - AGENT_DIR=/app/src
       - AGENT_NAME=local-dev
       - LOG_LEVEL=INFO
       - RELOAD_AGENTS=${RELOAD_AGENTS:-false}

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -102,6 +102,70 @@ healthy; `--wait-timeout` prevents an unhealthy startup from hanging automation
 indefinitely. When `DATABASE_URL` is configured, the entrypoint first runs a
 bounded `SELECT 1` readiness check before starting the server.
 
+## Artifact Storage Contract
+
+The local artifact root is not independently configurable. It is always
+`<AGENT_DIR>/.adk/artifacts`, where `AGENT_DIR` is resolved to an absolute
+directory at startup. The image and Compose service pin `AGENT_DIR` to
+`/app/src`, and Compose mounts the `agent_artifacts` named volume at
+`/app/src/.adk`. As a result, the artifact payload and metadata files under
+`/app/src/.adk/artifacts` survive normal process restarts and agent-container
+recreation. PostgreSQL remains the separate session store.
+
+Startup creates the artifact directory when needed and probes create, write,
+flush, sync, unlink, and directory-cleanup access before serving `/health`. If
+the directory is unusable, startup exits non-zero and reports the stable public
+message `Artifact storage is unavailable.` It does not silently select
+in-memory artifact storage.
+
+The supported server entrypoints are `python -m agent.server` and
+`uv run server`. Use one of those entrypoints so `main()` can enforce the
+sanitized startup-failure contract. The server intentionally no longer creates
+a module-global `app`, so the older `uvicorn agent.server:app` target is not
+supported. Invoking `create_app` directly through an external Uvicorn factory
+also bypasses the sanitized command boundary and is not a supported deployment
+entrypoint.
+
+Operate the filesystem backend within these boundaries:
+
+- Dedicate one artifact root to one ADK application. The filesystem key does
+  not include the application name.
+- Use one writer at a time for each
+  `user_id`/`session_id`/`filename` key. Concurrent version allocation for the
+  same key is not locked.
+- Expect persistence only across normal process or container recreation.
+  Payload and metadata files are written directly, so the template does not
+  claim power-loss safety or crash consistency.
+- Treat the startup probe as a point-in-time check. It does not reserve
+  capacity, lock the path against a trusted local actor, or prevent later
+  permission and storage failures.
+- Supply application authentication at the trusted ingress. Artifact storage
+  adds no authentication, quotas, retention, encryption, or backup automation.
+- Treat the artifact volume as trusted application data. Do not grant untrusted
+  users host or volume write access.
+- Set an appropriate process umask and filesystem ownership. ADK creates
+  directories and files according to that umask; owner-only modes are not
+  guaranteed by the template.
+
+For the provided image, the runtime user and group have UID/GID 1000. Docker
+initializes the named volume from the image-owned `/app/src/.adk` directory.
+For a bare-metal or operator-supplied bind mount, ensure the service account can
+create and remove files beneath `<AGENT_DIR>/.adk` before starting the service.
+The operator is responsible for host ownership, permissions, umask, capacity,
+monitoring, and backups.
+
+`docker compose down` removes containers and networks but retains the named
+artifact volume. The following variant is destructive:
+
+```bash
+docker compose down --volumes
+```
+
+It permanently removes this Compose project's `agent_artifacts` volume and all
+stored artifacts. There is no automated backup or restore workflow. Quiesce the
+single writer before taking an operator-managed volume snapshot or copy; a live
+copy is not promised to be crash-consistent.
+
 ## Network Security Boundary
 
 The process listens on `0.0.0.0:8080` inside its container so Docker can reach
@@ -283,10 +347,17 @@ operator-owned firewall policy.
 ## Troubleshooting
 
 ### Permission Errors with Artifacts
-If you encounter `PermissionError: [Errno 13] Permission denied: '/app/src/.adk'` when running with Docker:
-1.  This usually happens because the container user (UID 1000) cannot write to the host volume mounted at `./src`.
-2.  **Fix:** Ensure you have rebuilt the image to include the latest permission fixes:
-    ```bash
-    docker compose up -d --build
-    ```
-3.  If that fails, ensure your host user has UID 1000 (run `id -u`).
+
+When startup reports `Artifact storage is unavailable.`, inspect only bounded
+diagnostics and the resolved volume:
+
+```bash
+docker compose logs --no-color --tail=200 agent
+docker volume inspect YOUR_COMPOSE_PROJECT_agent_artifacts
+```
+
+Confirm that the selected volume or bind mount is trusted, has free space, and
+allows the service UID/GID to create, sync, and remove files beneath
+`<AGENT_DIR>/.adk`. Rebuilding the image does not repair ownership or a
+read-only operator-supplied mount. Do not delete the named volume as a
+permission fix; `docker compose down --volumes` destroys all stored artifacts.

--- a/docs/base-infra/dockerfile-strategy.md
+++ b/docs/base-infra/dockerfile-strategy.md
@@ -295,10 +295,10 @@ This causes the ADK web UI to show all installed packages (.dist-info directorie
 
 **The Solution:**
 
-```python
-# In server.py - configurable with smart default
-AGENT_DIR = os.getenv("AGENT_DIR", str(Path(__file__).parent.parent))
-```
+The typed `ServerEnv.agent_dir` setting supplies the configured path. The
+application factory otherwise derives the installed `src` directory from
+`Path(__file__)`, resolves it once, and uses that same absolute path for ADK and
+the filesystem artifact service.
 
 ```dockerfile
 # In Dockerfile - override for Docker environment
@@ -347,7 +347,8 @@ CMD ["python", "-m", "agent.server"]
 - Calls `server.main()` for unified startup logic
   - Sets up OpenTelemetry observability (traces and logs to your preferred backend)
   - Consistent entry point for both local dev (`uv run server`) and Docker
-- `main()` calls `uvicorn.run(app, host=os.getenv("HOST", "127.0.0.1"), port=...)`
+- `main()` builds the application with `create_app()` only after storage
+  readiness succeeds, then calls `uvicorn.run(app, host=env.host, port=env.port)`
   - Secure default: 127.0.0.1 (only local connections)
   - Dockerfile sets `HOST=0.0.0.0` to explicitly bind all interfaces for containers
   - Respects HOST and PORT environment variables for flexibility

--- a/docs/base-infra/environment-variables.md
+++ b/docs/base-infra/environment-variables.md
@@ -73,6 +73,24 @@ following bounds:
 - **Default:** The installed `src` directory detected by the server
 - **Purpose:** Directory containing ADK agent packages
 
+The server resolves this directory to an absolute path and always stores local
+artifacts beneath `<AGENT_DIR>/.adk/artifacts`; there is no separate artifact
+directory setting. Dedicate that root to one ADK application and use one writer
+at a time for each `user_id`/`session_id`/`filename` key.
+
+Compose pins `AGENT_DIR` to `/app/src`, and the trusted `agent_artifacts` named
+volume is mounted at `/app/src/.adk`. For direct or systemd execution, the
+service account must be able to create, write, sync, and remove files beneath
+the resolved `.adk` directory. Directory and file modes follow the process
+umask; ownership, permissions, umask, capacity, retention, encryption, and
+backups are operator responsibilities.
+
+The filesystem backend retains artifacts across normal process or container
+recreation only. It does not provide crash consistency, application
+authentication, quotas, retention, encryption, or backup automation. Treat the
+artifact root as trusted application data. `docker compose down --volumes`
+permanently deletes the Compose artifact volume.
+
 **ROOT_AGENT_MODEL**
 - **When:** Optional
 - **Default:** `gemini-2.5-flash`

--- a/src/agent/artifact_storage.py
+++ b/src/agent/artifact_storage.py
@@ -1,0 +1,100 @@
+"""Fail-closed preparation for ADK filesystem artifact storage."""
+
+import os
+import tempfile
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+from typing import IO
+
+ARTIFACT_STORAGE_ERROR_MESSAGE = "Artifact storage is unavailable."
+
+
+class ArtifactStorageError(RuntimeError):
+    """Indicate that durable artifact storage cannot be used safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedArtifactStorage:
+    """Resolved paths and URI for one prepared artifact storage root."""
+
+    agents_dir: Path
+    artifact_dir: Path
+    artifact_service_uri: str
+
+
+def _require_contained(path: Path, agents_dir: Path) -> None:
+    """Reject an artifact path that resolves outside its agent directory."""
+    if not path.is_relative_to(agents_dir):
+        raise ValueError("Artifact directory resolves outside the agent directory.")
+
+
+def _cleanup_probe(
+    probe_file: IO[bytes] | None,
+    probe_file_path: Path | None,
+    probe_dir: Path | None,
+) -> None:
+    """Best-effort cleanup that cannot replace the probe's original failure."""
+    if probe_file is not None:
+        with suppress(Exception):
+            probe_file.close()
+    if probe_file_path is not None:
+        with suppress(Exception):
+            probe_file_path.unlink(missing_ok=True)
+    if probe_dir is not None:
+        with suppress(Exception):
+            probe_dir.rmdir()
+
+
+def prepare_artifact_storage(agent_dir: str | Path) -> PreparedArtifactStorage:
+    """Resolve and verify durable artifact storage beneath an existing agent dir."""
+    probe_dir: Path | None = None
+    probe_file_path: Path | None = None
+    probe_file: IO[bytes] | None = None
+
+    try:
+        agents_dir = Path(agent_dir).resolve(strict=True)
+        if not agents_dir.is_dir():
+            raise NotADirectoryError("Agent directory is not a directory.")
+
+        artifact_candidate = agents_dir / ".adk" / "artifacts"
+        _require_contained(
+            artifact_candidate.resolve(strict=False),
+            agents_dir,
+        )
+        artifact_candidate.mkdir(parents=True, exist_ok=True)
+        artifact_dir = artifact_candidate.resolve(strict=True)
+        _require_contained(artifact_dir, agents_dir)
+
+        probe_dir = Path(
+            tempfile.mkdtemp(prefix=".artifact-storage-probe-", dir=artifact_dir)
+        )
+        probe_dir.chmod(0o700)
+        # Explicit lifetime preserves a write/sync failure if close also fails.
+        probe_file = tempfile.NamedTemporaryFile(  # noqa: SIM115
+            mode="w+b",
+            prefix=".probe-",
+            dir=probe_dir,
+            delete=False,
+        )
+        probe_file_path = Path(probe_file.name)
+        probe_file_path.chmod(0o600)
+        probe_file.write(b"\0")
+        probe_file.flush()
+        os.fsync(probe_file.fileno())
+        probe_file.close()
+        probe_file = None
+
+        probe_file_path.unlink()
+        probe_file_path = None
+        probe_dir.rmdir()
+        probe_dir = None
+
+        return PreparedArtifactStorage(
+            agents_dir=agents_dir,
+            artifact_dir=artifact_dir,
+            artifact_service_uri=artifact_dir.as_uri(),
+        )
+    except Exception as exc:
+        _cleanup_probe(probe_file, probe_file_path, probe_dir)
+        raise ArtifactStorageError(ARTIFACT_STORAGE_ERROR_MESSAGE) from exc

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -5,6 +5,7 @@ features using custom OpenTelemetry setup. Includes an optional ADK web interfac
 interactive agent testing.
 """
 
+import logging
 from pathlib import Path
 
 import uvicorn
@@ -12,6 +13,11 @@ from fastapi import FastAPI
 from google.adk.cli.fast_api import get_fast_api_app
 from openinference.instrumentation.google_adk import GoogleADKInstrumentor
 
+from .artifact_storage import (
+    ARTIFACT_STORAGE_ERROR_MESSAGE,
+    ArtifactStorageError,
+    prepare_artifact_storage,
+)
 from .utils import (
     ObservabilityEnv,
     ServerEnv,
@@ -20,55 +26,9 @@ from .utils import (
     setup_logging,
 )
 
-# Load and validate environment configuration
-env = initialize_environment(ServerEnv)
-observability_env = initialize_environment(ObservabilityEnv, print_config=False)
-
-# Configure OpenTelemetry
-configure_otel_resource(
-    agent_name=env.agent_name,
-    settings=observability_env,
-)
-
-# Initialize Langfuse/OpenInference instrumentation
-GoogleADKInstrumentor().instrument()
-
-# Configure logging
-setup_logging(log_level=env.log_level)
+logger = logging.getLogger("agent.server")
 
 
-# Use .resolve() to handle symlinks and ensure absolute path across environments
-AGENT_DIR = env.agent_dir or str(Path(__file__).resolve().parent.parent)
-
-# Handle database URL conversion for asyncpg
-session_uri = env.session_uri
-if session_uri and session_uri.startswith("postgresql://"):
-    session_uri = session_uri.replace("postgresql://", "postgresql+asyncpg://", 1)
-
-# Define engine/pool settings for asyncpg connections
-session_db_kwargs = {
-    "pool_pre_ping": env.db_pool_pre_ping,
-    "pool_recycle": env.db_pool_recycle,
-    "pool_size": env.db_pool_size,
-    "max_overflow": env.db_max_overflow,
-    "pool_timeout": env.db_pool_timeout,
-}
-
-# ADK fastapi app will set up OTel using resource attributes from env vars
-app: FastAPI = get_fast_api_app(
-    agents_dir=AGENT_DIR,
-    session_service_uri=session_uri,
-    session_db_kwargs=session_db_kwargs,
-    artifact_service_uri=None,  # Explicitly None as GCP bucket not used
-    # Memory service does not yet support Postgres scheme in ADK
-    memory_service_uri=None,
-    allow_origins=env.allow_origins_list,
-    web=env.serve_web_interface,
-    reload_agents=env.reload_agents,
-)
-
-
-@app.get("/health")
 async def health() -> dict[str, str]:
     """Health check endpoint for container orchestration.
 
@@ -76,6 +36,50 @@ async def health() -> dict[str, str]:
         dict with status key indicating service health
     """
     return {"status": "ok"}
+
+
+def create_app(env: ServerEnv | None = None) -> FastAPI:
+    """Create a configured ADK FastAPI application with durable artifacts."""
+    server_env = env or initialize_environment(ServerEnv, print_config=False)
+    observability_env = initialize_environment(ObservabilityEnv, print_config=False)
+
+    configure_otel_resource(
+        agent_name=server_env.agent_name,
+        settings=observability_env,
+    )
+    GoogleADKInstrumentor().instrument()
+    setup_logging(log_level=server_env.log_level)
+
+    configured_agent_dir = (
+        server_env.agent_dir or Path(__file__).resolve().parent.parent
+    )
+    artifact_storage = prepare_artifact_storage(configured_agent_dir)
+
+    session_uri = server_env.session_uri
+    if session_uri and session_uri.startswith("postgresql://"):
+        session_uri = session_uri.replace("postgresql://", "postgresql+asyncpg://", 1)
+
+    session_db_kwargs = {
+        "pool_pre_ping": server_env.db_pool_pre_ping,
+        "pool_recycle": server_env.db_pool_recycle,
+        "pool_size": server_env.db_pool_size,
+        "max_overflow": server_env.db_max_overflow,
+        "pool_timeout": server_env.db_pool_timeout,
+    }
+
+    app = get_fast_api_app(
+        agents_dir=str(artifact_storage.agents_dir),
+        session_service_uri=session_uri,
+        session_db_kwargs=session_db_kwargs,
+        artifact_service_uri=artifact_storage.artifact_service_uri,
+        # Memory service does not yet support Postgres scheme in ADK
+        memory_service_uri=None,
+        allow_origins=server_env.allow_origins_list,
+        web=server_env.serve_web_interface,
+        reload_agents=server_env.reload_agents,
+    )
+    app.get("/health")(health)
+    return app
 
 
 def main() -> None:
@@ -101,6 +105,14 @@ def main() -> None:
         HOST: Server host (default: 127.0.0.1, set to 0.0.0.0 for containers)
         PORT: Server port (default: 8080)
     """
+    env = initialize_environment(ServerEnv, print_config=False)
+    try:
+        app = create_app(env)
+    except ArtifactStorageError:
+        logger.error(ARTIFACT_STORAGE_ERROR_MESSAGE)
+        raise SystemExit(1) from None
+
+    env.print_config()
     uvicorn.run(
         app,
         host=env.host,

--- a/tests/postgres/test_session_persistence.py
+++ b/tests/postgres/test_session_persistence.py
@@ -50,7 +50,7 @@ payload = {
     "state": {"persisted": "real-postgres"},
 }
 
-with TestClient(server.app) as client:
+with TestClient(server.create_app()) as client:
     created = client.post(base_path, json=payload)
     duplicate = client.post(base_path, json=payload)
 
@@ -72,7 +72,7 @@ from agent import server
 base_path = "/apps/agent/users/integration-user/sessions"
 session_path = base_path + "/persistent-session"
 
-with TestClient(server.app) as client:
+with TestClient(server.create_app()) as client:
     fetched = client.get(session_path)
     listed = client.get(base_path)
     deleted = client.delete(session_path)
@@ -406,9 +406,15 @@ def _bounded_diagnostics(output: str, database_url: str) -> str:
     return redacted[-4000:]
 
 
-def _assert_local_storage_disabled(phase_root: Path) -> None:
-    """Verify the ADK child created no local storage tree."""
-    assert list(phase_root.rglob(".adk")) == []
+def _assert_only_artifact_local_storage(phase_root: Path) -> None:
+    """Permit artifacts while proving sessions did not fall back to SQLite."""
+    adk_root = phase_root / "agents" / ".adk"
+    artifact_root = adk_root / "artifacts"
+
+    assert sorted(phase_root.rglob(".adk")) == [adk_root]
+    assert artifact_root.is_dir()
+    assert set(adk_root.iterdir()) == {artifact_root}
+    assert list(phase_root.rglob("session.db*")) == []
 
 
 def test_database_url_replaces_admin_user_information() -> None:
@@ -645,7 +651,7 @@ def test_session_persists_across_server_processes(
         _CREATE_PHASE,
     )
 
-    _assert_local_storage_disabled(create_root)
+    _assert_only_artifact_local_storage(create_root)
     assert create_result["created_status"] == 200
     assert create_result["duplicate_status"] == 409
     assert create_result["created_body"]["id"] == _SESSION_ID
@@ -659,7 +665,7 @@ def test_session_persists_across_server_processes(
         _RESTART_PHASE,
     )
 
-    _assert_local_storage_disabled(restart_root)
+    _assert_only_artifact_local_storage(restart_root)
     assert restart_result["fetched_status"] == 200
     assert restart_result["fetched_body"]["id"] == _SESSION_ID
     assert restart_result["fetched_body"]["state"] == {"persisted": _PERSISTED_VALUE}

--- a/tests/test_artifact_http.py
+++ b/tests/test_artifact_http.py
@@ -1,0 +1,91 @@
+"""Real HTTP integration coverage for persistent ADK artifacts."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+from fastapi.testclient import TestClient
+from google.genai import types
+
+_APP_NAME = "agent"
+_USER_ID = "artifact-user"
+_SESSION_ID = "artifact-session"
+_ARTIFACT_NAME = "proof.txt"
+_ARTIFACT_TEXT = "persistent artifact"
+_ARTIFACTS_PATH = f"/apps/{_APP_NAME}/users/{_USER_ID}/sessions/{_SESSION_ID}/artifacts"
+
+
+@pytest.fixture
+def configured_artifact_server(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[ModuleType, Path]]:
+    """Import the production server against one isolated artifact root."""
+    agent_dir = tmp_path / "agent root"
+    agent_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("ADK_DISABLE_LOAD_DOTENV", "true")
+    monkeypatch.setenv("ADK_DISABLE_LOCAL_STORAGE", "true")
+    monkeypatch.setenv("AGENT_DIR", str(agent_dir))
+    monkeypatch.setenv("AGENT_NAME", "artifact-http-test")
+    monkeypatch.setenv("ALLOW_ORIGINS", "[]")
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+    monkeypatch.setenv("RELOAD_AGENTS", "false")
+    monkeypatch.setenv("SERVE_WEB_INTERFACE", "false")
+
+    sys.modules.pop("agent.server", None)
+    server = importlib.import_module("agent.server")
+    try:
+        yield server, agent_dir
+    finally:
+        sys.modules.pop("agent.server", None)
+
+
+def test_artifact_survives_fresh_production_app(
+    configured_artifact_server: tuple[ModuleType, Path],
+) -> None:
+    """Save through HTTP and load the exact version from a fresh app."""
+    server, agent_dir = configured_artifact_server
+    artifact = types.Part(text=_ARTIFACT_TEXT)
+    request_body = {
+        "filename": _ARTIFACT_NAME,
+        "artifact": artifact.model_dump(
+            mode="json",
+            by_alias=True,
+            exclude_none=True,
+        ),
+    }
+
+    with TestClient(server.create_app()) as client:
+        saved_response = client.post(_ARTIFACTS_PATH, json=request_body)
+
+    assert saved_response.status_code == 200
+    saved = saved_response.json()
+    assert saved["version"] == 0
+
+    with TestClient(server.create_app()) as client:
+        loaded_response = client.get(
+            f"{_ARTIFACTS_PATH}/{_ARTIFACT_NAME}/versions/{saved['version']}"
+        )
+
+    assert loaded_response.status_code == 200
+    assert loaded_response.json() == {"text": _ARTIFACT_TEXT}
+    assert (agent_dir / ".adk" / "artifacts").is_dir()
+
+
+def test_missing_artifact_returns_exact_404(
+    configured_artifact_server: tuple[ModuleType, Path],
+) -> None:
+    """Expose ADK's exact not-found contract through the production app."""
+    server, _ = configured_artifact_server
+
+    with TestClient(server.create_app()) as client:
+        response = client.get(f"{_ARTIFACTS_PATH}/missing.txt/versions/0")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Artifact not found"}

--- a/tests/test_artifact_storage.py
+++ b/tests/test_artifact_storage.py
@@ -1,0 +1,324 @@
+"""Tests for fail-closed filesystem artifact storage preparation."""
+
+import os
+import stat
+import tempfile
+from pathlib import Path
+from typing import Any, Protocol, cast
+from unittest.mock import MagicMock, create_autospec, patch
+
+import pytest
+from google.adk.artifacts import FileArtifactService
+from google.adk.cli.utils.service_factory import (
+    create_artifact_service_from_options,
+)
+from google.genai import types
+
+from agent.artifact_storage import (
+    ArtifactStorageError,
+    prepare_artifact_storage,
+)
+
+_ERROR_MESSAGE = "Artifact storage is unavailable."
+
+
+class _ProbeFile(Protocol):
+    """Strict surface used by the write-failure boundary double."""
+
+    @property
+    def name(self) -> str: ...
+
+    def write(self, data: bytes) -> int: ...
+
+    def flush(self) -> None: ...
+
+    def fileno(self) -> int: ...
+
+    def close(self) -> None: ...
+
+
+async def test_prepare_uses_restrictive_probe_and_real_adk_file_service(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Verify permissions, cleanup, URI wiring, and persistence with real code."""
+    monkeypatch.setenv("ADK_DISABLE_LOCAL_STORAGE", "true")
+    agents_dir = tmp_path / "agents with spaces"
+    agents_dir.mkdir()
+    observed_modes: dict[str, int] = {}
+    real_fsync = os.fsync
+
+    def inspect_probe_permissions(file_descriptor: int) -> None:
+        artifact_dir = agents_dir / ".adk" / "artifacts"
+        [probe_dir] = artifact_dir.iterdir()
+        [probe_file] = probe_dir.iterdir()
+        observed_modes["dir"] = stat.S_IMODE(probe_dir.stat().st_mode)
+        observed_modes["file"] = stat.S_IMODE(probe_file.stat().st_mode)
+        real_fsync(file_descriptor)
+
+    fsync_spy = create_autospec(
+        os.fsync,
+        spec_set=True,
+        side_effect=inspect_probe_permissions,
+    )
+    with patch("agent.artifact_storage.os.fsync", new=fsync_spy):
+        prepared = prepare_artifact_storage(agents_dir)
+
+    resolved_agents_dir = agents_dir.resolve()
+    expected_artifact_dir = resolved_agents_dir / ".adk" / "artifacts"
+    assert prepared.agents_dir == resolved_agents_dir
+    assert prepared.artifact_dir == expected_artifact_dir
+    assert prepared.artifact_service_uri == expected_artifact_dir.as_uri()
+    assert observed_modes == {"dir": 0o700, "file": 0o600}
+    assert list(expected_artifact_dir.iterdir()) == []
+    fsync_spy.assert_called_once()
+
+    service = create_artifact_service_from_options(
+        base_dir=prepared.agents_dir,
+        artifact_service_uri=prepared.artifact_service_uri,
+        strict_uri=True,
+    )
+    assert isinstance(service, FileArtifactService)
+    version = await service.save_artifact(
+        app_name="agent",
+        user_id="user",
+        session_id="session",
+        filename="proof.txt",
+        artifact=types.Part(text="durable"),
+    )
+    loaded = await service.load_artifact(
+        app_name="agent",
+        user_id="user",
+        session_id="session",
+        filename="proof.txt",
+        version=version,
+    )
+    assert loaded is not None
+    assert loaded.text == "durable"
+
+
+@pytest.mark.parametrize("agent_dir_kind", ["missing", "file"])
+def test_prepare_requires_an_existing_directory(
+    agent_dir_kind: str,
+    tmp_path: Path,
+) -> None:
+    """Reject missing paths and files with one stable public error."""
+    agent_dir = tmp_path / agent_dir_kind
+    expected_cause: type[OSError]
+    if agent_dir_kind == "file":
+        agent_dir.touch()
+        expected_cause = NotADirectoryError
+    else:
+        expected_cause = FileNotFoundError
+
+    with pytest.raises(ArtifactStorageError) as error:
+        prepare_artifact_storage(agent_dir)
+
+    assert str(error.value) == _ERROR_MESSAGE
+    assert isinstance(error.value.__cause__, expected_cause)
+    assert not (tmp_path / ".adk").exists()
+
+
+def test_prepare_rejects_symlink_escape(tmp_path: Path) -> None:
+    """Prevent a pre-existing symlink from moving artifacts outside agent_dir."""
+    agents_dir = tmp_path / "agents"
+    outside_dir = tmp_path / "outside"
+    agents_dir.mkdir()
+    outside_dir.mkdir()
+    (agents_dir / ".adk").symlink_to(outside_dir, target_is_directory=True)
+
+    with pytest.raises(ArtifactStorageError) as error:
+        prepare_artifact_storage(agents_dir)
+
+    assert str(error.value) == _ERROR_MESSAGE
+    assert isinstance(error.value.__cause__, ValueError)
+    assert list(outside_dir.iterdir()) == []
+
+
+def test_prepare_cleans_probe_without_masking_fsync_failure(tmp_path: Path) -> None:
+    """Keep the fsync error as the sole cause while removing probe resources."""
+    agents_dir = tmp_path / "agents"
+    agents_dir.mkdir()
+    fsync_error = OSError("filesystem rejected fsync")
+    fsync_failure = create_autospec(
+        os.fsync,
+        spec_set=True,
+        side_effect=fsync_error,
+    )
+
+    with (
+        patch("agent.artifact_storage.os.fsync", new=fsync_failure),
+        pytest.raises(ArtifactStorageError) as error,
+    ):
+        prepare_artifact_storage(agents_dir)
+
+    artifact_dir = agents_dir / ".adk" / "artifacts"
+    assert str(error.value) == _ERROR_MESSAGE
+    assert error.value.__cause__ is fsync_error
+    assert list(artifact_dir.iterdir()) == []
+    fsync_failure.assert_called_once()
+
+
+def test_prepare_cleans_probe_without_masking_write_failure(tmp_path: Path) -> None:
+    """Translate a real probe-file write boundary failure and clean up."""
+    agents_dir = tmp_path / "agents"
+    agents_dir.mkdir()
+    write_error = OSError("filesystem rejected write")
+
+    def failing_named_temporary_file(
+        *args: Any,
+        **kwargs: Any,
+    ) -> MagicMock:
+        assert args == ()
+        probe_path = Path(kwargs["dir"]) / ".probe-write-failure"
+        probe_path.touch(mode=0o600)
+        probe_file = cast(
+            MagicMock,
+            create_autospec(_ProbeFile, instance=True, spec_set=True),
+        )
+        probe_file.name = str(probe_path)
+        probe_file.write.side_effect = write_error
+        return probe_file
+
+    named_temporary_file = cast(
+        MagicMock,
+        create_autospec(
+            tempfile.NamedTemporaryFile,
+            spec_set=True,
+            side_effect=failing_named_temporary_file,
+        ),
+    )
+
+    with (
+        patch(
+            "agent.artifact_storage.tempfile.NamedTemporaryFile",
+            new=named_temporary_file,
+        ),
+        pytest.raises(ArtifactStorageError) as error,
+    ):
+        prepare_artifact_storage(agents_dir)
+
+    artifact_dir = agents_dir / ".adk" / "artifacts"
+    assert str(error.value) == _ERROR_MESSAGE
+    assert error.value.__cause__ is write_error
+    assert list(artifact_dir.iterdir()) == []
+    named_temporary_file.assert_called_once()
+
+
+def test_prepare_preserves_write_failure_when_probe_close_also_fails(
+    tmp_path: Path,
+) -> None:
+    """Keep the body failure as cause when best-effort close also fails."""
+    agents_dir = tmp_path / "agents"
+    agents_dir.mkdir()
+    write_error = OSError("filesystem rejected write")
+    close_error = OSError("filesystem rejected close")
+    probe_files: list[MagicMock] = []
+
+    def failing_named_temporary_file(
+        *args: Any,
+        **kwargs: Any,
+    ) -> MagicMock:
+        assert args == ()
+        probe_path = Path(kwargs["dir"]) / ".probe-write-close-failure"
+        probe_path.touch(mode=0o600)
+        probe_file = cast(
+            MagicMock,
+            create_autospec(_ProbeFile, instance=True, spec_set=True),
+        )
+        probe_file.name = str(probe_path)
+        probe_file.write.side_effect = write_error
+        probe_file.close.side_effect = close_error
+        probe_files.append(probe_file)
+        return probe_file
+
+    named_temporary_file = cast(
+        MagicMock,
+        create_autospec(
+            tempfile.NamedTemporaryFile,
+            spec_set=True,
+            side_effect=failing_named_temporary_file,
+        ),
+    )
+
+    with (
+        patch(
+            "agent.artifact_storage.tempfile.NamedTemporaryFile",
+            new=named_temporary_file,
+        ),
+        pytest.raises(ArtifactStorageError) as error,
+    ):
+        prepare_artifact_storage(agents_dir)
+
+    artifact_dir = agents_dir / ".adk" / "artifacts"
+    assert str(error.value) == _ERROR_MESSAGE
+    assert error.value.__cause__ is write_error
+    assert list(artifact_dir.iterdir()) == []
+    assert len(probe_files) == 1
+    probe_files[0].close.assert_called_once()
+
+
+@pytest.mark.parametrize("failure_stage", ["mkdir", "unlink", "rmdir"])
+def test_prepare_translates_create_and_cleanup_failures(
+    failure_stage: str,
+    tmp_path: Path,
+) -> None:
+    """Fail closed for artifact creation and both probe-cleanup boundaries."""
+    agents_dir = tmp_path / "agents"
+    agents_dir.mkdir()
+    boundary_error = OSError(f"filesystem rejected {failure_stage}")
+
+    if failure_stage == "mkdir":
+        boundary = cast(
+            MagicMock,
+            create_autospec(
+                Path.mkdir,
+                spec_set=True,
+                side_effect=boundary_error,
+            ),
+        )
+        boundary_patch = patch.object(Path, "mkdir", new=boundary)
+    elif failure_stage == "unlink":
+        real_unlink = Path.unlink
+
+        def fail_probe_unlink(path: Path, *args: Any, **kwargs: Any) -> None:
+            if path.name.startswith(".probe-"):
+                raise boundary_error
+            real_unlink(path, *args, **kwargs)
+
+        boundary = cast(
+            MagicMock,
+            create_autospec(
+                Path.unlink,
+                spec_set=True,
+                side_effect=fail_probe_unlink,
+            ),
+        )
+        boundary_patch = patch.object(Path, "unlink", new=boundary)
+    else:
+        real_rmdir = Path.rmdir
+
+        def fail_probe_rmdir(path: Path) -> None:
+            if path.name.startswith(".artifact-storage-probe-"):
+                raise boundary_error
+            real_rmdir(path)
+
+        boundary = cast(
+            MagicMock,
+            create_autospec(
+                Path.rmdir,
+                spec_set=True,
+                side_effect=fail_probe_rmdir,
+            ),
+        )
+        boundary_patch = patch.object(Path, "rmdir", new=boundary)
+
+    with (
+        boundary_patch,
+        pytest.raises(ArtifactStorageError) as error,
+    ):
+        prepare_artifact_storage(agents_dir)
+
+    assert str(error.value) == _ERROR_MESSAGE
+    assert error.value.__cause__ is boundary_error
+    boundary.assert_called()

--- a/tests/test_compose_workflow.py
+++ b/tests/test_compose_workflow.py
@@ -23,6 +23,7 @@ class SmokeHarness(NamedTuple):
 
     environment: dict[str, str]
     docker_log: Path
+    event_log: Path
     python_log: Path
     runner_temp: Path
 
@@ -64,10 +65,14 @@ def smoke_harness(tmp_path: Path) -> SmokeHarness:
     bin_dir = tmp_path / "bin"
     runner_temp = tmp_path / "runner-temp"
     docker_log = tmp_path / "docker.log"
+    docker_ps_counter = tmp_path / "docker-ps-counter"
+    event_log = tmp_path / "events.log"
     python_log = tmp_path / "python.log"
     bin_dir.mkdir()
     runner_temp.mkdir()
     docker_log.touch()
+    docker_ps_counter.write_text("0\n", encoding="utf-8")
+    event_log.touch()
     python_log.touch()
 
     docker_path = bin_dir / "docker"
@@ -76,6 +81,7 @@ def smoke_harness(tmp_path: Path) -> SmokeHarness:
 set -eu
 
 printf '%s\\n' "$*" >> "$FAKE_DOCKER_LOG"
+printf 'docker:%s\\n' "$*" >> "$FAKE_EVENT_LOG"
 
 case " $* " in
   *" config --images "*)
@@ -85,15 +91,43 @@ case " $* " in
   *" config --quiet "*|*" build "*)
     exit 0
     ;;
+  *"compose-smoke-read-only"*" up "*)
+    exit "${FAKE_READ_ONLY_UP_EXIT:-17}"
+    ;;
   *" up "*)
     exit "${FAKE_DOCKER_UP_EXIT:-0}"
     ;;
   *" ps --all -q agent "*)
-    printf '%s\\n' "synthetic-container-id"
+    ps_count="$(cat "$FAKE_DOCKER_PS_COUNTER")"
+    ps_count="$((ps_count + 1))"
+    printf '%s\\n' "$ps_count" > "$FAKE_DOCKER_PS_COUNTER"
+    if [ "${FAKE_REUSE_CONTAINER_ID:-0}" = "1" ]; then
+      printf '%s\\n' "synthetic-container-id"
+    else
+      printf 'synthetic-container-id-%s\\n' "$ps_count"
+    fi
     exit 0
     ;;
   *" port agent 8080 "*)
     printf '%s\\n' "${FAKE_PUBLISHED_ADDRESS:-127.0.0.1:8080}"
+    exit 0
+    ;;
+  *" inspect "*"State.Health.Status"*)
+    printf '%s\\n' "${FAKE_READ_ONLY_HEALTH:-none}"
+    exit 0
+    ;;
+  *" inspect "*"State.ExitCode"*)
+    printf '%s\\n' "${FAKE_READ_ONLY_EXIT_CODE:-1}"
+    exit 0
+    ;;
+  *" inspect "*"State.Status"*)
+    printf '%s\\n' "${FAKE_READ_ONLY_STATUS:-exited}"
+    exit 0
+    ;;
+  *"compose-smoke-read-only"*" logs "*)
+    default_readonly_log='[ERROR] agent.server: Artifact storage is unavailable.'
+    printf '%s\\n' \
+      "${FAKE_READ_ONLY_LOG_MESSAGE-$default_readonly_log}"
     exit 0
     ;;
   *" ps --all "*|*" logs "*)
@@ -117,8 +151,14 @@ esac
         """#!/bin/bash
 set -eu
 
-printf '%s\\n' "called" >> "$FAKE_PYTHON_LOG"
-exit "${FAKE_PYTHON_EXIT:-0}"
+phase="${SMOKE_PHASE:-unknown}"
+printf '%s\\n' "$phase" >> "$FAKE_PYTHON_LOG"
+printf 'python:%s\\n' "$phase" >> "$FAKE_EVENT_LOG"
+
+if [ "${FAKE_PYTHON_FAIL_PHASE:-}" = "$phase" ]; then
+  exit "${FAKE_PYTHON_EXIT:-19}"
+fi
+exit 0
 """,
         encoding="utf-8",
     )
@@ -127,15 +167,16 @@ exit "${FAKE_PYTHON_EXIT:-0}"
     environment = {
         "COMPOSE_DISABLE_ENV_FILE": "1",
         "FAKE_DOCKER_LOG": str(docker_log),
+        "FAKE_DOCKER_PS_COUNTER": str(docker_ps_counter),
+        "FAKE_EVENT_LOG": str(event_log),
         "FAKE_PYTHON_LOG": str(python_log),
-        "HOME": str(tmp_path),
         "IMAGE": "synthetic-compose-image",
         "LANG": "C",
         "PATH": f"{bin_dir}:/usr/bin:/bin",
         "RUNNER_TEMP": str(runner_temp),
         "SMOKE_PROJECT": "synthetic-compose-project",
     }
-    return SmokeHarness(environment, docker_log, python_log, runner_temp)
+    return SmokeHarness(environment, docker_log, event_log, python_log, runner_temp)
 
 
 def _run_smoke_script(
@@ -159,6 +200,22 @@ def _run_smoke_script(
 def _docker_calls(harness: SmokeHarness) -> list[str]:
     """Return the fake Docker invocations in execution order."""
     return harness.docker_log.read_text(encoding="utf-8").splitlines()
+
+
+def _events(harness: SmokeHarness) -> list[str]:
+    """Return all fake boundary events in execution order."""
+    return harness.event_log.read_text(encoding="utf-8").splitlines()
+
+
+def _assert_ordered_fragments(events: list[str], fragments: tuple[str, ...]) -> None:
+    """Require each fragment to occur after the preceding boundary event."""
+    position = -1
+    for fragment in fragments:
+        position = next(
+            index
+            for index in range(position + 1, len(events))
+            if fragment in events[index]
+        )
 
 
 def _assert_runner_temp_is_empty(harness: SmokeHarness) -> None:
@@ -219,7 +276,7 @@ def test_checkout_matcher_ignores_commented_pins() -> None:
 
 
 def test_smoke_script_is_secret_free_bounded_and_self_cleaning() -> None:
-    """Lock the startup, health assertion, diagnostics, and cleanup contract."""
+    """Lock persistence, read-only failure, diagnostics, and cleanup contracts."""
     document = WORKFLOW_PATH.read_text(encoding="utf-8")
     script = _workflow_step_script(document, SMOKE_STEP_NAME)
 
@@ -238,31 +295,75 @@ def test_smoke_script_is_secret_free_bounded_and_self_cleaning() -> None:
         "trap 'exit 130' INT",
         "trap 'exit 143' TERM",
         "umask 077",
+        "SUPPRESS_CLEANUP_AGENT_LOGS=0",
+        "SUPPRESS_CLEANUP_AGENT_LOGS=1",
+        "Agent logs withheld after storage failure.",
         "IMAGE: ghcr.io/example/agent:compose-${{ github.sha }}",
         'mktemp "${RUNNER_TEMP}/compose-smoke-env.XXXXXX"',
         'mktemp "${RUNNER_TEMP}/compose-smoke-override.XXXXXX.yaml"',
-        "export ENV_FILE",
+        'mktemp "${RUNNER_TEMP}/compose-smoke-read-only.XXXXXX.yaml"',
+        'mktemp -d "${RUNNER_TEMP}/compose-smoke-artifacts.XXXXXX"',
+        "export ENV_FILE READ_ONLY_ARTIFACT_PARENT",
         "env_file: !override",
         'restart: "no"',
         'OTEL_SDK_DISABLED: "true"',
+        "volumes: !override",
+        "source: ${READ_ONLY_ARTIFACT_PARENT:?Set READ_ONLY_ARTIFACT_PARENT}",
+        "target: /app/src/.adk",
+        "read_only: true",
+        "create_host_path: false",
         '"${compose[@]}" config --images',
         'if [ "$resolved_images" != "$IMAGE" ]; then',
         "Unexpected Compose image:",
         '"${compose[@]}" config --quiet',
+        '"${readonly_compose[@]}" config --quiet',
         '"${compose[@]}" build',
         "--detach --no-build --wait --wait-timeout 180",
         '"${compose[@]}" port agent 8080',
         'if [ "$published_address" != "127.0.0.1:8080" ]; then',
         "Unexpected published address:",
-        "python3 -c",
-        'if payload != {"status": "ok"}:',
-        'raise SystemExit(f"Unexpected health payload: {payload!r}")',
+        "SMOKE_PHASE=save python3 - <<'PY'",
+        '"filename": "compose-smoke.txt"',
+        '"artifact": {"text": artifact_text}',
+        'if saved.get("version") != 0:',
+        "--force-recreate --no-deps",
+        "--wait --wait-timeout 180 agent",
+        'recreated_container_id="$("${compose[@]}" ps --all -q agent)"',
+        'if [ "$recreated_container_id" = "$container_id" ]; then',
+        "Compose reused the original agent container.",
+        "SMOKE_PHASE=load python3 - <<'PY'",
+        "compose-smoke.txt/versions/0",
+        'if loaded != {"text": artifact_text}:',
+        "--wait --wait-timeout 30 agent",
+        'if [ "$readonly_up_exit" -eq 0 ]; then',
+        "Read-only artifact storage unexpectedly became healthy.",
+        "docker inspect --format '{{.State.Status}}'",
+        "docker inspect --format '{{.State.ExitCode}}'",
+        "State.Health.Status",
+        "Read-only agent did not exit:",
+        "Artifact storage is unavailable.",
+        "Traceback (most recent call last)",
+        "PermissionError",
+        "FileNotFoundError",
+        "NotADirectoryError",
+        "OSError",
+        "ValueError",
+        "[Errno",
+        "/app/src",
+        ".artifact-storage-probe-",
+        ".probe-",
+        "AGENT_DIR",
+        'storage_message_count="$(',
+        'storage_message_line="$(',
+        "Read-only public storage line was not exact.",
         '"${compose[@]}" ps --all || true',
         "--no-color --timestamps --tail=200 agent || true",
         "--volumes --remove-orphans --timeout 30",
         "|| down_exit_code=$?",
         'rm -f "$ENV_FILE"',
         'rm -f "$OVERRIDE_FILE"',
+        'rm -f "$READ_ONLY_OVERRIDE_FILE"',
+        'rmdir "$READ_ONLY_ARTIFACT_PARENT"',
         'exit "$exit_code"',
     )
     for fragment in required_fragments:
@@ -270,20 +371,48 @@ def test_smoke_script_is_secret_free_bounded_and_self_cleaning() -> None:
 
     assert "ports: !override" not in document
     assert "volumes: !reset" not in document
-    assert "assert payload" not in script
+    assert "assert " not in script
+    assert script.count("--volumes") == 1
+    assert script.count("logs \\") == 2
+    assert script.count("--tail=200 agent") == 2
+    assert '--project-name "$SMOKE_PROJECT"' in script
 
-    ordered_fragments = (
-        "trap cleanup EXIT",
-        "umask 077",
-        '"${compose[@]}" config --images',
-        '"${compose[@]}" config --quiet',
-        '"${compose[@]}" build',
-        '"${compose[@]}" up',
-        '"${compose[@]}" port agent 8080',
-        "python3 -c",
+    trap_position = script.index("trap cleanup EXIT")
+    umask_position = script.index("umask 077")
+    image_position = script.index('"${compose[@]}" config --images')
+    config_position = script.index('"${compose[@]}" config --quiet')
+    readonly_config_position = script.index('"${readonly_compose[@]}" config --quiet')
+    build_position = script.index('"${compose[@]}" build')
+    initial_up_position = script.index('"${compose[@]}" up', build_position)
+    port_position = script.index('"${compose[@]}" port agent 8080')
+    save_position = script.index("SMOKE_PHASE=save")
+    recreate_position = script.index('"${compose[@]}" up', initial_up_position + 1)
+    recreated_id_position = script.index(
+        'recreated_container_id="$("${compose[@]}" ps --all -q agent)"'
     )
-    positions = [script.index(fragment) for fragment in ordered_fragments]
-    assert positions == sorted(positions)
+    load_position = script.index("SMOKE_PHASE=load")
+    readonly_up_position = script.index('"${readonly_compose[@]}" up')
+    readonly_logs_position = script.index(
+        '"${readonly_compose[@]}" logs',
+        readonly_up_position,
+    )
+
+    assert (
+        trap_position
+        < umask_position
+        < image_position
+        < config_position
+        < readonly_config_position
+        < build_position
+        < initial_up_position
+        < port_position
+        < save_position
+        < recreate_position
+        < recreated_id_position
+        < load_position
+        < readonly_up_position
+        < readonly_logs_position
+    )
 
 
 def test_smoke_script_has_valid_bash_syntax() -> None:
@@ -305,32 +434,51 @@ def test_smoke_script_has_valid_bash_syntax() -> None:
 def test_smoke_script_success_probes_and_cleans_up(
     smoke_harness: SmokeHarness,
 ) -> None:
-    """Exercise the success path through health probing and teardown."""
+    """Exercise persistence, fail-closed storage, and scoped teardown."""
     document = WORKFLOW_PATH.read_text(encoding="utf-8")
     script = _workflow_step_script(document, SMOKE_STEP_NAME)
 
     result = _run_smoke_script(script, smoke_harness)
 
     assert result.returncode == 0, result.stderr
-    assert "Compose startup and health checks passed." in result.stdout
-    calls = _docker_calls(smoke_harness)
-    ordered_fragments = (
-        " config --images",
-        " config --quiet",
-        " build",
-        " up --detach",
-        " ps --all -q agent",
-        " port agent 8080",
-        " down --volumes",
+    assert "Artifact storage is unavailable." in result.stdout
+    assert "Compose artifact persistence and failure checks passed." in result.stdout
+    _assert_ordered_fragments(
+        _events(smoke_harness),
+        (
+            " config --images",
+            " config --quiet",
+            "compose-smoke-read-only",
+            " build",
+            " up --detach --no-build --wait --wait-timeout 180",
+            " ps --all -q agent",
+            " port agent 8080",
+            "python:save",
+            (
+                " up --detach --no-build --force-recreate --no-deps "
+                "--wait --wait-timeout 180 agent"
+            ),
+            " ps --all -q agent",
+            "python:load",
+            "--wait --wait-timeout 30 agent",
+            " ps --all -q agent",
+            "docker:inspect --format {{.State.Status}}",
+            "docker:inspect --format {{.State.ExitCode}}",
+            "docker:inspect --format {{if .State.Health}}",
+            " logs --no-color --timestamps --tail=200 agent",
+            " down --volumes",
+        ),
     )
-    positions = [
-        next(index for index, call in enumerate(calls) if fragment in call)
-        for fragment in ordered_fragments
-    ]
-    assert positions == sorted(positions)
+    calls = _docker_calls(smoke_harness)
     assert not any(call.endswith(" ps --all") for call in calls)
-    assert not any(" logs " in call for call in calls)
-    assert smoke_harness.python_log.read_text(encoding="utf-8") == "called\n"
+    log_calls = [call for call in calls if " logs " in call]
+    assert len(log_calls) == 1
+    assert all("--tail=200 agent" in call for call in log_calls)
+    down_calls = [call for call in calls if " down " in call]
+    assert len(down_calls) == 1
+    assert "--project-name synthetic-compose-project" in down_calls[0]
+    assert " down --volumes --remove-orphans --timeout 30" in down_calls[0]
+    assert smoke_harness.python_log.read_text(encoding="utf-8") == "save\nload\n"
     _assert_runner_temp_is_empty(smoke_harness)
 
 
@@ -352,7 +500,9 @@ def test_smoke_script_rejects_non_loopback_publication(
     calls = _docker_calls(smoke_harness)
     assert any(" port agent 8080" in call for call in calls)
     assert any(call.endswith(" ps --all") for call in calls)
-    assert any(" logs " in call for call in calls)
+    assert any(
+        " logs --no-color --timestamps --tail=200 agent" in call for call in calls
+    )
     assert any(" down --volumes" in call for call in calls)
     assert smoke_harness.python_log.read_text(encoding="utf-8") == ""
     _assert_runner_temp_is_empty(smoke_harness)
@@ -373,40 +523,193 @@ def test_smoke_script_preserves_startup_failure_and_diagnostics(
 
     assert result.returncode == 17
     calls = _docker_calls(smoke_harness)
-    ordered_fragments = (
-        " up --detach",
-        " ps --all",
-        " logs ",
-        " down --volumes",
+    _assert_ordered_fragments(
+        _events(smoke_harness),
+        (
+            " up --detach --no-build --wait --wait-timeout 180",
+            " ps --all",
+            " logs --no-color --timestamps --tail=200 agent",
+            " down --volumes",
+        ),
     )
-    positions = [
-        next(index for index, call in enumerate(calls) if fragment in call)
-        for fragment in ordered_fragments
-    ]
-    assert positions == sorted(positions)
+    assert all("--tail=200 agent" in call for call in calls if " logs " in call)
     assert smoke_harness.python_log.read_text(encoding="utf-8") == ""
     _assert_runner_temp_is_empty(smoke_harness)
 
 
-def test_smoke_script_propagates_health_probe_failure(
+def test_smoke_script_proves_agent_container_was_recreated(
     smoke_harness: SmokeHarness,
 ) -> None:
-    """Fail, diagnose, and clean up when the exact health probe fails."""
+    """Reject persistence evidence when Compose reuses the original container."""
     document = WORKFLOW_PATH.read_text(encoding="utf-8")
     script = _workflow_step_script(document, SMOKE_STEP_NAME)
 
     result = _run_smoke_script(
         script,
         smoke_harness,
+        FAKE_REUSE_CONTAINER_ID="1",
+    )
+
+    assert result.returncode == 1
+    assert "Compose reused the original agent container." in result.stderr
+    calls = _docker_calls(smoke_harness)
+    assert sum(" ps --all -q agent" in call for call in calls) == 2
+    assert any(" --force-recreate --no-deps " in f" {call} " for call in calls)
+    assert any(" down --volumes" in call for call in calls)
+    assert smoke_harness.python_log.read_text(encoding="utf-8") == "save\n"
+    _assert_runner_temp_is_empty(smoke_harness)
+
+
+@pytest.mark.parametrize(
+    ("failure_phase", "expected_python_log", "recreate_started"),
+    (
+        ("save", "save\n", False),
+        ("load", "save\nload\n", True),
+    ),
+)
+def test_smoke_script_propagates_artifact_probe_failure(
+    smoke_harness: SmokeHarness,
+    failure_phase: str,
+    expected_python_log: str,
+    recreate_started: bool,
+) -> None:
+    """Fail, diagnose, and clean up when either real HTTP probe fails."""
+    document = WORKFLOW_PATH.read_text(encoding="utf-8")
+    script = _workflow_step_script(document, SMOKE_STEP_NAME)
+
+    result = _run_smoke_script(
+        script,
+        smoke_harness,
+        FAKE_PYTHON_FAIL_PHASE=failure_phase,
         FAKE_PYTHON_EXIT="19",
     )
 
     assert result.returncode == 19
     calls = _docker_calls(smoke_harness)
     assert any(call.endswith(" ps --all") for call in calls)
-    assert any(" logs " in call for call in calls)
+    assert any(
+        " logs --no-color --timestamps --tail=200 agent" in call for call in calls
+    )
     assert any(" down --volumes" in call for call in calls)
-    assert smoke_harness.python_log.read_text(encoding="utf-8") == "called\n"
+    recreate_calls = [
+        call
+        for call in calls
+        if " --force-recreate --no-deps " in f" {call} "
+        and "compose-smoke-read-only" not in call
+    ]
+    assert bool(recreate_calls) is recreate_started
+    assert smoke_harness.python_log.read_text(encoding="utf-8") == expected_python_log
+    _assert_runner_temp_is_empty(smoke_harness)
+
+
+def test_smoke_script_rejects_healthy_read_only_case(
+    smoke_harness: SmokeHarness,
+) -> None:
+    """Never accept an in-memory fallback when the bind mount is read-only."""
+    document = WORKFLOW_PATH.read_text(encoding="utf-8")
+    script = _workflow_step_script(document, SMOKE_STEP_NAME)
+
+    result = _run_smoke_script(
+        script,
+        smoke_harness,
+        FAKE_READ_ONLY_UP_EXIT="0",
+    )
+
+    assert result.returncode == 1
+    assert "Read-only artifact storage unexpectedly became healthy." in result.stderr
+    calls = _docker_calls(smoke_harness)
+    assert any(
+        "compose-smoke-read-only" in call and "--wait-timeout 30 agent" in call
+        for call in calls
+    )
+    assert any(call.endswith(" ps --all") for call in calls)
+    assert any(" down --volumes" in call for call in calls)
+    assert smoke_harness.python_log.read_text(encoding="utf-8") == "save\nload\n"
+    _assert_runner_temp_is_empty(smoke_harness)
+
+
+@pytest.mark.parametrize(
+    ("status", "exit_code", "health", "expected_error"),
+    (
+        ("running", "0", "unhealthy", "Read-only agent did not exit: running."),
+        ("created", "0", "none", "Read-only agent did not exit: created."),
+        ("dead", "1", "none", "Read-only agent did not exit: dead."),
+        ("exited", "0", "none", "Read-only agent exited successfully."),
+        ("exited", "1", "healthy", "Read-only agent reported healthy."),
+    ),
+)
+def test_smoke_script_requires_fail_closed_read_only_state(
+    smoke_harness: SmokeHarness,
+    status: str,
+    exit_code: str,
+    health: str,
+    expected_error: str,
+) -> None:
+    """Accept only an exited, nonzero, never-healthy read-only container."""
+    document = WORKFLOW_PATH.read_text(encoding="utf-8")
+    script = _workflow_step_script(document, SMOKE_STEP_NAME)
+
+    result = _run_smoke_script(
+        script,
+        smoke_harness,
+        FAKE_READ_ONLY_STATUS=status,
+        FAKE_READ_ONLY_EXIT_CODE=exit_code,
+        FAKE_READ_ONLY_HEALTH=health,
+    )
+
+    assert result.returncode == 1
+    assert expected_error in result.stderr
+    calls = _docker_calls(smoke_harness)
+    assert any(call.startswith("inspect ") for call in calls)
+    assert any(" down --volumes" in call for call in calls)
+    _assert_runner_temp_is_empty(smoke_harness)
+
+
+@pytest.mark.parametrize(
+    ("log_message", "expected_error"),
+    (
+        ("", "Read-only failure omitted the public storage message."),
+        (
+            "[ERROR] agent.server: Artifact storage is unavailable. PermissionError",
+            "Read-only diagnostics failed sanitization.",
+        ),
+        (
+            (
+                "[ERROR] agent.server: /private/secret-path "
+                "Artifact storage is unavailable."
+            ),
+            "Read-only public storage line was not exact.",
+        ),
+        (
+            (
+                "[ERROR] agent.server: Artifact storage is unavailable. "
+                "Artifact storage is unavailable."
+            ),
+            "Read-only public storage line was not exact.",
+        ),
+    ),
+)
+def test_smoke_script_requires_sanitized_read_only_diagnostics(
+    smoke_harness: SmokeHarness,
+    log_message: str,
+    expected_error: str,
+) -> None:
+    """Require the stable public error without exposing filesystem causes."""
+    document = WORKFLOW_PATH.read_text(encoding="utf-8")
+    script = _workflow_step_script(document, SMOKE_STEP_NAME)
+
+    result = _run_smoke_script(
+        script,
+        smoke_harness,
+        FAKE_READ_ONLY_LOG_MESSAGE=log_message,
+    )
+
+    assert result.returncode == 1
+    assert expected_error in result.stderr
+    assert "/private/secret-path" not in result.stdout + result.stderr
+    calls = _docker_calls(smoke_harness)
+    assert all("--tail=200 agent" in call for call in calls if " logs " in call)
+    assert any(" down --volumes" in call for call in calls)
     _assert_runner_temp_is_empty(smoke_harness)
 
 
@@ -427,5 +730,8 @@ def test_smoke_script_surfaces_teardown_failure(
     calls = _docker_calls(smoke_harness)
     assert any(" down --volumes" in call for call in calls)
     assert not any(call.endswith(" ps --all") for call in calls)
-    assert not any(" logs " in call for call in calls)
+    log_calls = [call for call in calls if " logs " in call]
+    assert len(log_calls) == 1
+    assert "compose-smoke-read-only" in log_calls[0]
+    assert "--tail=200 agent" in log_calls[0]
     _assert_runner_temp_is_empty(smoke_harness)

--- a/tests/test_network_exposure.py
+++ b/tests/test_network_exposure.py
@@ -44,6 +44,7 @@ def test_compose_defaults_to_loopback_and_headless_runtime() -> None:
     assert agent["environment"] == [
         "HOST=0.0.0.0",
         "PORT=8080",
+        "AGENT_DIR=/app/src",
         "AGENT_NAME=local-dev",
         "LOG_LEVEL=INFO",
         "RELOAD_AGENTS=${RELOAD_AGENTS:-false}",

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -1,69 +1,99 @@
 """Tests for server bootstrap configuration."""
 
-import importlib
+import logging
 import os
+import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import create_autospec, patch
+from typing import cast
+from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
+import uvicorn
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from google.adk.cli.fast_api import get_fast_api_app
 from openinference.instrumentation.google_adk import GoogleADKInstrumentor
 
+from agent import server
 
-@pytest.mark.parametrize("configured_agent_dir", [None, "/srv/test-agents"])
-def test_server_bootstrap_uses_typed_settings_before_instrumentation(
-    configured_agent_dir: str | None,
+
+def _agent_dir(
+    *,
+    configured: bool,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Path:
+    """Create either an explicit agent directory or the module-derived default."""
+    if configured:
+        agent_dir = tmp_path / "configured agents"
+        agent_dir.mkdir()
+        monkeypatch.setenv("AGENT_DIR", str(agent_dir))
+        return agent_dir
+
+    source_root = tmp_path / "default agents"
+    (source_root / "agent").mkdir(parents=True)
+    monkeypatch.setattr(
+        server,
+        "__file__",
+        str(source_root / "agent" / "server.py"),
+    )
+    return source_root
+
+
+def _mock_instrumentor() -> MagicMock:
+    """Return a strict mock for the external ADK instrumentor."""
+    return cast(
+        MagicMock,
+        create_autospec(
+            GoogleADKInstrumentor,
+            spec_set=True,
+        ),
+    )
+
+
+@pytest.mark.parametrize("configured_agent_dir", [False, True])
+def test_create_app_uses_typed_settings_and_explicit_artifact_uri(
+    configured_agent_dir: bool,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Verify server, database, agent-dir, and OTel settings are composed."""
+    """Compose settings before passing one resolved path and URI to ADK."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("AGENT_NAME", "test-agent")
     monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@localhost/db")
     monkeypatch.setenv("TELEMETRY_NAMESPACE", "test-namespace")
-    if configured_agent_dir is not None:
-        monkeypatch.setenv("AGENT_DIR", configured_agent_dir)
-
-    mock_app = create_autospec(FastAPI, instance=True, spec_set=True)
+    agent_dir = _agent_dir(
+        configured=configured_agent_dir,
+        monkeypatch=monkeypatch,
+        tmp_path=tmp_path,
+    )
+    test_app = FastAPI()
     mock_get_app = create_autospec(
         get_fast_api_app,
         spec_set=True,
-        return_value=mock_app,
+        return_value=test_app,
     )
-    mock_instrumentor_class = create_autospec(
-        GoogleADKInstrumentor,
-        spec_set=True,
-    )
+    mock_instrumentor_class = _mock_instrumentor()
+
+    def assert_otel_is_ready() -> None:
+        resource_attributes = os.environ["OTEL_RESOURCE_ATTRIBUTES"]
+        assert "service.name=test-agent" in resource_attributes
+        assert "service.namespace=test-namespace" in resource_attributes
+
+    mock_instrumentor_class.return_value.instrument.side_effect = assert_otel_is_ready
     with (
-        patch(
-            "google.adk.cli.fast_api.get_fast_api_app",
-            new=mock_get_app,
-        ),
-        patch(
-            "openinference.instrumentation.google_adk.GoogleADKInstrumentor",
+        patch.object(server, "get_fast_api_app", new=mock_get_app),
+        patch.object(
+            server,
+            "GoogleADKInstrumentor",
             new=mock_instrumentor_class,
         ),
     ):
+        app = server.create_app()
 
-        def assert_otel_is_ready() -> None:
-            resource_attributes = os.environ["OTEL_RESOURCE_ATTRIBUTES"]
-            assert "service.name=test-agent" in resource_attributes
-            assert "service.namespace=test-namespace" in resource_attributes
-
-        mock_instrumentor_class.return_value.instrument.side_effect = (
-            assert_otel_is_ready
-        )
-        sys.modules.pop("agent.server", None)
-        server = importlib.import_module("agent.server")
-
-    server_file = server.__file__
-    assert server_file is not None
-    expected_agent_dir = configured_agent_dir or str(
-        Path(server_file).resolve().parent.parent
-    )
+    resolved_agent_dir = agent_dir.resolve()
+    artifact_dir = resolved_agent_dir / ".adk" / "artifacts"
     expected_db_kwargs = {
         "pool_pre_ping": True,
         "pool_recycle": 1800,
@@ -72,54 +102,280 @@ def test_server_bootstrap_uses_typed_settings_before_instrumentation(
         "pool_timeout": 30,
     }
 
+    assert app is test_app
     mock_instrumentor_class.return_value.instrument.assert_called_once_with()
     mock_get_app.assert_called_once()
     call_kwargs = mock_get_app.call_args.kwargs
-    assert call_kwargs["agents_dir"] == expected_agent_dir
+    assert call_kwargs["agents_dir"] == str(resolved_agent_dir)
+    assert call_kwargs["artifact_service_uri"] == artifact_dir.as_uri()
     assert call_kwargs["session_service_uri"] == (
         "postgresql+asyncpg://user:pass@localhost/db"
     )
     assert call_kwargs["session_db_kwargs"] == expected_db_kwargs
-    assert expected_agent_dir == server.AGENT_DIR
-
-    sys.modules.pop("agent.server", None)
+    assert artifact_dir.is_dir()
+    assert list(artifact_dir.iterdir()) == []
 
 
 def test_health_endpoint_reports_process_liveness(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Verify the registered health route serves the container liveness contract."""
-    monkeypatch.chdir(tmp_path)
+    """Verify the factory registers the container liveness contract."""
+    agent_dir = tmp_path / "agents"
+    agent_dir.mkdir()
     test_app = FastAPI()
     mock_get_app = create_autospec(
         get_fast_api_app,
         spec_set=True,
         return_value=test_app,
     )
-    mock_instrumentor_class = create_autospec(
-        GoogleADKInstrumentor,
-        spec_set=True,
-    )
+    mock_instrumentor_class = _mock_instrumentor()
 
     with (
-        patch.dict(os.environ, {"AGENT_NAME": "health-test-agent"}, clear=True),
-        patch(
-            "google.adk.cli.fast_api.get_fast_api_app",
-            new=mock_get_app,
+        patch.dict(
+            os.environ,
+            {
+                "AGENT_DIR": str(agent_dir),
+                "AGENT_NAME": "health-test-agent",
+            },
+            clear=True,
         ),
-        patch(
-            "openinference.instrumentation.google_adk.GoogleADKInstrumentor",
+        patch.object(server, "get_fast_api_app", new=mock_get_app),
+        patch.object(
+            server,
+            "GoogleADKInstrumentor",
             new=mock_instrumentor_class,
         ),
     ):
-        sys.modules.pop("agent.server", None)
-        try:
-            server = importlib.import_module("agent.server")
-            with TestClient(server.app) as client:
-                response = client.get("/health")
-        finally:
-            sys.modules.pop("agent.server", None)
+        app = server.create_app()
+        with TestClient(app) as client:
+            response = client.get("/health")
 
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
+
+
+def test_import_has_no_application_or_storage_side_effect() -> None:
+    """Require callers to opt into application and storage creation."""
+    assert not hasattr(server, "app")
+
+
+def test_main_runs_factory_application(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Run uvicorn with the configured host and port after preparation."""
+    agent_dir = tmp_path / "agents"
+    agent_dir.mkdir()
+    test_app = FastAPI()
+    mock_get_app = create_autospec(
+        get_fast_api_app,
+        spec_set=True,
+        return_value=test_app,
+    )
+    mock_instrumentor_class = _mock_instrumentor()
+    mock_uvicorn_run = create_autospec(
+        uvicorn.run,
+        spec_set=True,
+    )
+    monkeypatch.setenv("AGENT_DIR", str(agent_dir))
+    monkeypatch.setenv("AGENT_NAME", "main-test-agent")
+    monkeypatch.setenv("HOST", "127.0.0.2")
+    monkeypatch.setenv("PORT", "9090")
+
+    with (
+        patch.object(server, "get_fast_api_app", new=mock_get_app),
+        patch.object(
+            server,
+            "GoogleADKInstrumentor",
+            new=mock_instrumentor_class,
+        ),
+        patch.object(server.uvicorn, "run", new=mock_uvicorn_run),
+    ):
+        server.main()
+
+    mock_uvicorn_run.assert_called_once_with(
+        test_app,
+        host="127.0.0.2",
+        port=9090,
+    )
+
+
+def test_main_logs_stable_storage_failure_without_traceback(
+    caplog: pytest.LogCaptureFixture,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Exit one without exposing the underlying filesystem failure."""
+    agent_dir = tmp_path / "agents"
+    outside_dir = tmp_path / "outside"
+    agent_dir.mkdir()
+    outside_dir.mkdir()
+    (agent_dir / ".adk").symlink_to(outside_dir, target_is_directory=True)
+    mock_get_app = create_autospec(
+        get_fast_api_app,
+        spec_set=True,
+    )
+    mock_instrumentor_class = _mock_instrumentor()
+    mock_uvicorn_run = create_autospec(
+        uvicorn.run,
+        spec_set=True,
+    )
+    monkeypatch.setenv("AGENT_DIR", str(agent_dir))
+    monkeypatch.setenv("AGENT_NAME", "failure-test-agent")
+    caplog.set_level(logging.ERROR, logger="agent.server")
+
+    with (
+        patch.object(server, "get_fast_api_app", new=mock_get_app),
+        patch.object(
+            server,
+            "GoogleADKInstrumentor",
+            new=mock_instrumentor_class,
+        ),
+        patch.object(server.uvicorn, "run", new=mock_uvicorn_run),
+        pytest.raises(SystemExit) as exit_error,
+    ):
+        server.main()
+
+    failure_records = [
+        record for record in caplog.records if record.name == "agent.server"
+    ]
+    assert exit_error.value.code == 1
+    assert exit_error.value.__cause__ is None
+    assert exit_error.value.__suppress_context__
+    assert [record.getMessage() for record in failure_records] == [
+        "Artifact storage is unavailable."
+    ]
+    assert all(record.exc_info is None for record in failure_records)
+    assert all(record.stack_info is None for record in failure_records)
+    captured = capsys.readouterr()
+    process_output = captured.out + captured.err
+    for forbidden in (
+        "AGENT_DIR",
+        str(agent_dir),
+        str(outside_dir),
+        "ValueError",
+        "Traceback",
+    ):
+        assert forbidden not in process_output
+    mock_get_app.assert_not_called()
+    mock_uvicorn_run.assert_not_called()
+
+
+def test_main_sanitizes_post_creation_probe_failure(
+    caplog: pytest.LogCaptureFixture,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Never expose a raw sync error or random probe after directory creation."""
+    agent_dir = tmp_path / "agents"
+    agent_dir.mkdir()
+    raw_failure = OSError(
+        f"sync failed at {agent_dir}/.artifact-storage-probe-secret/.probe-secret"
+    )
+    fsync_failure = create_autospec(
+        os.fsync,
+        spec_set=True,
+        side_effect=raw_failure,
+    )
+    mock_get_app = create_autospec(
+        get_fast_api_app,
+        spec_set=True,
+    )
+    mock_instrumentor_class = _mock_instrumentor()
+    mock_uvicorn_run = create_autospec(
+        uvicorn.run,
+        spec_set=True,
+    )
+    monkeypatch.setenv("AGENT_DIR", str(agent_dir))
+    monkeypatch.setenv("AGENT_NAME", "probe-failure-test-agent")
+    caplog.set_level(logging.ERROR, logger="agent.server")
+
+    with (
+        patch("agent.artifact_storage.os.fsync", new=fsync_failure),
+        patch.object(server, "get_fast_api_app", new=mock_get_app),
+        patch.object(
+            server,
+            "GoogleADKInstrumentor",
+            new=mock_instrumentor_class,
+        ),
+        patch.object(server.uvicorn, "run", new=mock_uvicorn_run),
+        pytest.raises(SystemExit) as exit_error,
+    ):
+        server.main()
+
+    failure_records = [
+        record for record in caplog.records if record.name == "agent.server"
+    ]
+    captured = capsys.readouterr()
+    process_output = captured.out + captured.err
+    assert exit_error.value.code == 1
+    assert [record.getMessage() for record in failure_records] == [
+        "Artifact storage is unavailable."
+    ]
+    for forbidden in (
+        "AGENT_DIR",
+        str(agent_dir),
+        str(raw_failure),
+        ".artifact-storage-probe-",
+        ".probe-",
+        "OSError",
+        "Traceback",
+    ):
+        assert forbidden not in process_output
+    assert list((agent_dir / ".adk" / "artifacts").iterdir()) == []
+    fsync_failure.assert_called_once()
+    mock_get_app.assert_not_called()
+    mock_uvicorn_run.assert_not_called()
+
+
+def test_module_entrypoint_sanitizes_real_startup_failure(tmp_path: Path) -> None:
+    """Verify the supported process boundary without imported-module mocks."""
+    missing_agent_dir = tmp_path / "missing-agent-dir"
+    environment = {
+        "ADK_DISABLE_LOAD_DOTENV": "true",
+        "ADK_DISABLE_LOCAL_STORAGE": "true",
+        "AGENT_DIR": str(missing_agent_dir),
+        "AGENT_NAME": "module-failure-test-agent",
+        "ALLOW_ORIGINS": "[]",
+        "LANG": "C",
+        "OTEL_SDK_DISABLED": "true",
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "PYTHONUNBUFFERED": "1",
+        "RELOAD_AGENTS": "false",
+        "SERVE_WEB_INTERFACE": "false",
+    }
+
+    result = subprocess.run(  # noqa: S603 - fixed interpreter and module
+        [sys.executable, "-m", "agent.server"],
+        cwd=tmp_path,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    process_output = result.stdout + result.stderr
+    message_lines = [
+        line
+        for line in process_output.splitlines()
+        if "Artifact storage is unavailable." in line
+    ]
+    assert result.returncode == 1
+    assert len(message_lines) == 1
+    assert message_lines[0].endswith(
+        "[ERROR] agent.server: Artifact storage is unavailable."
+    )
+    for forbidden in (
+        "AGENT_DIR",
+        str(missing_agent_dir),
+        "FileNotFoundError",
+        "OSError",
+        "[Errno",
+        "Traceback",
+        ".artifact-storage-probe-",
+        ".probe-",
+    ):
+        assert forbidden not in process_output


### PR DESCRIPTION
## What

Add fail-closed, filesystem-backed ADK artifact persistence for a single-VM
deployment.

## Why

The existing Compose volume was mounted at `/app/src/.adk`, but the server
passed no artifact service URI to ADK. Artifacts could therefore fall back to
process memory instead of surviving a normal process or container recreation.

## How

- Prepare `<resolved AGENT_DIR>/.adk/artifacts` with a restrictive write,
  flush, `fsync`, and cleanup probe before health can succeed.
- Pass the canonical `file://` artifact URI explicitly to ADK 1.36.2.
- Pin Compose `AGENT_DIR=/app/src` so `.env` cannot route artifacts away from
  the named volume.
- Build the FastAPI application through `create_app()` without import-time
  filesystem side effects.
- Exit with one stable, sanitized storage error when preparation fails.
- Exercise real ADK HTTP save/load behavior, PostgreSQL session isolation, and
  Compose persistence plus read-only failure behavior.
- Document the single-VM lifecycle, security boundary, backup ownership, and
  destructive volume operations.

## Tests

- [x] `uv sync --locked`
- [x] `uv run ruff format`
- [x] `uv run ruff format --check`
- [x] `uv run ruff check --no-fix --output-format=github`
- [x] `uv run mypy .`
- [x] `uv run pytest --cov=src --cov-report=xml --cov-report=term-missing`
      (`408 passed`, `4 skipped`, 100% statement and branch coverage)
- [x] Real `python -m agent.server` sanitized-failure subprocess
- [x] Secret-free real `docker compose config` for named-volume and read-only
      mount resolution
- [x] GitHub Code Quality job with its PostgreSQL service
- [x] GitHub Compose Smoke job with real container recreation

## Breaking Changes

`agent.server` no longer creates a module-global `app`. Supported production
startup remains `python -m agent.server` or `uv run server`; the older
`uvicorn agent.server:app` target is not supported.

## Related Issues

Closes #1
