### PR TITLE
fix: pin VM deploy to commit and digest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,6 +30,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      digest: ${{ steps.build-push.outputs.digest }}
 
     steps:
       - name: Checkout repository
@@ -81,6 +83,14 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Record immutable image reference
+        env:
+          IMAGE_DIGEST: ${{ steps.build-push.outputs.digest }}
+        run: |
+          printf '### Immutable image\n\n`%s/%s@%s`\n' \
+            "$REGISTRY" "$IMAGE_NAME" "$IMAGE_DIGEST" \
+            >> "$GITHUB_STEP_SUMMARY"
+
   deploy:
     needs: build
     if: >-
@@ -88,30 +98,151 @@ jobs:
       github.ref == 'refs/heads/main' &&
       inputs.deploy
     runs-on: ubuntu-latest
+    concurrency:
+      group: production-deployment
+      cancel-in-progress: false
+      queue: max
     steps:
+      - name: Validate deployment provenance
+        env:
+          DEPLOY_SHA: ${{ github.sha }}
+          IMAGE_DIGEST: ${{ needs.build.outputs.digest }}
+        run: |
+          set -eu
+
+          if [ "${#DEPLOY_SHA}" -ne 40 ]; then
+            echo "ERROR: Invalid deployment commit."
+            exit 1
+          fi
+          case "$DEPLOY_SHA" in
+            *[!0123456789abcdef]*)
+              echo "ERROR: Invalid deployment commit."
+              exit 1
+              ;;
+          esac
+
+          case "$IMAGE_DIGEST" in
+            sha256:*) ;;
+            *)
+              echo "ERROR: Invalid image digest."
+              exit 1
+              ;;
+          esac
+          DIGEST_HEX=${IMAGE_DIGEST#sha256:}
+          if [ "${#DIGEST_HEX}" -ne 64 ]; then
+            echo "ERROR: Invalid image digest."
+            exit 1
+          fi
+          case "$DIGEST_HEX" in
+            *[!0123456789abcdef]*)
+              echo "ERROR: Invalid image digest."
+              exit 1
+              ;;
+          esac
+
       - name: Deploy to Server
         uses: appleboy/ssh-action@v1.0.3
+        env:
+          DEPLOY_SHA: ${{ github.sha }}
+          IMAGE_DIGEST: ${{ needs.build.outputs.digest }}
         with:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
+          envs: DEPLOY_SHA,IMAGE_DIGEST
           script: |
             set -eu
+
+            if [ "${#DEPLOY_SHA}" -ne 40 ]; then
+              echo "ERROR: Invalid deployment commit."
+              exit 1
+            fi
+            case "$DEPLOY_SHA" in
+              *[!0123456789abcdef]*)
+                echo "ERROR: Invalid deployment commit."
+                exit 1
+                ;;
+            esac
+
+            case "$IMAGE_DIGEST" in
+              sha256:*) ;;
+              *)
+                echo "ERROR: Invalid image digest."
+                exit 1
+                ;;
+            esac
+            DIGEST_HEX=${IMAGE_DIGEST#sha256:}
+            if [ "${#DIGEST_HEX}" -ne 64 ]; then
+              echo "ERROR: Invalid image digest."
+              exit 1
+            fi
+            case "$DIGEST_HEX" in
+              *[!0123456789abcdef]*)
+                echo "ERROR: Invalid image digest."
+                exit 1
+                ;;
+            esac
 
             # 1. Set dynamic project directory based on repository name
             PROJECT_NAME="${{ github.event.repository.name }}"
             PROJECT_DIR="$HOME/$PROJECT_NAME"
-            IMAGE_NAME="$(printf '%s' "ghcr.io/${{ github.repository }}:main" | tr '[:upper:]' '[:lower:]')"
+            EXPECTED_ORIGIN="https://github.com/${{ github.repository }}"
+            IMAGE_REPOSITORY="$(
+              printf '%s' "ghcr.io/${{ github.repository }}" \
+                | tr '[:upper:]' '[:lower:]'
+            )"
+            IMAGE_NAME="${IMAGE_REPOSITORY}@${IMAGE_DIGEST}"
+            DEPLOY_PROJECT="$(
+              printf 'adk-%s' "$PROJECT_NAME" | tr '[:upper:].' '[:lower:]-'
+            )"
 
             # 2. Ensure project directory exists
-            if [ ! -d "$PROJECT_DIR" ]; then
+            if [ -e "$PROJECT_DIR" ] && [ ! -d "$PROJECT_DIR/.git" ]; then
+              echo "ERROR: Project path exists without a Git checkout."
+              exit 1
+            fi
+            if [ ! -d "$PROJECT_DIR/.git" ]; then
               echo "Project directory not found. Cloning..."
               git clone https://github.com/${{ github.repository }} "$PROJECT_DIR"
             fi
 
-            # 3. Navigate and Update Code
+            # 3. Navigate to the exact source revision without discarding changes
             cd "$PROJECT_DIR"
-            git pull
+            ACTUAL_ORIGIN="$(git remote get-url origin)"
+            case "$ACTUAL_ORIGIN" in
+              "$EXPECTED_ORIGIN"|"$EXPECTED_ORIGIN.git") ;;
+              *)
+                echo "ERROR: Existing checkout has an unexpected origin."
+                exit 1
+                ;;
+            esac
+            if ! git diff --quiet --; then
+              echo "ERROR: Tracked worktree changes block deployment."
+              exit 1
+            fi
+            if ! git diff --cached --quiet --; then
+              echo "ERROR: Staged changes block deployment."
+              exit 1
+            fi
+            git fetch --no-tags origin "$DEPLOY_SHA"
+            git checkout --detach "$DEPLOY_SHA"
+            CHECKED_OUT_SHA="$(git rev-parse --verify HEAD)"
+            if [ "$CHECKED_OUT_SHA" != "$DEPLOY_SHA" ]; then
+              echo "ERROR: Checked-out commit does not match deployment commit."
+              exit 1
+            fi
+            if ! git diff --quiet --; then
+              echo "ERROR: Checkout left tracked worktree changes."
+              exit 1
+            fi
+            if ! git diff --cached --quiet --; then
+              echo "ERROR: Checkout left staged changes."
+              exit 1
+            fi
+            if ! git ls-files --error-unmatch -- compose.yaml >/dev/null 2>&1; then
+              echo "ERROR: Deployment commit does not track compose.yaml."
+              exit 1
+            fi
 
             # 4. Inject Secrets into .env (Automated Configuration)
             echo "Generating .env file from GitHub Secrets..."
@@ -131,6 +262,51 @@ jobs:
 
             # 5. Deploy with dynamic image
             export IMAGE="$IMAGE_NAME"
-            docker compose pull
-            docker compose up --no-build --wait --wait-timeout 180
+            CONFIGURED_IMAGE="$(
+              docker compose --project-name "$DEPLOY_PROJECT" \
+                --env-file .env -f compose.yaml config --images
+            )"
+            if [ "$CONFIGURED_IMAGE" != "$IMAGE_NAME" ]; then
+              echo "ERROR: Compose image does not match the deployment digest."
+              exit 1
+            fi
+            docker compose --project-name "$DEPLOY_PROJECT" \
+              --env-file .env -f compose.yaml pull agent
+            docker compose --project-name "$DEPLOY_PROJECT" \
+              --env-file .env -f compose.yaml \
+              up --no-build --wait --wait-timeout 180 agent
+
+            CONTAINER_ID="$(
+              docker compose --project-name "$DEPLOY_PROJECT" \
+                --env-file .env -f compose.yaml ps --quiet agent
+            )"
+            if [ -z "$CONTAINER_ID" ]; then
+              echo "ERROR: Compose did not return the agent container."
+              exit 1
+            fi
+            RUNNING_IMAGE="$(
+              docker inspect --type container \
+                --format '{{.Config.Image}}' "$CONTAINER_ID"
+            )"
+            if [ "$RUNNING_IMAGE" != "$IMAGE_NAME" ]; then
+              echo "ERROR: Running image does not match the deployment digest."
+              exit 1
+            fi
+            CONTAINER_IMAGE_ID="$(
+              docker inspect --type container --format '{{.Image}}' "$CONTAINER_ID"
+            )"
+            if [ -z "$CONTAINER_IMAGE_ID" ]; then
+              echo "ERROR: Running container does not expose an image ID."
+              exit 1
+            fi
+            RUNNING_REVISION="$(
+              docker image inspect \
+                --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' \
+                "$CONTAINER_IMAGE_ID"
+            )"
+            if [ "$RUNNING_REVISION" != "$DEPLOY_SHA" ]; then
+              echo "ERROR: Running image revision does not match the deployment commit."
+              exit 1
+            fi
+
             docker image prune -f

--- a/README.md
+++ b/README.md
@@ -62,16 +62,24 @@ We've simplified deployment to the absolute basics. No Kubernetes required.
 Every successful Docker Publish workflow on `main` publishes an image for that
 repository. From the cloned repository on your server, create `.env`, then
 replace both placeholders below with the lowercase owner and repository that
-published the image. The export is session-scoped, so repeat it in each new
-deployment shell.
+published the image, and replace the digest placeholder with the lowercase
+OCI digest from the Docker Publish workflow summary. Tags such as `main` can
+move; the digest is the immutable deployment identity. The export is
+session-scoped, so repeat it in each new deployment shell.
 
 ```bash
-export IMAGE="ghcr.io/<your-org-or-username>/<your-repository>:main"
+export IMAGE="ghcr.io/<your-org-or-username>/<your-repository>@sha256:<64-lowercase-hex>"
 docker compose pull && docker compose up --no-build --wait --wait-timeout 180
 ```
 
 Public GHCR packages can be pulled anonymously. Private packages require the
 least-privilege login described in the full deployment guide.
+
+When `Docker Publish` is manually dispatched from `main` with deployment
+enabled, it binds the rollout to the workflow commit SHA and that run's build
+digest. The VM checks out the commit in detached mode, uses only the tracked
+`compose.yaml`, and verifies the running image reference and OCI revision before
+the deployment succeeds.
 
 ### Option 2: Build Yourself
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -45,6 +45,16 @@ This repository includes a GitHub Actions workflow that automatically:
 2.  **Validates** code quality via `ruff`, `mypy`, and `pytest` before building.
 3.  **Caches** build layers using GitHub Actions cache (`type=gha`) for ultra-fast rebuilds.
 4.  **Pushes** the image to **GitHub Container Registry (GHCR)**.
+5.  **Deploys only on explicit manual confirmation** from `main`, using the
+    exact workflow commit SHA and OCI digest produced by that run.
+
+The automated VM deployment treats `(workflow commit SHA, build digest)` as one
+provenance pair. Before changing the VM it validates both values, then checks
+out the commit in detached mode without resetting or cleaning operator files.
+It invokes only the tracked `compose.yaml` under an explicit project name and
+verifies both the running digest-qualified image reference and the image's OCI
+revision label. The immutable image reference is also written to the Docker
+Publish workflow summary.
 
 ### Using GHCR Images
 
@@ -62,12 +72,14 @@ printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u YOUR_GITHUB_USERNAME --passw
 ```
 
 Replace both placeholders below with the lowercase GitHub owner and repository
-whose workflow published the image. `IMAGE` selects the existing
-`${IMAGE:-agent}` Compose image contract; do not edit `compose.yaml`. The export
-is session-scoped, so repeat it in each new deployment shell.
+whose workflow published the image. Replace the digest placeholder with the
+lowercase digest from the Docker Publish workflow summary. `IMAGE` selects the
+existing `${IMAGE:-agent}` Compose image contract; do not edit `compose.yaml`.
+Tags such as `main` can move, while a digest selects one immutable OCI image.
+The export is session-scoped, so repeat it in each new deployment shell.
 
 ```bash
-export IMAGE="ghcr.io/<your-org-or-username>/<your-repository>:main"
+export IMAGE="ghcr.io/<your-org-or-username>/<your-repository>@sha256:<64-lowercase-hex>"
 docker compose pull && docker compose up --no-build --wait --wait-timeout 180
 ```
 

--- a/tests/test_deployment_docs.py
+++ b/tests/test_deployment_docs.py
@@ -8,7 +8,10 @@ import pytest
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 README_PATH = REPOSITORY_ROOT / "README.md"
 DEPLOYMENT_GUIDE_PATH = REPOSITORY_ROOT / "docs" / "DEPLOYMENT.md"
-IMAGE_EXPORT = 'export IMAGE="ghcr.io/<your-org-or-username>/<your-repository>:main"'
+IMAGE_EXPORT = (
+    'export IMAGE="ghcr.io/<your-org-or-username>/'
+    '<your-repository>@sha256:<64-lowercase-hex>"'
+)
 PREBUILT_DEPLOY_COMMAND = (
     "docker compose pull && docker compose up --no-build --wait --wait-timeout 180"
 )
@@ -47,6 +50,8 @@ def test_prebuilt_image_workflow_uses_configurable_compose_contract(
     assert "cloned repository" in document
     assert "`.env`" in document
     assert "lowercase" in document
+    assert "digest" in document
+    assert "immutable" in document
     assert "session-scoped" in document
     assert LOCAL_BUILD_COMMAND in document
 
@@ -61,6 +66,21 @@ def test_guides_remove_stale_registry_and_compose_edit_instructions() -> None:
     assert "docker pull " not in combined
     assert "update your `compose.yaml`" not in deployment_guide.casefold()
     assert "image: ghcr.io/" not in deployment_guide.casefold()
+
+
+def test_guides_document_exact_automated_deployment_provenance() -> None:
+    """Explain the commit-and-digest pair without promising mutable tags."""
+    readme = " ".join(README_PATH.read_text(encoding="utf-8").split())
+    deployment_guide = " ".join(
+        DEPLOYMENT_GUIDE_PATH.read_text(encoding="utf-8").split()
+    )
+
+    for document in (readme, deployment_guide):
+        assert "workflow commit SHA" in document
+        assert "build digest" in document
+        assert "detached mode" in document
+        assert "tracked `compose.yaml`" in document
+        assert "OCI revision" in document
 
 
 def test_private_registry_login_uses_least_privilege_stdin_contract() -> None:

--- a/tests/test_deployment_workflow.py
+++ b/tests/test_deployment_workflow.py
@@ -1,5 +1,8 @@
 """Deployment workflow safety contract tests."""
 
+import os
+import shlex
+import shutil
 import subprocess
 from pathlib import Path
 from typing import NamedTuple
@@ -19,6 +22,11 @@ EXPECTED_DEPLOY_CLAUSES = {
     "github.ref == 'refs/heads/main'",
     "inputs.deploy",
 }
+VALID_SHA = "a" * 40
+VALID_DIGEST = f"sha256:{'b' * 64}"
+EXPECTED_IMAGE = f"ghcr.io/mixedowner/mixed-repository@{VALID_DIGEST}"
+EXPECTED_ORIGIN = "https://github.com/MixedOwner/Mixed-Repository"
+EXPECTED_PROJECT = "adk-mixed-repository"
 SECRET_CANARIES = {
     "DATABASE_URL": "postgresql://user:p$UNSET@database/agent",
     "OPENROUTER_API_KEY": "$(printf command-substitution)",
@@ -35,7 +43,9 @@ class DeployHarness(NamedTuple):
 
     environment: dict[str, str]
     docker_log: Path
+    event_log: Path
     git_log: Path
+    git_state: Path
     home: Path
 
 
@@ -84,7 +94,7 @@ def _deploy_script(document: str) -> str:
 
 
 def _materialize_deploy_script(script: str) -> str:
-    """Replace GitHub expressions with deterministic non-secret values."""
+    """Replace non-provenance GitHub expressions with deterministic values."""
     replacements = {
         "${{ github.event.repository.name }}": "Mixed-Repository",
         "${{ github.repository }}": "MixedOwner/Mixed-Repository",
@@ -103,64 +113,168 @@ def _materialize_deploy_script(script: str) -> str:
     return script
 
 
+def _write_executable(path: Path, content: str) -> None:
+    """Write one executable fake boundary."""
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
 @pytest.fixture
 def deploy_harness(tmp_path: Path) -> DeployHarness:
-    """Provide fake Git and Docker executables on an isolated remote home."""
+    """Provide strict fake Git and Docker boundaries on an isolated host."""
     bin_directory = tmp_path / "bin"
     home = tmp_path / "home"
     docker_log = tmp_path / "docker.log"
+    event_log = tmp_path / "events.log"
     git_log = tmp_path / "git.log"
+    git_state = tmp_path / "git.state"
     bin_directory.mkdir()
     home.mkdir()
     docker_log.touch()
+    event_log.touch()
     git_log.touch()
 
-    git_path = bin_directory / "git"
-    git_path.write_text(
+    _write_executable(
+        bin_directory / "git",
         """#!/bin/sh
 set -eu
 
 printf '%s\\n' "$*" >> "$FAKE_GIT_LOG"
+printf 'git|%s\\n' "$*" >> "$FAKE_EVENT_LOG"
 
 case "$1" in
   clone)
-    mkdir -p "$3"
+    exit_code=${FAKE_GIT_CLONE_EXIT:-0}
+    [ "$exit_code" -eq 0 ] || exit "$exit_code"
+    mkdir -p "$3/.git"
     ;;
-  pull)
+  remote)
+    [ "${2:-}" = "get-url" ] && [ "${3:-}" = "origin" ] || exit 99
+    exit_code=${FAKE_GIT_REMOTE_EXIT:-0}
+    [ "$exit_code" -eq 0 ] || exit "$exit_code"
+    printf '%s\\n' "${FAKE_GIT_ORIGIN}"
+    ;;
+  diff)
+    if [ "${2:-}" = "--cached" ]; then
+      if [ -f "$FAKE_GIT_STATE" ]; then
+        exit "${FAKE_GIT_STAGED_AFTER_EXIT:-0}"
+      fi
+      exit "${FAKE_GIT_STAGED_BEFORE_EXIT:-0}"
+    fi
+    if [ -f "$FAKE_GIT_STATE" ]; then
+      exit "${FAKE_GIT_UNSTAGED_AFTER_EXIT:-0}"
+    fi
+    exit "${FAKE_GIT_UNSTAGED_BEFORE_EXIT:-0}"
+    ;;
+  fetch)
+    exit "${FAKE_GIT_FETCH_EXIT:-0}"
+    ;;
+  checkout)
+    exit_code=${FAKE_GIT_CHECKOUT_EXIT:-0}
+    [ "$exit_code" -eq 0 ] || exit "$exit_code"
+    : > "$FAKE_GIT_STATE"
+    ;;
+  rev-parse)
+    exit_code=${FAKE_GIT_REV_PARSE_EXIT:-0}
+    [ "$exit_code" -eq 0 ] || exit "$exit_code"
+    printf '%s\\n' "${FAKE_GIT_HEAD:-$DEPLOY_SHA}"
+    ;;
+  ls-files)
+    exit "${FAKE_GIT_LS_FILES_EXIT:-0}"
     ;;
   *)
     exit 99
     ;;
 esac
 """,
-        encoding="utf-8",
     )
-    git_path.chmod(0o755)
 
-    docker_path = bin_directory / "docker"
-    docker_path.write_text(
+    _write_executable(
+        bin_directory / "docker",
         """#!/bin/sh
 set -eu
 
 printf 'IMAGE=%s|%s\\n' "${IMAGE:-}" "$*" >> "$FAKE_DOCKER_LOG"
+printf 'docker|IMAGE=%s|%s\\n' "${IMAGE:-}" "$*" >> "$FAKE_EVENT_LOG"
 
-if [ "$1" = "compose" ] && [ "$2" = "pull" ]; then
-  exit "${FAKE_DOCKER_PULL_EXIT:-0}"
+if [ "$1" = "compose" ]; then
+  operation=${8:-}
+  case "$operation" in
+    config)
+      exit_code=${FAKE_DOCKER_CONFIG_EXIT:-0}
+      [ "$exit_code" -eq 0 ] || exit "$exit_code"
+      printf '%s\\n' "${FAKE_DOCKER_CONFIG_IMAGE:-$IMAGE}"
+      ;;
+    pull)
+      exit "${FAKE_DOCKER_PULL_EXIT:-0}"
+      ;;
+    up)
+      exit "${FAKE_DOCKER_UP_EXIT:-0}"
+      ;;
+    ps)
+      exit_code=${FAKE_DOCKER_PS_EXIT:-0}
+      [ "$exit_code" -eq 0 ] || exit "$exit_code"
+      printf '%s' "${FAKE_DOCKER_CONTAINER_ID-agent-container}"
+      ;;
+    *)
+      exit 98
+      ;;
+  esac
+  exit 0
 fi
+
+if [ "$1" = "inspect" ]; then
+  case "$5" in
+    *Config.Image*)
+      exit_code=${FAKE_DOCKER_CONFIG_INSPECT_EXIT:-0}
+      [ "$exit_code" -eq 0 ] || exit "$exit_code"
+      printf '%s\\n' "${FAKE_DOCKER_RUNNING_IMAGE:-$IMAGE}"
+      ;;
+    *.Image*)
+      exit_code=${FAKE_DOCKER_IMAGE_ID_EXIT:-0}
+      [ "$exit_code" -eq 0 ] || exit "$exit_code"
+      printf '%s\\n' "${FAKE_DOCKER_IMAGE_ID-sha256:platform-image}"
+      ;;
+    *)
+      exit 97
+      ;;
+  esac
+  exit 0
+fi
+
+if [ "$1" = "image" ] && [ "$2" = "inspect" ]; then
+  exit_code=${FAKE_DOCKER_REVISION_EXIT:-0}
+  [ "$exit_code" -eq 0 ] || exit "$exit_code"
+  printf '%s\\n' "${FAKE_DOCKER_REVISION:-$DEPLOY_SHA}"
+  exit 0
+fi
+
+if [ "$1" = "image" ] && [ "$2" = "prune" ]; then
+  exit "${FAKE_DOCKER_PRUNE_EXIT:-0}"
+fi
+
+exit 96
 """,
-        encoding="utf-8",
     )
-    docker_path.chmod(0o755)
 
     environment = {
         "FAKE_DOCKER_LOG": str(docker_log),
-        "FAKE_DOCKER_PULL_EXIT": "0",
+        "FAKE_EVENT_LOG": str(event_log),
         "FAKE_GIT_LOG": str(git_log),
+        "FAKE_GIT_ORIGIN": EXPECTED_ORIGIN,
+        "FAKE_GIT_STATE": str(git_state),
         "HOME": str(home),
         "LANG": "C",
         "PATH": f"{bin_directory}:/usr/bin:/bin",
     }
-    return DeployHarness(environment, docker_log, git_log, home)
+    return DeployHarness(
+        environment,
+        docker_log,
+        event_log,
+        git_log,
+        git_state,
+        home,
+    )
 
 
 def _run_deploy_script(
@@ -169,7 +283,14 @@ def _run_deploy_script(
     **environment_overrides: str,
 ) -> subprocess.CompletedProcess[str]:
     """Execute the materialized remote program against synthetic boundaries."""
-    environment = harness.environment | environment_overrides
+    environment = (
+        harness.environment
+        | {
+            "DEPLOY_SHA": VALID_SHA,
+            "IMAGE_DIGEST": VALID_DIGEST,
+        }
+        | environment_overrides
+    )
     return subprocess.run(  # noqa: S603 - execute the tracked trusted script
         ["/bin/sh"],
         input=_materialize_deploy_script(script),
@@ -199,6 +320,11 @@ def _evaluate_guard(
     assert len(clauses) == len(EXPECTED_DEPLOY_CLAUSES)
     assert set(clauses) == EXPECTED_DEPLOY_CLAUSES
     return all(outcomes[clause] for clause in clauses)
+
+
+def _workflow_script() -> str:
+    """Read the current remote deployment program."""
+    return _deploy_script(WORKFLOW_PATH.read_text(encoding="utf-8"))
 
 
 def test_workflow_exposes_explicit_deploy_confirmation() -> None:
@@ -232,71 +358,448 @@ def test_reusable_quality_call_grants_only_codecov_oidc_permissions() -> None:
     assert "packages: write" not in quality_block
 
 
-def test_remote_deploy_uses_lowercase_literal_secret_contract(
-    deploy_harness: DeployHarness,
-) -> None:
-    """Clone under HOME and deploy one lowercase image without expanding secrets."""
+def test_build_digest_is_passed_as_data_to_serialized_deploy() -> None:
+    """Bind the remote deployment to build output without script interpolation."""
     document = WORKFLOW_PATH.read_text(encoding="utf-8")
+    build_block = _indented_block(document, "build:", 2)
+    deploy_block = _indented_block(document, "deploy:", 2)
+    concurrency = _indented_block(deploy_block, "concurrency:", 4)
     script = _deploy_script(document)
-    image_assignment = next(
-        line for line in script.splitlines() if line.startswith("IMAGE_NAME=")
-    )
-    expected_assignment = (
-        "IMAGE_NAME=\"$(printf '%s' "
-        '"ghcr.io/${{ github.repository }}:main" '
-        "| tr '[:upper:]' '[:lower:]')\""
-    )
 
-    assert image_assignment == expected_assignment
-    assert script.splitlines()[0] == "set -eu"
-    assert script.index('export IMAGE="$IMAGE_NAME"') < script.index(
-        "docker compose pull"
-    )
-    assert script.index("docker compose pull") < script.index(
-        "docker compose up --no-build --wait --wait-timeout 180"
-    )
-    assert 'PROJECT_DIR="$HOME/$PROJECT_NAME"' in script
-    assert "cat <<'ENV_FILE' > .env" in script
+    assert "      digest: ${{ steps.build-push.outputs.digest }}" in build_block
+    assert "      - name: Record immutable image reference" in build_block
+    assert '            >> "$GITHUB_STEP_SUMMARY"' in build_block
+    assert "          DEPLOY_SHA: ${{ github.sha }}" in deploy_block
+    assert "          IMAGE_DIGEST: ${{ needs.build.outputs.digest }}" in deploy_block
+    assert "          envs: DEPLOY_SHA,IMAGE_DIGEST" in deploy_block
+    assert concurrency.splitlines() == [
+        "      group: production-deployment",
+        "      cancel-in-progress: false",
+        "      queue: max",
+    ]
+    assert "${{ github.sha }}" not in script
+    assert "${{ needs.build.outputs.digest }}" not in script
 
-    result = _run_deploy_script(script, deploy_harness)
+
+def test_remote_script_forbids_mutable_or_destructive_deploy_operations() -> None:
+    """Require detached provenance and one explicit Compose configuration."""
+    script = _workflow_script()
+
+    for forbidden in (
+        "git pull",
+        "git reset",
+        "git clean",
+        "checkout --force",
+        "checkout -f",
+        "ghcr.io/${{ github.repository }}:main",
+    ):
+        assert forbidden not in script
+
+    assert 'git checkout --detach "$DEPLOY_SHA"' in script
+    assert script.count('docker compose --project-name "$DEPLOY_PROJECT"') == 4
+    assert script.count("--env-file .env -f compose.yaml") == 4
+    assert script.count("docker inspect --type container") == 2
+
+
+def test_compose_resolves_one_exact_digest_without_repository_secrets(
+    tmp_path: Path,
+) -> None:
+    """Ask the real Compose parser to resolve the digest in an isolated copy."""
+    docker = shutil.which("docker")
+    if docker is None:
+        pytest.skip("Docker CLI is unavailable")
+
+    compose_path = WORKFLOW_PATH.parents[2] / "compose.yaml"
+    (tmp_path / "compose.yaml").write_text(
+        compose_path.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    environment = {
+        "COMPOSE_DISABLE_ENV_FILE": "1",
+        "HOME": os.environ.get("HOME", str(tmp_path)),
+        "IMAGE": EXPECTED_IMAGE,
+        "LANG": "C",
+        "PATH": os.environ["PATH"],
+    }
+
+    result = subprocess.run(  # noqa: S603 - resolved Docker, fixed arguments
+        [
+            docker,
+            "compose",
+            "--project-name",
+            EXPECTED_PROJECT,
+            "--env-file",
+            ".env",
+            "-f",
+            "compose.yaml",
+            "config",
+            "--images",
+        ],
+        cwd=tmp_path,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
 
     assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == [EXPECTED_IMAGE]
+
+
+@pytest.mark.parametrize(
+    ("field", "invalid_value"),
+    [
+        ("DEPLOY_SHA", ""),
+        ("DEPLOY_SHA", "a" * 39),
+        ("DEPLOY_SHA", "a" * 41),
+        ("DEPLOY_SHA", "A" * 40),
+        ("DEPLOY_SHA", "g" * 40),
+        ("DEPLOY_SHA", f"{'a' * 39}\n"),
+        ("DEPLOY_SHA", "$(touch should-not-run)"),
+        ("IMAGE_DIGEST", ""),
+        ("IMAGE_DIGEST", f"sha256:{'b' * 63}"),
+        ("IMAGE_DIGEST", f"sha256:{'b' * 65}"),
+        ("IMAGE_DIGEST", f"sha256:{'B' * 64}"),
+        ("IMAGE_DIGEST", f"sha256:{'g' * 64}"),
+        ("IMAGE_DIGEST", f"sha256:{'b' * 63}\n"),
+        ("IMAGE_DIGEST", f"sha512:{'b' * 64}"),
+        ("IMAGE_DIGEST", "b" * 64),
+        ("IMAGE_DIGEST", "$(touch should-not-run)"),
+    ],
+)
+def test_invalid_provenance_fails_before_side_effects(
+    deploy_harness: DeployHarness,
+    field: str,
+    invalid_value: str,
+) -> None:
+    """Reject malformed provenance as data before touching Git or Docker."""
+    sentinel = deploy_harness.home / "should-not-run"
+    value = invalid_value.replace("should-not-run", str(sentinel))
+
+    result = _run_deploy_script(
+        _workflow_script(),
+        deploy_harness,
+        **{field: value},
+    )
+
+    assert result.returncode != 0
+    assert "ERROR: Invalid " in result.stdout
+    assert deploy_harness.git_log.read_text(encoding="utf-8") == ""
+    assert deploy_harness.docker_log.read_text(encoding="utf-8") == ""
+    assert not (deploy_harness.home / "Mixed-Repository").exists()
+    assert not sentinel.exists()
+
+
+@pytest.mark.parametrize("existing_checkout", [False, True])
+def test_remote_deploy_uses_exact_commit_digest_and_literal_secrets(
+    deploy_harness: DeployHarness,
+    existing_checkout: bool,
+) -> None:
+    """Deploy one exact revision and preserve shell-sensitive secret bytes."""
     project_directory = deploy_harness.home / "Mixed-Repository"
-    assert project_directory.is_dir()
-    assert deploy_harness.git_log.read_text(encoding="utf-8").splitlines() == [
-        (f"clone https://github.com/MixedOwner/Mixed-Repository {project_directory}"),
-        "pull",
+    if existing_checkout:
+        (project_directory / ".git").mkdir(parents=True)
+
+    result = _run_deploy_script(_workflow_script(), deploy_harness)
+
+    assert result.returncode == 0, result.stderr
+    git_commands = deploy_harness.git_log.read_text(encoding="utf-8").splitlines()
+    expected_after_clone = [
+        "remote get-url origin",
+        "diff --quiet --",
+        "diff --cached --quiet --",
+        f"fetch --no-tags origin {VALID_SHA}",
+        f"checkout --detach {VALID_SHA}",
+        "rev-parse --verify HEAD",
+        "diff --quiet --",
+        "diff --cached --quiet --",
+        "ls-files --error-unmatch -- compose.yaml",
     ]
+    if existing_checkout:
+        assert git_commands == expected_after_clone
+    else:
+        assert git_commands == [
+            f"clone {EXPECTED_ORIGIN} {project_directory}",
+            *expected_after_clone,
+        ]
+
+    compose_prefix = (
+        f"compose --project-name {EXPECTED_PROJECT} --env-file .env -f compose.yaml"
+    )
     assert deploy_harness.docker_log.read_text(encoding="utf-8").splitlines() == [
-        ("IMAGE=ghcr.io/mixedowner/mixed-repository:main|compose pull"),
+        f"IMAGE={EXPECTED_IMAGE}|{compose_prefix} config --images",
+        f"IMAGE={EXPECTED_IMAGE}|{compose_prefix} pull agent",
         (
-            "IMAGE=ghcr.io/mixedowner/mixed-repository:main|"
-            "compose up --no-build --wait --wait-timeout 180"
+            f"IMAGE={EXPECTED_IMAGE}|{compose_prefix} "
+            "up --no-build --wait --wait-timeout 180 agent"
         ),
-        ("IMAGE=ghcr.io/mixedowner/mixed-repository:main|image prune -f"),
+        f"IMAGE={EXPECTED_IMAGE}|{compose_prefix} ps --quiet agent",
+        (
+            f"IMAGE={EXPECTED_IMAGE}|inspect --type container "
+            "--format {{.Config.Image}} agent-container"
+        ),
+        (
+            f"IMAGE={EXPECTED_IMAGE}|inspect --type container "
+            "--format {{.Image}} agent-container"
+        ),
+        (
+            f"IMAGE={EXPECTED_IMAGE}|image inspect --format "
+            '{{ index .Config.Labels "org.opencontainers.image.revision" }} '
+            "sha256:platform-image"
+        ),
+        f"IMAGE={EXPECTED_IMAGE}|image prune -f",
     ]
     environment_document = (project_directory / ".env").read_text(encoding="utf-8")
     for secret_value in SECRET_CANARIES.values():
         assert secret_value in environment_document
 
 
-def test_remote_deploy_stops_after_failed_pull(
+def test_remote_deploy_checks_out_real_git_commit_detached(
     deploy_harness: DeployHarness,
+    tmp_path: Path,
 ) -> None:
-    """Propagate a pull failure without starting a stale image or pruning."""
-    document = WORKFLOW_PATH.read_text(encoding="utf-8")
-    script = _deploy_script(document)
+    """Independently prove the tracked program reaches an exact detached commit."""
+    real_git = shutil.which("git")
+    assert real_git is not None
 
-    result = _run_deploy_script(
-        script,
-        deploy_harness,
-        FAKE_DOCKER_PULL_EXIT="23",
+    remote = tmp_path / "remote.git"
+    seed = tmp_path / "seed"
+    project = deploy_harness.home / "Mixed-Repository"
+    git_environment = {
+        "HOME": str(deploy_harness.home),
+        "LANG": "C",
+        "PATH": "/usr/bin:/bin",
+    }
+
+    def run_git(*arguments: str, cwd: Path | None = None) -> str:
+        result = subprocess.run(  # noqa: S603 - resolved Git, controlled arguments
+            [real_git, *arguments],
+            cwd=cwd,
+            env=git_environment,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        return result.stdout.strip()
+
+    run_git("init", "--bare", str(remote))
+    run_git("init", str(seed))
+    run_git("-C", str(seed), "config", "user.email", "test@example.com")
+    run_git("-C", str(seed), "config", "user.name", "Test Author")
+    tracked_file = seed / "tracked.txt"
+    tracked_file.write_text("first\n", encoding="utf-8")
+    (seed / "compose.yaml").write_text(
+        "services:\n  agent:\n    image: agent\n",
+        encoding="utf-8",
+    )
+    run_git("-C", str(seed), "add", "tracked.txt", "compose.yaml")
+    run_git("-C", str(seed), "commit", "-m", "first")
+    run_git("-C", str(seed), "remote", "add", "origin", str(remote))
+    run_git("-C", str(seed), "push", "origin", "HEAD:main")
+    run_git("--git-dir", str(remote), "symbolic-ref", "HEAD", "refs/heads/main")
+    run_git("clone", str(remote), str(project))
+    run_git("-C", str(project), "remote", "set-url", "origin", EXPECTED_ORIGIN)
+
+    tracked_file.write_text("second\n", encoding="utf-8")
+    run_git("-C", str(seed), "add", "tracked.txt")
+    run_git("-C", str(seed), "commit", "-m", "second")
+    target_sha = run_git("-C", str(seed), "rev-parse", "HEAD")
+    run_git("-C", str(seed), "push", "origin", "HEAD:main")
+
+    real_bin = tmp_path / "real-bin"
+    real_bin.mkdir()
+    shutil.copy2(
+        Path(deploy_harness.environment["PATH"].split(":", maxsplit=1)[0]) / "docker",
+        real_bin / "docker",
+    )
+    _write_executable(
+        real_bin / "git",
+        f"""#!/bin/sh
+set -eu
+if [ "$1" = "fetch" ] && [ "$2" = "--no-tags" ] && [ "$3" = "origin" ]; then
+  exec {shlex.quote(real_git)} fetch --no-tags {shlex.quote(str(remote))} "$4"
+fi
+exec {shlex.quote(real_git)} "$@"
+""",
     )
 
-    assert result.returncode == 23
-    assert deploy_harness.docker_log.read_text(encoding="utf-8").splitlines() == [
-        ("IMAGE=ghcr.io/mixedowner/mixed-repository:main|compose pull")
-    ]
+    result = _run_deploy_script(
+        _workflow_script(),
+        deploy_harness,
+        DEPLOY_SHA=target_sha,
+        PATH=f"{real_bin}:/usr/bin:/bin",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert run_git("-C", str(project), "rev-parse", "HEAD") == target_sha
+    symbolic_ref = subprocess.run(  # noqa: S603 - resolved Git, controlled arguments
+        [real_git, "-C", str(project), "symbolic-ref", "--quiet", "HEAD"],
+        env=git_environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert symbolic_ref.returncode == 1
+    assert (project / "tracked.txt").read_text(encoding="utf-8") == "second\n"
+
+
+def test_remote_deploy_accepts_equivalent_dot_git_origin(
+    deploy_harness: DeployHarness,
+) -> None:
+    """Allow Git's conventional suffix without accepting another repository."""
+    project_directory = deploy_harness.home / "Mixed-Repository"
+    (project_directory / ".git").mkdir(parents=True)
+
+    result = _run_deploy_script(
+        _workflow_script(),
+        deploy_harness,
+        FAKE_GIT_ORIGIN=f"{EXPECTED_ORIGIN}.git",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_remote_deploy_rejects_non_git_project_path(
+    deploy_harness: DeployHarness,
+) -> None:
+    """Never overwrite an operator-owned path that is not this checkout."""
+    project_directory = deploy_harness.home / "Mixed-Repository"
+    project_directory.mkdir()
+    sentinel = project_directory / "operator-owned"
+    sentinel.write_text("preserve\n", encoding="utf-8")
+
+    result = _run_deploy_script(_workflow_script(), deploy_harness)
+
+    assert result.returncode != 0
+    assert "path exists without a Git checkout" in result.stdout
+    assert deploy_harness.git_log.read_text(encoding="utf-8") == ""
+    assert deploy_harness.docker_log.read_text(encoding="utf-8") == ""
+    assert sentinel.read_text(encoding="utf-8") == "preserve\n"
+
+
+def test_remote_deploy_rejects_untracked_only_compose_file(
+    deploy_harness: DeployHarness,
+) -> None:
+    """Do not let a host file replace config deleted by the exact commit."""
+    project_directory = deploy_harness.home / "Mixed-Repository"
+    (project_directory / ".git").mkdir(parents=True)
+    untracked_compose = project_directory / "compose.yaml"
+    untracked_compose.write_text("operator-owned\n", encoding="utf-8")
+
+    result = _run_deploy_script(
+        _workflow_script(),
+        deploy_harness,
+        FAKE_GIT_LS_FILES_EXIT="1",
+    )
+
+    assert result.returncode != 0
+    assert "does not track compose.yaml" in result.stdout
+    assert deploy_harness.docker_log.read_text(encoding="utf-8") == ""
+    assert not (project_directory / ".env").exists()
+    assert untracked_compose.read_text(encoding="utf-8") == "operator-owned\n"
+
+
+@pytest.mark.parametrize(
+    ("environment", "expected_message", "forbidden_event"),
+    [
+        (
+            {"FAKE_GIT_ORIGIN": "https://github.com/other/repository"},
+            "unexpected origin",
+            "git|fetch",
+        ),
+        (
+            {"FAKE_GIT_UNSTAGED_BEFORE_EXIT": "31"},
+            "Tracked worktree changes",
+            "git|fetch",
+        ),
+        (
+            {"FAKE_GIT_STAGED_BEFORE_EXIT": "32"},
+            "Staged changes",
+            "git|fetch",
+        ),
+        (
+            {"FAKE_GIT_HEAD": "c" * 40},
+            "Checked-out commit does not match",
+            "docker|",
+        ),
+        (
+            {"FAKE_GIT_UNSTAGED_AFTER_EXIT": "33"},
+            "Checkout left tracked",
+            "docker|",
+        ),
+        (
+            {"FAKE_GIT_STAGED_AFTER_EXIT": "34"},
+            "Checkout left staged",
+            "docker|",
+        ),
+    ],
+)
+def test_checkout_provenance_failures_stop_before_docker(
+    deploy_harness: DeployHarness,
+    environment: dict[str, str],
+    expected_message: str,
+    forbidden_event: str,
+) -> None:
+    """Keep unrelated origins, dirty trees, and SHA drift out of deployment."""
+    project_directory = deploy_harness.home / "Mixed-Repository"
+    (project_directory / ".git").mkdir(parents=True)
+    existing_env = project_directory / ".env"
+    existing_env.write_text("operator-owned\n", encoding="utf-8")
+
+    result = _run_deploy_script(
+        _workflow_script(),
+        deploy_harness,
+        **environment,
+    )
+
+    assert result.returncode != 0
+    assert expected_message in result.stdout
+    assert forbidden_event not in deploy_harness.event_log.read_text(encoding="utf-8")
+    assert existing_env.read_text(encoding="utf-8") == "operator-owned\n"
+
+
+@pytest.mark.parametrize(
+    ("environment", "forbidden_fragment"),
+    [
+        ({"FAKE_GIT_CLONE_EXIT": "40"}, "git|remote"),
+        ({"FAKE_GIT_FETCH_EXIT": "41"}, "git|checkout"),
+        ({"FAKE_GIT_CHECKOUT_EXIT": "42"}, "git|rev-parse"),
+        ({"FAKE_GIT_REV_PARSE_EXIT": "43"}, "docker|"),
+        ({"FAKE_DOCKER_CONFIG_EXIT": "51"}, " pull agent"),
+        ({"FAKE_DOCKER_CONFIG_IMAGE": "ghcr.io/other@sha256:bad"}, " pull agent"),
+        ({"FAKE_DOCKER_PULL_EXIT": "52"}, " up --no-build"),
+        ({"FAKE_DOCKER_UP_EXIT": "53"}, " ps --quiet agent"),
+        ({"FAKE_DOCKER_PS_EXIT": "54"}, "inspect --type container"),
+        ({"FAKE_DOCKER_CONTAINER_ID": ""}, "inspect --type container"),
+        ({"FAKE_DOCKER_CONFIG_INSPECT_EXIT": "55"}, "format {{.Image}}"),
+        (
+            {"FAKE_DOCKER_RUNNING_IMAGE": "ghcr.io/other@sha256:bad"},
+            "format {{.Image}}",
+        ),
+        ({"FAKE_DOCKER_IMAGE_ID_EXIT": "56"}, "image inspect"),
+        ({"FAKE_DOCKER_IMAGE_ID": ""}, "image inspect"),
+        ({"FAKE_DOCKER_REVISION_EXIT": "57"}, "image prune"),
+        ({"FAKE_DOCKER_REVISION": "d" * 40}, "image prune"),
+    ],
+)
+def test_deploy_boundary_failure_stops_later_actions(
+    deploy_harness: DeployHarness,
+    environment: dict[str, str],
+    forbidden_fragment: str,
+) -> None:
+    """Propagate each external failure without continuing or pruning."""
+    result = _run_deploy_script(
+        _workflow_script(),
+        deploy_harness,
+        **environment,
+    )
+
+    assert result.returncode != 0
+    assert forbidden_fragment not in deploy_harness.event_log.read_text(
+        encoding="utf-8"
+    )
+    assert "image prune -f" not in deploy_harness.docker_log.read_text(encoding="utf-8")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What

Bind every manually approved VM deployment to the exact workflow commit and
multi-platform GHCR digest produced by that run.

## Why

The build already produced an immutable OCI digest, but deployment discarded it
and pulled the mutable `:main` tag while `git pull` independently moved the
remote Compose configuration. The VM could therefore run bytes or configuration
different from the artifact that passed CI.

## How

- Export the Build Push Action digest and record the immutable image URI in the
  workflow summary.
- Validate the 40-character commit SHA and `sha256:` digest on both the runner
  and VM before deployment side effects.
- Queue approved production jobs without canceling running or pending deploys.
- Reject unrelated origins, staged or unstaged tracked changes, SHA drift, and
  a `compose.yaml` not tracked by the exact commit.
- Fetch and check out the exact commit in detached mode without pull, reset,
  clean, or forced checkout.
- Run only the tracked Compose file under an explicit project name and deploy
  only the lowercase digest-qualified GHCR image.
- Verify the container's configured image and the actual platform image's OCI
  revision label before pruning.
- Document immutable manual and automated deployment behavior.

## Tests

- [x] `uv sync --locked`
- [x] `uv run ruff format`
- [x] `uv run ruff format --check`
- [x] `uv run ruff check --no-fix --output-format=github`
- [x] `uv run mypy .`
- [x] `uv run pytest --cov=src --cov-report=xml --cov-report=term-missing`
- [x] 456 tests passed, 4 local PostgreSQL-service tests skipped, 100%
      statement and branch coverage
- [x] Real Git integration fetched and checked out the exact detached commit
- [x] Real daemon-free Compose resolution returned one exact digest image
- [x] PR Code Quality
- [x] PR Compose Smoke

No model evaluation applies because this changes deterministic deployment
provenance, not prompts, tools, models, or agent responses.

## Related Issues

Closes #101
