### PR TITLE
feat: add truthful readiness probes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,8 @@ DATABASE_URL=postgresql://user:pass@host:port/dbname?ssl=require
 DB_READY_TIMEOUT=60
 DB_READY_RETRY_INTERVAL=1
 DB_READY_ATTEMPT_TIMEOUT=5
+# Bound each recurring HTTP PostgreSQL readiness probe below its 3s client
+DB_READINESS_PROBE_TIMEOUT=2
 DB_POOL_PRE_PING=true
 DB_POOL_RECYCLE=1800
 DB_POOL_SIZE=5

--- a/README.md
+++ b/README.md
@@ -89,8 +89,18 @@ docker compose up --build --wait --wait-timeout 180
 ```
 
 The bounded `--wait` command returns only after the agent's container
-healthcheck passes, so scripts can distinguish a healthy startup from a
-container that merely started.
+healthcheck passes. Compose calls `/ready`, which runs one bounded PostgreSQL
+`SELECT 1` whenever `DATABASE_URL` is configured. Without PostgreSQL it reports
+`database: not_configured` and remains ready for local, in-memory, or Agent
+Engine-only development.
+
+`/live` and ADK's existing `/health` endpoint are process-only. Use `/ready` for
+traffic admission and deployment waits. It proves fresh PostgreSQL connectivity
+only—not ADK pool capacity, Agent Engine, model/provider, tool, or post-start
+artifact health.
+
+Keep `/ready` internal or behind authenticated, rate-limited ingress because
+each call opens one short-lived database connection.
 
 ## Artifact persistence
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -32,7 +32,7 @@ services:
           import urllib.request;
           urllib.request.build_opener(
           urllib.request.ProxyHandler({})).open(
-          "http://127.0.0.1:8080/health", timeout=3).read()
+          "http://127.0.0.1:8080/ready", timeout=3).read()
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -108,11 +108,30 @@ Best if you don't want to manage Python versions on the host.
     docker compose up --build --wait --wait-timeout 180
     ```
 
-The Compose healthcheck calls the agent's process-level `/health` endpoint from
-inside the container. `--wait` exits successfully only after the service becomes
-healthy; `--wait-timeout` prevents an unhealthy startup from hanging automation
-indefinitely. When `DATABASE_URL` is configured, the entrypoint first runs a
-bounded `SELECT 1` readiness check before starting the server.
+The Compose healthcheck calls `/ready` from inside the container. When
+`DATABASE_URL` is configured, every call opens one bounded connection and runs
+`SELECT 1`; a failed connection, authentication, query, or close returns HTTP
+503. When PostgreSQL is not configured, the response explicitly reports
+`database: not_configured` and remains ready for local, in-memory, or Agent
+Engine-only development. `--wait` exits successfully only after this contract
+passes, while `--wait-timeout` prevents an unhealthy startup from hanging
+automation.
+
+Use `/live` for process-only liveness. ADK's existing `/health` endpoint remains
+a process-only compatibility route. Neither process endpoint checks PostgreSQL.
+The database readiness attempt defaults to two seconds, which is shorter than
+the healthcheck client's three-second HTTP timeout.
+
+This is deliberately a PostgreSQL connectivity check, not a claim that every
+dependency is healthy. It does not prove spare capacity in ADK's internal
+SQLAlchemy pool, schema permissions beyond `SELECT 1`, Agent Engine
+reachability, model/provider availability, tool health, or artifact capacity
+after startup.
+
+Each `/ready` request creates a short-lived database connection and each failure
+emits one generic warning. Keep the endpoint on the loopback/internal operations
+path. If an ingress exposes it, require authentication and rate limiting so
+untrusted callers cannot amplify connection or log load.
 
 ## Artifact Storage Contract
 
@@ -125,9 +144,9 @@ directory at startup. The image and Compose service pin `AGENT_DIR` to
 recreation. PostgreSQL remains the separate session store.
 
 Startup creates the artifact directory when needed and probes create, write,
-flush, sync, unlink, and directory-cleanup access before serving `/health`. If
-the directory is unusable, startup exits non-zero and reports the stable public
-message `Artifact storage is unavailable.` It does not silently select
+flush, sync, unlink, and directory-cleanup access before starting the server.
+If the directory is unusable, startup exits non-zero and reports the stable
+public message `Artifact storage is unavailable.` It does not silently select
 in-memory artifact storage.
 
 The supported server entrypoints are `python -m agent.server` and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,14 +12,29 @@ Google ADK is useful even without Google Cloud:
 
 - **Entry point**: `python -m agent.server`
   - Wraps `google.adk.cli.fast_api.get_fast_api_app(...)`
-  - Forces a Postgres-backed session store via `DATABASE_URL`
+  - Uses a Postgres-backed session store when `DATABASE_URL` is configured
   - Configures OpenTelemetry for vendor-neutral tracing (Langfuse auto-config included)
 - **Agents directory**: `src/`
   - ADK Dev UI lists *directories* under `agents_dir`.
 - **Main Agent**: `src/agent/agent.py`
   - Contains `root_agent` to keep ADK discovery simple.
-- **DB URL normalization**: Handled in `server.py`
-  - Converts standard Postgres URLs (e.g. `postgresql://`) to asyncpg-compatible ones (`postgresql+asyncpg://`)
+- **DB URL normalization**: Shared by startup and HTTP readiness
+  - Gives direct asyncpg and ADK's SQLAlchemy service compatible forms of the
+    same validated PostgreSQL URL
+
+### Runtime health contracts
+
+- `/health` is ADK's unchanged process-level compatibility endpoint.
+- `/live` is the template's explicit process-only endpoint and performs no
+  external calls.
+- `/ready` performs one bounded fresh `SELECT 1` when PostgreSQL is configured.
+  Without PostgreSQL it reports `database: not_configured`.
+
+Compose probes `/ready`, so a later PostgreSQL outage changes container health
+without pretending the process has died. The readiness check intentionally does
+not create another persistent connection pool. It proves current PostgreSQL
+connectivity and credentials, not ADK pool capacity, schema compatibility,
+Agent Engine, models, tools, or artifact capacity after startup.
 
 ### What ADK uses the database for
 

--- a/docs/base-infra/docker-compose-workflow.md
+++ b/docs/base-infra/docker-compose-workflow.md
@@ -63,8 +63,15 @@ docker compose up --build --wait --wait-timeout 180
 ```
 
 The healthcheck uses Python's standard HTTP client inside the container to call
-`/health`. It reports process liveness after the container entrypoint has
-completed its bounded database readiness check when `DATABASE_URL` is configured.
+`/ready`. With `DATABASE_URL`, each call runs one bounded PostgreSQL `SELECT 1`
+and returns HTTP 503 when that check fails. Without PostgreSQL it reports
+`database: not_configured` and succeeds. `/live` and ADK's compatibility
+`/health` route are process-only and are not used by Compose.
+
+The recurring database probe defaults to two seconds, below the client's
+three-second HTTP timeout and the container healthcheck's five-second timeout.
+It verifies fresh PostgreSQL connectivity only; it does not inspect ADK's
+internal pool, Agent Engine, models, tools, or post-start artifact capacity.
 
 ---
 

--- a/docs/base-infra/environment-variables.md
+++ b/docs/base-infra/environment-variables.md
@@ -39,6 +39,22 @@ following bounds:
 - **Default:** `5`
 - **Purpose:** Maximum seconds for one connection, query, and close attempt
 
+**DB_READINESS_PROBE_TIMEOUT**
+- **Default:** `2`
+- **Range:** Greater than `0` and at most `2`
+- **Purpose:** Maximum seconds for one recurring `/ready` PostgreSQL attempt
+
+The HTTP readiness budget is separate from startup retries and is always
+shorter than the Compose client's three-second timeout. `/ready` performs one
+fresh authenticated `SELECT 1` without retrying. A failure returns HTTP 503
+without returning or logging the database URL, credentials, database name, or
+exception text.
+
+`/ready` reports only PostgreSQL connectivity. It does not verify ADK's internal
+SQLAlchemy pool or schema permissions beyond `SELECT 1`, Agent Engine, the model
+provider, tools, or artifact capacity after startup. `/live` and ADK's legacy
+`/health` route are process-only.
+
 ### API Keys
 
 **GOOGLE_API_KEY**

--- a/src/agent/database.py
+++ b/src/agent/database.py
@@ -1,0 +1,52 @@
+"""Shared PostgreSQL connectivity checks."""
+
+from __future__ import annotations
+
+import asyncio
+import math
+from contextlib import suppress
+
+import asyncpg  # type: ignore[import-untyped]
+
+from .utils.config import _normalize_asyncpg_database_url
+
+
+def _require_positive_finite(name: str, value: float) -> None:
+    """Reject invalid timing without including the supplied value."""
+    if not math.isfinite(value) or value <= 0:
+        msg = f"{name} must be a positive finite number"
+        raise ValueError(msg)
+
+
+def normalize_database_url(database_url: str) -> str:
+    """Normalize a supported PostgreSQL URL for direct asyncpg use."""
+    return _normalize_asyncpg_database_url(database_url)
+
+
+async def check_database(
+    database_url: str,
+    *,
+    attempt_timeout: float,
+) -> None:
+    """Connect, run the readiness query, and close within one bounded attempt."""
+    _require_positive_finite("attempt_timeout", attempt_timeout)
+
+    connection: asyncpg.Connection | None = None
+    try:
+        async with asyncio.timeout(attempt_timeout):
+            connection = await asyncpg.connect(
+                database_url,
+                timeout=attempt_timeout,
+                command_timeout=attempt_timeout,
+            )
+            result = await connection.fetchval("SELECT 1", timeout=attempt_timeout)
+            if result != 1:
+                msg = "Database readiness query returned an unexpected result"
+                raise RuntimeError(msg)
+            await connection.close(timeout=attempt_timeout)
+            connection = None
+    except BaseException:
+        if connection is not None:
+            with suppress(Exception):
+                connection.terminate()
+        raise

--- a/src/agent/health.py
+++ b/src/agent/health.py
@@ -1,0 +1,73 @@
+"""Truthful process liveness and database readiness probes."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi.responses import JSONResponse
+from pydantic import SecretStr
+
+from .database import (
+    _require_positive_finite,
+    check_database,
+    normalize_database_url,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def live() -> dict[str, str]:
+    """Report process liveness without checking external dependencies."""
+    return {"status": "alive"}
+
+
+class DatabaseReadinessProbe:
+    """Report whether the configured PostgreSQL dependency is ready."""
+
+    def __init__(
+        self,
+        database_url: SecretStr | None,
+        *,
+        attempt_timeout: float,
+    ) -> None:
+        _require_positive_finite("attempt_timeout", attempt_timeout)
+        self._database_url = (
+            SecretStr(normalize_database_url(database_url.get_secret_value()))
+            if database_url is not None
+            else None
+        )
+        self._attempt_timeout = attempt_timeout
+
+    async def __call__(self) -> JSONResponse:
+        """Run one bounded database check and return a stable public contract."""
+        if self._database_url is None:
+            return JSONResponse(
+                status_code=200,
+                content={
+                    "status": "ready",
+                    "checks": {"database": "not_configured"},
+                },
+            )
+
+        try:
+            await check_database(
+                self._database_url.get_secret_value(),
+                attempt_timeout=self._attempt_timeout,
+            )
+        except Exception:
+            logger.warning("Database readiness check failed.")
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "status": "not_ready",
+                    "checks": {"database": "unavailable"},
+                },
+            )
+
+        return JSONResponse(
+            status_code=200,
+            content={
+                "status": "ready",
+                "checks": {"database": "healthy"},
+            },
+        )

--- a/src/agent/pre_start.py
+++ b/src/agent/pre_start.py
@@ -4,16 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import errno
-import math
 import os
 import signal
 import socket
 import sys
-from contextlib import suppress
 from types import FrameType
 from typing import NoReturn
 
-import asyncpg  # type: ignore[import-untyped]
+import asyncpg as asyncpg  # type: ignore[import-untyped]
 from tenacity import (
     AsyncRetrying,
     retry_if_exception,
@@ -21,8 +19,12 @@ from tenacity import (
     wait_fixed,
 )
 
+from .database import (
+    _require_positive_finite,
+    check_database,
+    normalize_database_url,
+)
 from .utils import DatabaseReadinessEnv
-from .utils.config import _normalize_asyncpg_database_url
 
 _TRANSIENT_DATABASE_ERROR_TYPES = (
     ConnectionError,
@@ -51,13 +53,6 @@ _TRANSIENT_NETWORK_ERRNOS = frozenset(
 )
 
 
-def _require_positive_finite(name: str, value: float) -> None:
-    """Reject invalid retry timing without including the supplied value."""
-    if not math.isfinite(value) or value <= 0:
-        msg = f"{name} must be a positive finite number"
-        raise ValueError(msg)
-
-
 def _is_transient_database_error(error: BaseException) -> bool:
     """Return whether a failure can plausibly recover during VM startup."""
     if isinstance(error, _TRANSIENT_DATABASE_ERROR_TYPES):
@@ -65,40 +60,6 @@ def _is_transient_database_error(error: BaseException) -> bool:
     return type(error) is OSError and (
         error.errno is None or error.errno in _TRANSIENT_NETWORK_ERRNOS
     )
-
-
-def normalize_database_url(database_url: str) -> str:
-    """Normalize a supported PostgreSQL URL for direct asyncpg use."""
-    return _normalize_asyncpg_database_url(database_url)
-
-
-async def check_database(
-    database_url: str,
-    *,
-    attempt_timeout: float,
-) -> None:
-    """Connect, run the readiness query, and close within one bounded attempt."""
-    _require_positive_finite("attempt_timeout", attempt_timeout)
-
-    connection: asyncpg.Connection | None = None
-    try:
-        async with asyncio.timeout(attempt_timeout):
-            connection = await asyncpg.connect(
-                database_url,
-                timeout=attempt_timeout,
-                command_timeout=attempt_timeout,
-            )
-            result = await connection.fetchval("SELECT 1", timeout=attempt_timeout)
-            if result != 1:
-                msg = "Database readiness query returned an unexpected result"
-                raise RuntimeError(msg)
-            await connection.close(timeout=attempt_timeout)
-            connection = None
-    except BaseException:
-        if connection is not None:
-            with suppress(Exception):
-                connection.terminate()
-        raise
 
 
 async def wait_for_database(

--- a/src/agent/server.py
+++ b/src/agent/server.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import uvicorn
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 from google.adk.cli.fast_api import get_fast_api_app
 from openinference.instrumentation.google_adk import GoogleADKInstrumentor
 
@@ -18,6 +19,7 @@ from .artifact_storage import (
     ArtifactStorageError,
     prepare_artifact_storage,
 )
+from .health import DatabaseReadinessProbe, live
 from .utils import (
     ObservabilityEnv,
     ServerEnv,
@@ -27,15 +29,6 @@ from .utils import (
 )
 
 logger = logging.getLogger("agent.server")
-
-
-async def health() -> dict[str, str]:
-    """Health check endpoint for container orchestration.
-
-    Returns:
-        dict with status key indicating service health
-    """
-    return {"status": "ok"}
 
 
 def create_app(env: ServerEnv | None = None) -> FastAPI:
@@ -78,7 +71,17 @@ def create_app(env: ServerEnv | None = None) -> FastAPI:
         web=server_env.serve_web_interface,
         reload_agents=server_env.reload_agents,
     )
-    app.get("/health")(health)
+    readiness_probe = DatabaseReadinessProbe(
+        database_url=server_env.database_url,
+        attempt_timeout=server_env.db_readiness_probe_timeout,
+    )
+
+    async def ready() -> JSONResponse:
+        """Report configured PostgreSQL connectivity readiness."""
+        return await readiness_probe()
+
+    app.get("/live")(live)
+    app.get("/ready")(ready)
     return app
 
 
@@ -100,6 +103,7 @@ def main() -> None:
         RELOAD_AGENTS: Whether to reload agents on file changes (true/false)
         AGENT_ENGINE: Agent Engine instance for session and memory
         DATABASE_URL: Postgres URL for session and memory
+        DB_READINESS_PROBE_TIMEOUT: Maximum seconds for one HTTP database probe
         OPENROUTER_API_KEY: Key for LiteLLM/OpenRouter
         ALLOW_ORIGINS: JSON array string of allowed CORS origins
         HOST: Server host (default: 127.0.0.1, set to 0.0.0.0 for containers)

--- a/src/agent/utils/config.py
+++ b/src/agent/utils/config.py
@@ -35,6 +35,7 @@ _EXAMPLE_SECRET_VALUES = {
 }
 _DATABASE_READINESS_MAX_TIMEOUT = 3600.0
 _DATABASE_READINESS_MAX_INTERVAL = 60.0
+_DATABASE_READINESS_MAX_PROBE_TIMEOUT = 2.0
 _SHARED_ASYNCPG_QUERY_KEYS = frozenset(
     {
         "gsslib",
@@ -482,6 +483,7 @@ class ServerEnv(RedactedBaseSettings):
         reload_agents: Whether to reload agents on file changes (local dev only).
         agent_engine: Agent Engine instance ID for session and memory persistence.
         database_url: Database URL used for persistent session storage.
+        db_readiness_probe_timeout: Maximum duration of an HTTP readiness query.
         openrouter_api_key: OpenRouter key validated before server startup.
         allow_origins: JSON array string of allowed CORS origins.
         host: Server host (127.0.0.1 for local, 0.0.0.0 for containers).
@@ -523,6 +525,14 @@ class ServerEnv(RedactedBaseSettings):
         default=None,
         alias="DATABASE_URL",
         description="Database URL for session storage (e.g., postgresql://...)",
+    )
+
+    db_readiness_probe_timeout: float = Field(
+        default=2.0,
+        alias="DB_READINESS_PROBE_TIMEOUT",
+        gt=0,
+        le=_DATABASE_READINESS_MAX_PROBE_TIMEOUT,
+        description="Maximum seconds for one HTTP database readiness probe",
     )
 
     db_pool_pre_ping: bool = Field(
@@ -621,6 +631,7 @@ class ServerEnv(RedactedBaseSettings):
         masked_database_url = str(self.database_url) if self.database_url else None
         print(f"DATABASE_URL:          {masked_database_url}")
         if self.database_url:
+            print(f"DB_READINESS_PROBE_TIMEOUT: {self.db_readiness_probe_timeout}")
             print(f"DB_POOL_PRE_PING:      {self.db_pool_pre_ping}")
             print(f"DB_POOL_RECYCLE:       {self.db_pool_recycle}")
             print(f"DB_POOL_SIZE:          {self.db_pool_size}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -402,6 +402,7 @@ def clean_environment(monkeypatch: pytest.MonkeyPatch) -> None:
         "AGENT_DIR",
         "ARTIFACT_SERVICE_URI",
         "DATABASE_URL",
+        "DB_READINESS_PROBE_TIMEOUT",
         "DB_POOL_PRE_PING",
         "DB_POOL_RECYCLE",
         "DB_POOL_SIZE",

--- a/tests/postgres/test_session_persistence.py
+++ b/tests/postgres/test_session_persistence.py
@@ -19,8 +19,10 @@ from urllib.parse import parse_qsl, quote, unquote, urlsplit, urlunsplit
 
 import asyncpg  # type: ignore[import-untyped]
 import pytest
+from fastapi.testclient import TestClient
 
-from agent import pre_start
+from agent import pre_start, server
+from agent.utils import ServerEnv
 
 _ADMIN_URL_ENV = "TEST_POSTGRES_ADMIN_URL"
 _DATABASE_NAME_PATTERN = re.compile(r"\Aadk_test_[0-9a-f]{32}\Z")
@@ -289,6 +291,41 @@ async def _drop_role(admin_url: str, role_name: str) -> None:
         await connection.execute(
             f'DROP ROLE IF EXISTS "{role_name}"'  # noqa: S608
         )
+    finally:
+        await _close_connection(connection)
+
+
+async def _set_database_connections_allowed(
+    admin_url: str,
+    database_name: str,
+    *,
+    allowed: bool,
+) -> None:
+    """Toggle connections only for one generated isolated test database."""
+    database_name = _validate_database_name(database_name)
+    connection = await asyncpg.connect(
+        admin_url,
+        timeout=10,
+        command_timeout=10,
+    )
+    try:
+        allow_connections = "true" if allowed else "false"
+        await connection.execute(
+            f"""
+            ALTER DATABASE "{database_name}"
+            WITH ALLOW_CONNECTIONS {allow_connections}
+            """  # noqa: S608
+        )
+        if not allowed:
+            await connection.execute(
+                """
+                SELECT pg_terminate_backend(pid)
+                FROM pg_stat_activity
+                WHERE datname = $1
+                  AND pid <> pg_backend_pid()
+                """,
+                database_name,
+            )
     finally:
         await _close_connection(connection)
 
@@ -685,6 +722,83 @@ async def test_database_readiness_succeeds_with_real_postgres(
         postgres_database_url,
         attempt_timeout=5,
     )
+
+
+def test_http_readiness_tracks_real_postgres_outage_and_recovery(
+    postgres_database_url: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Keep liveness up while one isolated database becomes unavailable."""
+    admin_url = os.environ[_ADMIN_URL_ENV]
+    monkeypatch.delenv(_ADMIN_URL_ENV)
+    parsed_database_url = urlsplit(postgres_database_url)
+    database_name = unquote(parsed_database_url.path.removeprefix("/"))
+    agent_dir = tmp_path / "agents"
+    agent_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("ADK_DISABLE_LOAD_DOTENV", "true")
+    monkeypatch.setenv("ADK_DISABLE_LOCAL_STORAGE", "true")
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+    environment = ServerEnv.model_validate(
+        {
+            "AGENT_DIR": str(agent_dir),
+            "AGENT_NAME": "postgres-readiness-agent",
+            "ALLOW_ORIGINS": "[]",
+            "DATABASE_URL": postgres_database_url,
+            "DB_MAX_OVERFLOW": 0,
+            "DB_POOL_SIZE": 1,
+            "DB_POOL_TIMEOUT": 5,
+            "DB_READINESS_PROBE_TIMEOUT": 1,
+            "RELOAD_AGENTS": False,
+            "SERVE_WEB_INTERFACE": False,
+        }
+    )
+    with TestClient(server.create_app(environment)) as client:
+        initial_ready = client.get("/ready")
+        assert initial_ready.status_code == 200
+        assert initial_ready.json() == {
+            "status": "ready",
+            "checks": {"database": "healthy"},
+        }
+
+        try:
+            asyncio.run(
+                _set_database_connections_allowed(
+                    admin_url,
+                    database_name,
+                    allowed=False,
+                )
+            )
+
+            unavailable = client.get("/ready")
+            live = client.get("/live")
+            health = client.get("/health")
+
+            assert unavailable.status_code == 503
+            assert unavailable.json() == {
+                "status": "not_ready",
+                "checks": {"database": "unavailable"},
+            }
+            assert live.status_code == 200
+            assert live.json() == {"status": "alive"}
+            assert health.status_code == 200
+            assert health.json() == {"status": "ok"}
+        finally:
+            asyncio.run(
+                _set_database_connections_allowed(
+                    admin_url,
+                    database_name,
+                    allowed=True,
+                )
+            )
+
+        recovered = client.get("/ready")
+        assert recovered.status_code == 200
+        assert recovered.json() == {
+            "status": "ready",
+            "checks": {"database": "healthy"},
+        }
 
 
 @pytest.mark.asyncio

--- a/tests/test_compose_healthcheck.py
+++ b/tests/test_compose_healthcheck.py
@@ -18,7 +18,7 @@ EXPECTED_HEALTHCHECK_BLOCK = """\
           import urllib.request;
           urllib.request.build_opener(
           urllib.request.ProxyHandler({})).open(
-          "http://127.0.0.1:8080/health", timeout=3).read()
+          "http://127.0.0.1:8080/ready", timeout=3).read()
       interval: 10s
       timeout: 5s
       retries: 5
@@ -39,8 +39,8 @@ def _indented_block(document: str, heading: str, indentation: int) -> str:
     return "\n".join(block)
 
 
-def test_agent_healthcheck_has_exact_process_liveness_contract() -> None:
-    """Keep one exec-form Python probe with an explicit small-VM timing policy."""
+def test_agent_healthcheck_has_exact_database_readiness_contract() -> None:
+    """Keep one bounded exec-form readiness probe for the small-VM runtime."""
     document = COMPOSE_PATH.read_text(encoding="utf-8")
     agent_block = _indented_block(document, "agent:", 2)
     healthcheck_block = _indented_block(agent_block, "healthcheck:", 4)
@@ -56,3 +56,6 @@ def test_operator_guides_wait_for_container_health() -> None:
     for guide_path in guide_paths:
         guide = guide_path.read_text(encoding="utf-8")
         assert "docker compose up --build --wait --wait-timeout 180" in guide
+        assert "`/ready`" in guide
+        assert "`/live`" in guide
+        assert "not_configured" in guide

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,6 +63,7 @@ class TestServerEnv:
         assert env.reload_agents is False
         assert env.agent_engine is None
         assert env.database_url is None
+        assert env.db_readiness_probe_timeout == 2
         assert env.openrouter_api_key is None
         assert env.agent_dir is None
         assert env.allow_origins == '["http://127.0.0.1", "http://127.0.0.1:8080"]'
@@ -81,6 +82,7 @@ class TestServerEnv:
             "RELOAD_AGENTS": "true",
             "AGENT_ENGINE": "test-engine-id",
             "DATABASE_URL": "postgresql://user:pass@localhost/db",
+            "DB_READINESS_PROBE_TIMEOUT": "1.5",
             "OPENROUTER_API_KEY": "sk-or-v1-test",
             "AGENT_DIR": "/srv/agents",
             "ALLOW_ORIGINS": '["http://localhost:3000"]',
@@ -99,12 +101,31 @@ class TestServerEnv:
         assert (
             env.database_url.get_secret_value() == "postgresql://user:pass@localhost/db"
         )
+        assert env.db_readiness_probe_timeout == 1.5
         assert isinstance(env.openrouter_api_key, SecretStr)
         assert env.openrouter_api_key.get_secret_value() == "sk-or-v1-test"
         assert env.agent_dir == "/srv/agents"
         assert env.allow_origins == '["http://localhost:3000"]'
         assert env.host == "0.0.0.0"  # noqa: S104
         assert env.port == 9000
+
+    @pytest.mark.parametrize(
+        "probe_timeout",
+        [0, -1, 2.1, 3, float("inf"), float("nan")],
+    )
+    def test_server_env_rejects_readiness_probe_outside_http_budget(
+        self,
+        valid_server_env: dict[str, str],
+        probe_timeout: float,
+    ) -> None:
+        """Keep the database attempt strictly inside the HTTP client timeout."""
+        data = {
+            **valid_server_env,
+            "DB_READINESS_PROBE_TIMEOUT": probe_timeout,
+        }
+
+        with pytest.raises(ValidationError):
+            ServerEnv.model_validate(data)
 
     def test_agent_engine_uri_property(self, valid_server_env: dict[str, str]) -> None:
         """Test that agent_engine_uri property is computed correctly."""
@@ -223,6 +244,7 @@ class TestServerEnv:
         output = captured.out
 
         assert "DB_POOL_PRE_PING" in output
+        assert "DB_READINESS_PROBE_TIMEOUT" in output
         assert "DB_POOL_RECYCLE" in output
         assert "DB_POOL_SIZE" in output
         assert "DB_MAX_OVERFLOW" in output

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,221 @@
+"""Process liveness and database readiness response contracts."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any, cast
+from unittest.mock import create_autospec
+
+import asyncpg  # type: ignore[import-untyped]
+import pytest
+from pydantic import SecretStr
+
+from agent import database
+from agent.health import DatabaseReadinessProbe, live
+
+DATABASE_URL = (
+    "postgresql+asyncpg://private-user:encoded%40password@localhost/private-db"
+    "?channel_binding=require&target_session_attrs=any"
+)
+NORMALIZED_DATABASE_URL = (
+    "postgresql://private-user:encoded%40password@localhost/private-db"
+    "?target_session_attrs=any"
+)
+
+
+def _connection(*, query_result: int = 1) -> Any:
+    """Return a strict asyncpg connection boundary double."""
+    connection = create_autospec(
+        asyncpg.Connection,
+        instance=True,
+        spec_set=True,
+    )
+    connection.fetchval.return_value = query_result
+    return connection
+
+
+def _connect(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    connection: Any | None = None,
+    side_effect: BaseException | None = None,
+) -> Any:
+    """Replace only the asyncpg connection boundary with a strict double."""
+    connect = create_autospec(asyncpg.connect, spec_set=True)
+    if side_effect is None:
+        connect.return_value = connection or _connection()
+    else:
+        connect.side_effect = side_effect
+    monkeypatch.setattr(database.asyncpg, "connect", connect)
+    return connect
+
+
+def _response_body(response: Any) -> dict[str, object]:
+    """Decode one JSONResponse body for exact contract assertions."""
+    return cast(dict[str, object], json.loads(response.body))
+
+
+@pytest.mark.asyncio
+async def test_live_reports_process_liveness() -> None:
+    assert await live() == {"status": "alive"}
+
+
+@pytest.mark.asyncio
+async def test_readiness_without_database_is_ready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connect = _connect(monkeypatch)
+    probe = DatabaseReadinessProbe(None, attempt_timeout=0.5)
+
+    response = await probe()
+
+    assert response.status_code == 200
+    assert _response_body(response) == {
+        "status": "ready",
+        "checks": {"database": "not_configured"},
+    }
+    connect.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_readiness_normalizes_checks_and_closes_database(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection = _connection()
+    connect = _connect(monkeypatch, connection=connection)
+    probe = DatabaseReadinessProbe(
+        SecretStr(DATABASE_URL),
+        attempt_timeout=0.5,
+    )
+
+    response = await probe()
+
+    assert response.status_code == 200
+    assert _response_body(response) == {
+        "status": "ready",
+        "checks": {"database": "healthy"},
+    }
+    connect.assert_awaited_once_with(
+        NORMALIZED_DATABASE_URL,
+        timeout=0.5,
+        command_timeout=0.5,
+    )
+    connection.fetchval.assert_awaited_once_with("SELECT 1", timeout=0.5)
+    connection.close.assert_awaited_once_with(timeout=0.5)
+    connection.terminate.assert_not_called()
+    assert isinstance(probe._database_url, SecretStr)
+    assert DATABASE_URL not in repr(probe.__dict__)
+    assert "private-user" not in repr(probe.__dict__)
+    assert "encoded%40password" not in repr(probe.__dict__)
+
+
+@pytest.mark.parametrize(
+    ("failure_stage", "expected_termination"),
+    [
+        ("connection", False),
+        ("query", True),
+        ("unexpected_result", True),
+        ("timeout", False),
+        ("close", True),
+        ("authentication", False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_database_failures_map_to_one_secret_free_response(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    failure_stage: str,
+    expected_termination: bool,
+) -> None:
+    failure_canary = "synthetic failure encoded%40password"
+    connection = _connection(
+        query_result=0 if failure_stage == "unexpected_result" else 1
+    )
+    connect_error: BaseException | None = None
+    if failure_stage == "connection":
+        connect_error = ConnectionError(failure_canary)
+    elif failure_stage == "query":
+        connection.fetchval.side_effect = OSError(failure_canary)
+    elif failure_stage == "timeout":
+        connect_error = TimeoutError(failure_canary)
+    elif failure_stage == "close":
+        connection.close.side_effect = OSError(failure_canary)
+    elif failure_stage == "authentication":
+        connect_error = asyncpg.InvalidPasswordError(failure_canary)
+
+    connect = _connect(
+        monkeypatch,
+        connection=connection,
+        side_effect=connect_error,
+    )
+    probe = DatabaseReadinessProbe(
+        SecretStr(DATABASE_URL),
+        attempt_timeout=0.5,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="agent.health"):
+        response = await probe()
+
+    assert response.status_code == 503
+    assert _response_body(response) == {
+        "status": "not_ready",
+        "checks": {"database": "unavailable"},
+    }
+    connect.assert_awaited_once_with(
+        NORMALIZED_DATABASE_URL,
+        timeout=0.5,
+        command_timeout=0.5,
+    )
+    if expected_termination:
+        connection.terminate.assert_called_once_with()
+    else:
+        connection.terminate.assert_not_called()
+
+    records = [record for record in caplog.records if record.name == "agent.health"]
+    assert len(records) == 1
+    assert records[0].getMessage() == "Database readiness check failed."
+    public_output = bytes(response.body).decode() + caplog.text
+    assert DATABASE_URL not in public_output
+    assert NORMALIZED_DATABASE_URL not in public_output
+    assert "private-user" not in public_output
+    assert "encoded%40password" not in public_output
+    assert failure_canary not in public_output
+
+
+@pytest.mark.asyncio
+async def test_readiness_propagates_cancellation_without_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    connection = _connection()
+    connection.fetchval.side_effect = asyncio.CancelledError
+    connect = _connect(monkeypatch, connection=connection)
+    probe = DatabaseReadinessProbe(
+        SecretStr(DATABASE_URL),
+        attempt_timeout=0.5,
+    )
+
+    with (
+        caplog.at_level(logging.WARNING, logger="agent.health"),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await probe()
+
+    connect.assert_awaited_once()
+    connection.terminate.assert_called_once_with()
+    assert not [record for record in caplog.records if record.name == "agent.health"]
+
+
+@pytest.mark.parametrize("attempt_timeout", [0, float("inf"), float("nan")])
+def test_readiness_rejects_invalid_attempt_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    attempt_timeout: float,
+) -> None:
+    connect = _connect(monkeypatch)
+
+    with pytest.raises(ValueError, match="attempt_timeout"):
+        DatabaseReadinessProbe(None, attempt_timeout=attempt_timeout)
+
+    connect.assert_not_called()

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -116,20 +116,19 @@ def test_create_app_uses_typed_settings_and_explicit_artifact_uri(
     assert list(artifact_dir.iterdir()) == []
 
 
-def test_health_endpoint_reports_process_liveness(
+def test_real_factory_exposes_one_secret_free_health_contract(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Verify the factory registers the container liveness contract."""
+    """Keep ADK health while adding explicit live and ready endpoints."""
     agent_dir = tmp_path / "agents"
     agent_dir.mkdir()
-    test_app = FastAPI()
-    mock_get_app = create_autospec(
-        get_fast_api_app,
-        spec_set=True,
-        return_value=test_app,
+    database_url = (
+        "postgresql://openapi-user:encoded%40db-secret-canary@127.0.0.1:1/"
+        "openapi-database"
     )
     mock_instrumentor_class = _mock_instrumentor()
+    monkeypatch.chdir(tmp_path)
 
     with (
         patch.dict(
@@ -137,10 +136,12 @@ def test_health_endpoint_reports_process_liveness(
             {
                 "AGENT_DIR": str(agent_dir),
                 "AGENT_NAME": "health-test-agent",
+                "ALLOW_ORIGINS": "[]",
+                "DATABASE_URL": database_url,
+                "OTEL_SDK_DISABLED": "true",
             },
             clear=True,
         ),
-        patch.object(server, "get_fast_api_app", new=mock_get_app),
         patch.object(
             server,
             "GoogleADKInstrumentor",
@@ -149,10 +150,30 @@ def test_health_endpoint_reports_process_liveness(
     ):
         app = server.create_app()
         with TestClient(app) as client:
-            response = client.get("/health")
+            health_response = client.get("/health")
+            live_response = client.get("/live")
+            openapi_response = client.get("/openapi.json")
 
-    assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
+    route_paths = [getattr(route, "path", None) for route in app.routes]
+    assert route_paths.count("/health") == 1
+    assert route_paths.count("/live") == 1
+    assert route_paths.count("/ready") == 1
+    assert health_response.status_code == 200
+    assert health_response.json() == {"status": "ok"}
+    assert live_response.status_code == 200
+    assert live_response.json() == {"status": "alive"}
+    assert openapi_response.status_code == 200
+    ready_operation = openapi_response.json()["paths"]["/ready"]["get"]
+    assert ready_operation.get("parameters", []) == []
+    assert "requestBody" not in ready_operation
+    for forbidden in (
+        database_url,
+        "openapi-user",
+        "encoded%40db-secret-canary",
+        "encoded@db-secret-canary",
+        "openapi-database",
+    ):
+        assert forbidden not in openapi_response.text
 
 
 def test_import_has_no_application_or_storage_side_effect() -> None:


### PR DESCRIPTION
## What

Add explicit process liveness and PostgreSQL connectivity readiness contracts
for single-VM deployments.

## Why

The Compose healthcheck previously called ADK's process-only `/health` route,
so a running process could remain healthy after its PostgreSQL session store
became unavailable. The repository also appended a second `/health` handler,
but ADK's earlier route shadowed it in the real application.

## How

- Preserve ADK's single `/health` process-liveness route.
- Add process-only `/live` and database-aware `/ready` endpoints.
- Run one secret-safe, bounded `SELECT 1` per configured readiness request.
- Cap the database attempt at two seconds beneath the probe client timeout.
- Share direct PostgreSQL normalization and checking with the startup gate.
- Point the exact exec-form Compose healthcheck at `/ready`.
- Prove route ordering, OpenAPI secrecy, failure mapping, cancellation, and
  isolated PostgreSQL outage recovery.
- Document the probe boundary and internal/rate-limited exposure requirement.

## Tests

- [x] `uv sync --locked`
- [x] `uv run ruff format --check`
- [x] `uv run ruff check --no-fix --output-format=github`
- [x] `uv run mypy .`
- [x] `uv run pytest --cov=src --cov-report=xml --cov-report=term-missing`
      (`475 passed`, `5` local PostgreSQL-service skips, `100%` statement and
      branch coverage)
- [x] Secret-free `docker compose config --images`
- [x] GitHub's PostgreSQL-backed
      [Code Quality lane](https://github.com/QueryPlanner/google-adk-on-bare-metal/actions/runs/30335721165)
      executes the real outage/recovery test (`480 passed`, no skips, `100%`
      statement and branch coverage)
- [x] GitHub's
      [Compose Smoke lane](https://github.com/QueryPlanner/google-adk-on-bare-metal/actions/runs/30335721268)
      builds the image and waits on `/ready`

## Related Issues

Closes #103
