### PR TITLE
fix: pin Pydantic for LiteLLM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
+      # Remove when the supported LiteLLM range no longer pins Pydantic to 2.12.5.
+      - dependency-name: "pydantic"
+        update-types:
+          - "version-update:semver-patch"
+          - "version-update:semver-minor"
       - dependency-name: "opentelemetry-exporter-gcp-logging"
         update-types:
           - "version-update:semver-minor"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ dependencies = [
     "opentelemetry-exporter-otlp-proto-http==1.37.0",
     "opentelemetry-instrumentation-google-genai>=0.6b0,<1",
     "opentelemetry-instrumentation-logging>=0.58b0,<0.59",
-    "pydantic>=2.11.0,<3.0.0",
+    # LiteLLM 1.83.7-1.83.14 requires this exact Pydantic release.
+    "pydantic==2.12.5",
     "pydantic-settings>=2.12.0,<3.0.0",
     "tenacity>=9.1.2,<10.0.0",
     "litellm>=1.83.7,<=1.83.14",

--- a/tests/test_dependabot.py
+++ b/tests/test_dependabot.py
@@ -29,6 +29,13 @@ EXPECTED_IGNORES = {
             "update-types": ["version-update:semver-major"],
         },
         {
+            "dependency-name": "pydantic",
+            "update-types": [
+                "version-update:semver-patch",
+                "version-update:semver-minor",
+            ],
+        },
+        {
             "dependency-name": "opentelemetry-exporter-gcp-logging",
             "update-types": ["version-update:semver-minor"],
         },
@@ -227,6 +234,14 @@ def test_ignore_policy_is_narrow_and_version_only() -> None:
     }
     assert "google-adk" not in uv_dependency_names
     assert "opentelemetry-*" not in uv_dependency_names
+    uv_ignores_by_dependency = {
+        condition["dependency-name"]: set(condition["update-types"])
+        for condition in EXPECTED_IGNORES[("uv", "/")]
+    }
+    assert (
+        uv_ignores_by_dependency["*"] | uv_ignores_by_dependency["pydantic"]
+        == SUPPORTED_UPDATE_TYPES
+    )
     assert "versions" not in {
         key
         for conditions in EXPECTED_IGNORES.values()
@@ -288,3 +303,39 @@ def test_configuration_targets_real_supported_manifests() -> None:
         "Dormant while compose.yaml uses the unversioned ${IMAGE:-agent}"
         in dependabot_document
     )
+    assert (
+        "Remove when the supported LiteLLM range no longer pins "
+        "Pydantic to 2.12.5." in dependabot_document
+    )
+
+
+def test_pydantic_constraint_matches_locked_litellm_compatibility() -> None:
+    """Keep the direct constraint truthful without changing resolved runtime code."""
+    project = tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
+    assert "pydantic==2.12.5" in project["project"]["dependencies"]
+
+    lockfile = tomllib.loads(LOCKFILE_PATH.read_text(encoding="utf-8"))
+    packages = lockfile["package"]
+    root_package = next(
+        package for package in packages if package["name"] == "google-adk-on-bare-metal"
+    )
+    pydantic_requirement = next(
+        requirement
+        for requirement in root_package["metadata"]["requires-dist"]
+        if requirement["name"] == "pydantic"
+    )
+    assert pydantic_requirement == {
+        "name": "pydantic",
+        "specifier": "==2.12.5",
+    }
+
+    resolved_versions = {
+        package["name"]: package["version"]
+        for package in packages
+        if package["name"] in {"google-adk", "litellm", "pydantic"}
+    }
+    assert resolved_versions == {
+        "google-adk": "1.36.2",
+        "litellm": "1.83.14",
+        "pydantic": "2.12.5",
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -625,7 +625,7 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = "==1.37.0" },
     { name = "opentelemetry-instrumentation-google-genai", specifier = ">=0.6b0,<1" },
     { name = "opentelemetry-instrumentation-logging", specifier = ">=0.58b0,<0.59" },
-    { name = "pydantic", specifier = ">=2.11.0,<3.0.0" },
+    { name = "pydantic", specifier = "==2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.12.0,<3.0.0" },
     { name = "tenacity", specifier = ">=9.1.2,<10.0.0" },
 ]


### PR DESCRIPTION
## What

Pin Pydantic to the exact version required by the supported LiteLLM range and prevent Dependabot version-update churn that cannot resolve.

## Why

The hosted root `uv` updater currently proposes Pydantic 2.13.4, but LiteLLM 1.83.7 through 1.83.14 require Pydantic 2.12.5. That makes the dependency file unresolvable even though the committed lock remains valid.

## How

- Pin the direct Pydantic dependency to 2.12.5
- Ignore Pydantic patch and minor version updates while retaining security updates
- Assert the manifest, lock metadata, resolved versions, and ignore policy
- Document when the temporary compatibility ignore must be removed

## Tests

- [x] `uv sync --locked`
- [x] `uv run ruff format`
- [x] `uv run ruff format --check`
- [x] `uv run ruff check --no-fix --output-format=github`
- [x] `uv run mypy .`
- [x] `uv run pytest --cov=src --cov-report=xml --cov-report=term-missing` (561 passed, 5 skipped, 100.00% coverage)
- [x] Confirm a fresh hosted root `uv` Dependabot update succeeds after merge ([run 30345041182](https://github.com/QueryPlanner/google-adk-on-bare-metal/actions/runs/30345041182))

## Related Issues

Closes #108