### PR TITLE
feat: add private Compose env serializer

### DIFF
--- a/src/agent/compose_env.py
+++ b/src/agent/compose_env.py
@@ -1,0 +1,122 @@
+"""Serialize selected process settings into a private Docker Compose env file."""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+_ENVIRONMENT_KEY = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+_FORBIDDEN_VALUE_CHARACTERS = frozenset({"\0", "\r", "\n"})
+
+
+class ComposeEnvironmentError(ValueError):
+    """Report a safe, deterministic Compose environment validation failure."""
+
+
+def quote_compose_value(value: str) -> str:
+    """Quote one value without line injection or Compose interpolation."""
+    if any(character in value for character in _FORBIDDEN_VALUE_CHARACTERS):
+        raise ComposeEnvironmentError(
+            "environment values cannot contain NUL or line breaks"
+        )
+
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"').replace("$", "$$")
+    return f'"{escaped}"'
+
+
+def serialize_compose_environment(
+    names: Sequence[str],
+    environment: Mapping[str, str],
+) -> str:
+    """Serialize an ordered allowlist of environment variables."""
+    if not names:
+        raise ComposeEnvironmentError("at least one environment key is required")
+
+    seen_names: set[str] = set()
+    lines: list[str] = []
+    for name in names:
+        if _ENVIRONMENT_KEY.fullmatch(name) is None:
+            raise ComposeEnvironmentError("environment key is invalid")
+        if name in seen_names:
+            raise ComposeEnvironmentError(f"environment key is duplicated: {name}")
+        if name not in environment:
+            raise ComposeEnvironmentError(f"environment key is missing: {name}")
+
+        seen_names.add(name)
+        lines.append(f"{name}={quote_compose_value(environment[name])}")
+    return "\n".join(lines) + "\n"
+
+
+def write_compose_environment(
+    path: Path,
+    names: Sequence[str],
+    environment: Mapping[str, str],
+) -> None:
+    """Atomically publish a complete mode-0600 Compose environment file."""
+    payload = serialize_compose_environment(names, environment).encode()
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=".compose-env-",
+        suffix=".tmp",
+        dir=path.parent,
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        os.fchmod(descriptor, 0o600)
+        remaining = memoryview(payload)
+        while remaining:
+            written = os.write(descriptor, remaining)
+            if written <= 0:
+                raise OSError("environment file write made no progress")
+            remaining = remaining[written:]
+        os.fsync(descriptor)
+        descriptor_to_close = descriptor
+        descriptor = -1
+        os.close(descriptor_to_close)
+        os.link(
+            temporary_path,
+            path,
+            follow_symlinks=False,
+        )
+    finally:
+        try:
+            if descriptor >= 0:
+                os.close(descriptor)
+        finally:
+            temporary_path.unlink(missing_ok=True)
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    environment: Mapping[str, str] | None = None,
+) -> int:
+    """Write requested variables and return a process exit status."""
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    if len(arguments) < 2:
+        print(
+            "usage: python -m agent.compose_env OUTPUT VARIABLE [VARIABLE ...]",
+            file=sys.stderr,
+        )
+        return 2
+
+    selected_environment = os.environ if environment is None else environment
+    try:
+        write_compose_environment(
+            Path(arguments[0]),
+            arguments[1:],
+            selected_environment,
+        )
+    except ComposeEnvironmentError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    except OSError:
+        print("ERROR: environment file could not be created", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_compose_env.py
+++ b/tests/test_compose_env.py
@@ -1,0 +1,493 @@
+"""Private Docker Compose environment serializer tests."""
+
+from __future__ import annotations
+
+import json
+import os
+import runpy
+import shutil
+import subprocess
+import sys
+import warnings
+from pathlib import Path
+from unittest.mock import create_autospec, patch
+
+import pytest
+
+from agent.compose_env import (
+    ComposeEnvironmentError,
+    main,
+    quote_compose_value,
+    serialize_compose_environment,
+    write_compose_environment,
+)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("", '""'),
+        ("simple", '"simple"'),
+        (" leading and trailing ", '" leading and trailing "'),
+        ('double"quote', '"double\\"quote"'),
+        ("single'quote", '"single\'quote"'),
+        ("back\\slash", '"back\\\\slash"'),
+        ("equals=value # literal", '"equals=value # literal"'),
+        ("$VAR ${OTHER} $$", '"$$VAR $${OTHER} $$$$"'),
+        ("\tunicode-हॅलो", '"\tunicode-हॅलो"'),
+    ],
+)
+def test_quote_compose_value_preserves_supported_bytes(
+    value: str,
+    expected: str,
+) -> None:
+    """Preserve supported values while neutralizing Compose interpolation."""
+    assert quote_compose_value(value) == expected
+
+
+@pytest.mark.parametrize("unsafe_character", ["\0", "\r", "\n"])
+def test_quote_compose_value_rejects_line_injection(
+    unsafe_character: str,
+) -> None:
+    """Reject control bytes without including the supplied value in the error."""
+    canary = f"secret-before{unsafe_character}secret-after"
+
+    with pytest.raises(
+        ComposeEnvironmentError,
+        match="environment values cannot contain NUL or line breaks",
+    ) as error:
+        quote_compose_value(canary)
+
+    assert "secret-before" not in str(error.value)
+    assert "secret-after" not in str(error.value)
+
+
+def test_serialize_compose_environment_preserves_allowlist_order() -> None:
+    """Write only selected variables in the caller's explicit order."""
+    environment = {
+        "FIRST": "one",
+        "SECOND": "$two",
+        "UNSELECTED": "three",
+    }
+
+    assert (
+        serialize_compose_environment(
+            ["SECOND", "FIRST"],
+            environment,
+        )
+        == 'SECOND="$$two"\nFIRST="one"\n'
+    )
+
+
+def test_serialize_compose_environment_requires_at_least_one_key() -> None:
+    """Reject an empty allowlist instead of creating an ambiguous file."""
+    with pytest.raises(
+        ComposeEnvironmentError,
+        match="at least one environment key is required",
+    ):
+        serialize_compose_environment([], {})
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["", "1INVALID", "INVALID-NAME", "INVALID.NAME", "INVALID\nINJECT"],
+)
+def test_serialize_compose_environment_rejects_invalid_keys(name: str) -> None:
+    """Reject unsafe key syntax without reflecting it into the error."""
+    with pytest.raises(
+        ComposeEnvironmentError,
+        match="environment key is invalid",
+    ) as error:
+        serialize_compose_environment([name], {name: "secret-canary"})
+
+    assert str(error.value) == "environment key is invalid"
+    assert "secret-canary" not in str(error.value)
+
+
+def test_serialize_compose_environment_rejects_duplicate_keys() -> None:
+    """Prevent ambiguous duplicate assignments."""
+    with pytest.raises(
+        ComposeEnvironmentError,
+        match="environment key is duplicated: DUPLICATE",
+    ):
+        serialize_compose_environment(
+            ["DUPLICATE", "DUPLICATE"],
+            {"DUPLICATE": "secret-canary"},
+        )
+
+
+def test_serialize_compose_environment_rejects_missing_keys() -> None:
+    """Require every allowlisted name without exposing another value."""
+    with pytest.raises(
+        ComposeEnvironmentError,
+        match="environment key is missing: MISSING",
+    ) as error:
+        serialize_compose_environment(
+            ["PRESENT", "MISSING"],
+            {"PRESENT": "secret-canary"},
+        )
+
+    assert "secret-canary" not in str(error.value)
+
+
+def test_write_compose_environment_creates_complete_private_file(
+    tmp_path: Path,
+) -> None:
+    """Persist exact serialized bytes with owner-only permissions."""
+    output = tmp_path / "deploy.env"
+
+    write_compose_environment(
+        output,
+        ["SECRET", "EMPTY"],
+        {"SECRET": "$value", "EMPTY": ""},
+    )
+
+    assert output.read_bytes() == b'SECRET="$$value"\nEMPTY=""\n'
+    assert output.stat().st_mode & 0o777 == 0o600
+    assert list(tmp_path.iterdir()) == [output]
+
+
+@pytest.mark.parametrize(
+    ("names", "environment"),
+    [
+        ([], {}),
+        (["INVALID-NAME"], {"INVALID-NAME": "secret-canary"}),
+        (["DUPLICATE", "DUPLICATE"], {"DUPLICATE": "secret-canary"}),
+        (["MISSING"], {}),
+        (["SECRET"], {"SECRET": "before\0after"}),
+        (["SECRET"], {"SECRET": "before\rafter"}),
+        (["SECRET"], {"SECRET": "before\nafter"}),
+    ],
+)
+def test_write_validation_fails_before_destination_creation(
+    names: list[str],
+    environment: dict[str, str],
+    tmp_path: Path,
+) -> None:
+    """Complete validation before opening an output path."""
+    output = tmp_path / "deploy.env"
+
+    with pytest.raises(ComposeEnvironmentError):
+        write_compose_environment(output, names, environment)
+
+    assert not output.exists()
+
+
+def test_write_compose_environment_never_replaces_existing_file(
+    tmp_path: Path,
+) -> None:
+    """Fail closed when the requested output path already exists."""
+    output = tmp_path / "deploy.env"
+    output.write_text("operator-owned\n", encoding="utf-8")
+
+    with pytest.raises(FileExistsError):
+        write_compose_environment(output, ["SECRET"], {"SECRET": "new-value"})
+
+    assert output.read_text(encoding="utf-8") == "operator-owned\n"
+    assert list(tmp_path.iterdir()) == [output]
+
+
+def test_write_compose_environment_never_replaces_symlink(
+    tmp_path: Path,
+) -> None:
+    """Treat an existing symlink as a collision without changing its target."""
+    target = tmp_path / "operator-owned"
+    output = tmp_path / "deploy.env"
+    target.write_text("preserve\n", encoding="utf-8")
+    output.symlink_to(target)
+
+    with pytest.raises(FileExistsError):
+        write_compose_environment(output, ["SECRET"], {"SECRET": "new-value"})
+
+    assert output.is_symlink()
+    assert target.read_text(encoding="utf-8") == "preserve\n"
+    assert set(tmp_path.iterdir()) == {output, target}
+
+
+def test_write_compose_environment_removes_partial_write(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Remove the private temporary file if writing stops making progress."""
+    output = tmp_path / "deploy.env"
+    real_write = os.write
+    calls = 0
+
+    def partial_then_stalled(descriptor: int, payload: bytes | memoryview) -> int:
+        nonlocal calls
+        assert not output.exists()
+        calls += 1
+        if calls == 1:
+            return real_write(descriptor, bytes(payload[:1]))
+        return 0
+
+    monkeypatch.setattr(os, "write", partial_then_stalled)
+
+    with pytest.raises(OSError, match="write made no progress"):
+        write_compose_environment(
+            output,
+            ["SECRET"],
+            {"SECRET": "secret-canary"},
+        )
+
+    assert calls == 2
+    assert not output.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_write_compose_environment_handles_successful_short_writes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Publish only after every successful short write is complete."""
+    output = tmp_path / "deploy.env"
+    real_write = os.write
+    calls = 0
+
+    def one_byte_at_a_time(descriptor: int, payload: bytes | memoryview) -> int:
+        nonlocal calls
+        assert not output.exists()
+        calls += 1
+        return real_write(descriptor, bytes(payload[:1]))
+
+    monkeypatch.setattr(os, "write", one_byte_at_a_time)
+    write_compose_environment(
+        output,
+        ["SECRET"],
+        {"SECRET": "secret-canary"},
+    )
+
+    assert calls == len(b'SECRET="secret-canary"\n')
+    assert output.read_bytes() == b'SECRET="secret-canary"\n'
+    assert list(tmp_path.iterdir()) == [output]
+
+
+def test_write_compose_environment_close_failure_is_not_published(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Keep the final pathname absent when closing the complete temp file fails."""
+    output = tmp_path / "deploy.env"
+    real_close = os.close
+
+    def close_then_fail(descriptor: int) -> None:
+        real_close(descriptor)
+        raise OSError("synthetic close failure")
+
+    monkeypatch.setattr(os, "close", close_then_fail)
+
+    with pytest.raises(OSError, match="synthetic close failure"):
+        write_compose_environment(
+            output,
+            ["SECRET"],
+            {"SECRET": "secret-canary"},
+        )
+
+    assert not output.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_write_compose_environment_removes_unsynced_file(
+    tmp_path: Path,
+) -> None:
+    """Remove the private temporary file when synchronization fails."""
+    output = tmp_path / "deploy.env"
+    sync_failure = create_autospec(
+        os.fsync,
+        spec_set=True,
+        side_effect=OSError("synthetic sync failure"),
+    )
+
+    with (
+        patch("agent.compose_env.os.fsync", new=sync_failure),
+        pytest.raises(OSError, match="synthetic sync failure"),
+    ):
+        write_compose_environment(
+            output,
+            ["SECRET"],
+            {"SECRET": "secret-canary"},
+        )
+
+    sync_failure.assert_called_once()
+    assert not output.exists()
+
+
+def test_cli_reports_usage_without_creating_output(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """Return a distinct usage status before opening a destination."""
+    output = tmp_path / "deploy.env"
+
+    assert main([str(output)], {}) == 2
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == (
+        "usage: python -m agent.compose_env OUTPUT VARIABLE [VARIABLE ...]\n"
+    )
+    assert not output.exists()
+
+
+def test_cli_writes_selected_environment(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """Return success without printing serialized environment bytes."""
+    output = tmp_path / "deploy.env"
+
+    assert (
+        main(
+            [str(output), "SECRET"],
+            {"SECRET": "secret-canary"},
+        )
+        == 0
+    )
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+    assert output.read_text(encoding="utf-8") == 'SECRET="secret-canary"\n'
+
+
+@pytest.mark.parametrize(
+    ("environment", "expected_error"),
+    [
+        ({}, "ERROR: environment key is missing: SECRET\n"),
+        (
+            {"SECRET": "secret-canary\ninjected"},
+            "ERROR: environment values cannot contain NUL or line breaks\n",
+        ),
+    ],
+)
+def test_cli_reports_safe_validation_failures(
+    capsys: pytest.CaptureFixture[str],
+    environment: dict[str, str],
+    expected_error: str,
+    tmp_path: Path,
+) -> None:
+    """Report deterministic validation errors without echoing values."""
+    output = tmp_path / "deploy.env"
+
+    assert main([str(output), "SECRET"], environment) == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == expected_error
+    assert "secret-canary" not in captured.err
+    assert not output.exists()
+
+
+def test_cli_reports_output_collision_without_path_or_value(
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """Map filesystem failures to one secret-free public error."""
+    output = tmp_path / "deploy.env"
+    output.write_text("operator-owned\n", encoding="utf-8")
+
+    assert (
+        main(
+            [str(output), "SECRET"],
+            {"SECRET": "secret-canary"},
+        )
+        == 1
+    )
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "ERROR: environment file could not be created\n"
+    assert str(output) not in captured.err
+    assert "secret-canary" not in captured.err
+    assert output.read_text(encoding="utf-8") == "operator-owned\n"
+
+
+def test_module_entrypoint_uses_process_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Exercise the supported module CLI without exposing its selected value."""
+    output = tmp_path / "deploy.env"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["agent.compose_env", str(output), "SECRET"],
+    )
+    monkeypatch.setenv("SECRET", "process-secret-canary")
+
+    with (
+        warnings.catch_warnings(),
+        pytest.raises(SystemExit) as exit_error,
+    ):
+        warnings.filterwarnings(
+            "ignore",
+            message=".*found in sys.modules.*",
+            category=RuntimeWarning,
+        )
+        runpy.run_module("agent.compose_env", run_name="__main__")
+
+    assert exit_error.value.code == 0
+    assert output.read_text(encoding="utf-8") == ('SECRET="process-secret-canary"\n')
+
+
+def test_real_compose_round_trip_preserves_shell_sensitive_value(
+    tmp_path: Path,
+) -> None:
+    """Use Docker Compose's parser to verify the serialized byte contract."""
+    docker = shutil.which("docker")
+    if docker is None:
+        pytest.skip("Docker CLI is unavailable")
+
+    sample_value = (
+        "dollar$VAR${OTHER} quote\" single' backslash\\ space # hash & equals="
+    )
+    env_file = tmp_path / "deploy.env"
+    compose_file = tmp_path / "compose.yaml"
+    write_compose_environment(
+        env_file,
+        ["SECRET"],
+        {"SECRET": sample_value},
+    )
+    compose_file.write_text(
+        "services:\n"
+        "  agent:\n"
+        "    image: synthetic.invalid/agent:compose-env-contract\n"
+        "    env_file:\n"
+        "      - ${ENV_FILE:?Set ENV_FILE to the private environment file}\n",
+        encoding="utf-8",
+    )
+    environment = {
+        "COMPOSE_DISABLE_ENV_FILE": "1",
+        "ENV_FILE": str(env_file),
+        "HOME": os.environ.get("HOME", str(tmp_path)),
+        "LANG": "C",
+        "PATH": os.environ["PATH"],
+    }
+
+    result = subprocess.run(  # noqa: S603 - resolved Docker, fixed arguments
+        [
+            docker,
+            "compose",
+            "--project-name",
+            f"compose-env-{os.getpid()}",
+            "--env-file",
+            str(env_file),
+            "-f",
+            str(compose_file),
+            "config",
+            "--format",
+            "json",
+        ],
+        cwd=tmp_path,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    service = json.loads(result.stdout)["services"]["agent"]
+    # Canonical Compose output re-escapes literal dollars for safe re-parsing.
+    assert service["environment"]["SECRET"] == sample_value.replace("$", "$$")
+    assert service["image"] == "synthetic.invalid/agent:compose-env-contract"
+    assert env_file.stat().st_mode & 0o777 == 0o600


### PR DESCRIPTION
## What

Add a standard-library-only serializer and CLI for publishing selected process
environment variables as a private Docker Compose environment file.

## Why

Transactional VM deployment needs one tested serialization boundary before
secrets are transferred or promoted. The current production workflow still
interpolates secrets directly into a shell heredoc; this PR intentionally adds
the prerequisite without changing that workflow yet.

## How

- Validate an explicit ordered allowlist before touching the filesystem.
- Reject invalid or duplicate names, missing values, and NUL/CR/LF bytes.
- Escape quotes, backslashes, and Compose `$` interpolation.
- Write and fsync an unpredictable same-directory mode-0600 temporary file.
- Close it before atomic no-replace publication through a hard link.
- Preserve existing files and symlinks and clean only the private temporary.
- Return deterministic CLI errors without environment values or file paths.

## Tests

- [x] Run `uv sync --locked`.
- [x] Run `uv run ruff format --check`.
- [x] Run `uv run ruff check --no-fix --output-format=github`.
- [x] Run `uv run mypy .`.
- [x] Run `uv run pytest --cov=src --cov-report=xml --cov-report=term-missing`
      (`642 passed`, `6 skipped`, 100% statement and branch coverage).
- [x] Verify the final path stays absent through forced short writes, fsync
      failure, and close failure.
- [x] Verify existing files and symlinks are never replaced.
- [x] Parse shell-sensitive synthetic values with real
      `docker compose config --format json`.
- [x] Verify CLI failures never print selected environment values.

The serializer's deterministic filesystem and Compose contracts are the
relevant evaluation for this non-runtime prerequisite. Agent prompts, tools,
model calls, and production deployment behavior are unchanged.

## Related Issues

Fixes #113
Related to #111
