### PR TITLE
feat: add isolated candidate Compose

### DIFF
--- a/.github/workflows/test-docker-compose.yml
+++ b/.github/workflows/test-docker-compose.yml
@@ -330,6 +330,36 @@ jobs:
           echo "Artifact storage is unavailable."
           echo "Compose artifact persistence and failure checks passed."
 
+  candidate:
+    name: Validate isolated candidate runtime
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      RUN_CANDIDATE_INTEGRATION: "1"
+      CANDIDATE_TEST_PROJECT_PREFIX: >-
+        adk-candidate-${{ github.run_id }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Install Python
+        run: uv python install 3.13
+
+      - name: Install locked dependencies
+        run: uv sync --locked
+
+      - name: Run isolated candidate proof
+        run: uv run pytest tests/test_candidate_runtime.py -q
+
   trace-gateway:
     name: Validate trace-redaction gateway
     runs-on: ubuntu-latest

--- a/compose.candidate.yaml
+++ b/compose.candidate.yaml
@@ -1,0 +1,74 @@
+x-candidate-environment-file: "${ENV_FILE:?Set ENV_FILE to the candidate environment file}"
+
+services:
+  agent:
+    image: "${IMAGE:?Set IMAGE to the candidate image}"
+    pull_policy: never
+    environment:
+      # Interpolated values come only from a private serializer-produced allowlist.
+      AGENT_NAME: "${AGENT_NAME:?Set AGENT_NAME for the candidate}"
+      ROOT_AGENT_MODEL: "${ROOT_AGENT_MODEL:?Set ROOT_AGENT_MODEL for the candidate}"
+      LOG_LEVEL: "${LOG_LEVEL:?Set LOG_LEVEL for the candidate}"
+      TELEMETRY_NAMESPACE: "${TELEMETRY_NAMESPACE:?Set TELEMETRY_NAMESPACE for the candidate}"
+      K_REVISION: "${K_REVISION:?Set K_REVISION for the candidate}"
+      CANDIDATE_ENV_CANARY: "${CANDIDATE_ENV_CANARY:?Set CANDIDATE_ENV_CANARY for the candidate}"
+      HOST: "127.0.0.1"
+      PORT: "8080"
+      AGENT_DIR: "/app/src"
+      ALLOW_ORIGINS: "[]"
+      SERVE_WEB_INTERFACE: "false"
+      RELOAD_AGENTS: "false"
+      ADK_DISABLE_LOAD_DOTENV: "true"
+      DATABASE_URL: ""
+      AGENT_ENGINE: ""
+      OPENROUTER_API_KEY: ""
+      GOOGLE_API_KEY: ""
+      GEMINI_API_KEY: ""
+      GOOGLE_GENAI_USE_VERTEXAI: "false"
+      GOOGLE_APPLICATION_CREDENTIALS: ""
+      GOOGLE_CLOUD_PROJECT: ""
+      GOOGLE_CLOUD_LOCATION: ""
+      VERTEXAI_PROJECT: ""
+      VERTEXAI_LOCATION: ""
+      MEM0_LLM_API_KEY: ""
+      MEM0_QDRANT_HOST: ""
+      MEM0_QDRANT_PORT: ""
+      LANGFUSE_PUBLIC_KEY: ""
+      LANGFUSE_SECRET_KEY: ""
+      LANGFUSE_BASE_URL: ""
+      OTEL_SDK_DISABLED: "true"
+      OTEL_TRACES_EXPORTER: "none"
+      OTEL_METRICS_EXPORTER: "none"
+      OTEL_LOGS_EXPORTER: "none"
+      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: ""
+      OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: ""
+      OTEL_EXPORTER_OTLP_TRACES_HEADERS: ""
+      OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE: ""
+      OTEL_EXPORTER_OTLP_TRACES_TIMEOUT: ""
+      OTEL_GATEWAY_BEARER_TOKEN_FILE: ""
+      OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT: "false"
+      ADK_CAPTURE_MESSAGE_CONTENT_IN_SPANS: "false"
+      OTEL_PYTHON_EXPORTER_OTLP_HTTP_CREDENTIAL_PROVIDER: ""
+      OTEL_PYTHON_EXPORTER_OTLP_HTTP_TRACES_CREDENTIAL_PROVIDER: ""
+    network_mode: none
+    user: "1000:1000"
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    restart: "no"
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - >-
+          import urllib.request;
+          urllib.request.build_opener(
+          urllib.request.ProxyHandler({})).open(
+          "http://127.0.0.1:8080/ready", timeout=1).read()
+      interval: 2s
+      timeout: 2s
+      retries: 10
+      start_period: 20s
+    stop_grace_period: 10s

--- a/tests/test_candidate_compose.py
+++ b/tests/test_candidate_compose.py
@@ -1,0 +1,360 @@
+"""Static and canonical contracts for the standalone candidate service."""
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml  # type: ignore[import-untyped]
+
+from agent.compose_env import write_compose_environment
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+CANDIDATE_COMPOSE_PATH = REPOSITORY_ROOT / "compose.candidate.yaml"
+CANDIDATE_IMAGE = "agent:candidate-contract"
+FORBIDDEN_SERVICE_KEYS = {
+    "build",
+    "command",
+    "devices",
+    "entrypoint",
+    "env_file",
+    "expose",
+    "ipc",
+    "networks",
+    "pid",
+    "ports",
+    "privileged",
+    "volumes",
+}
+CANDIDATE_ENVIRONMENT_ALLOWLIST = (
+    "AGENT_NAME",
+    "ROOT_AGENT_MODEL",
+    "LOG_LEVEL",
+    "TELEMETRY_NAMESPACE",
+    "K_REVISION",
+    "CANDIDATE_ENV_CANARY",
+)
+REQUIRED_ENVIRONMENT = {
+    name: f"${{{name}:?Set {name} for the candidate}}"
+    for name in CANDIDATE_ENVIRONMENT_ALLOWLIST
+}
+ALLOWED_ENVIRONMENT = {
+    "AGENT_NAME": "candidate-static-agent",
+    "ROOT_AGENT_MODEL": "gemini-2.5-flash",
+    "LOG_LEVEL": "INFO",
+    "TELEMETRY_NAMESPACE": "candidate-static",
+    "K_REVISION": "candidate-static",
+    "CANDIDATE_ENV_CANARY": "candidate-static-canary",
+}
+FIXED_ENVIRONMENT = {
+    "ADK_CAPTURE_MESSAGE_CONTENT_IN_SPANS": "false",
+    "ADK_DISABLE_LOAD_DOTENV": "true",
+    "AGENT_DIR": "/app/src",
+    "AGENT_ENGINE": "",
+    "ALLOW_ORIGINS": "[]",
+    "DATABASE_URL": "",
+    "GEMINI_API_KEY": "",
+    "GOOGLE_API_KEY": "",
+    "GOOGLE_APPLICATION_CREDENTIALS": "",
+    "GOOGLE_CLOUD_LOCATION": "",
+    "GOOGLE_CLOUD_PROJECT": "",
+    "GOOGLE_GENAI_USE_VERTEXAI": "false",
+    "HOST": "127.0.0.1",
+    "LANGFUSE_BASE_URL": "",
+    "LANGFUSE_PUBLIC_KEY": "",
+    "LANGFUSE_SECRET_KEY": "",
+    "MEM0_LLM_API_KEY": "",
+    "MEM0_QDRANT_HOST": "",
+    "MEM0_QDRANT_PORT": "",
+    "OPENROUTER_API_KEY": "",
+    "OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE": "",
+    "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "",
+    "OTEL_EXPORTER_OTLP_TRACES_HEADERS": "",
+    "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "",
+    "OTEL_EXPORTER_OTLP_TRACES_TIMEOUT": "",
+    "OTEL_GATEWAY_BEARER_TOKEN_FILE": "",
+    "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT": "false",
+    "OTEL_LOGS_EXPORTER": "none",
+    "OTEL_METRICS_EXPORTER": "none",
+    "OTEL_PYTHON_EXPORTER_OTLP_HTTP_CREDENTIAL_PROVIDER": "",
+    "OTEL_PYTHON_EXPORTER_OTLP_HTTP_TRACES_CREDENTIAL_PROVIDER": "",
+    "OTEL_SDK_DISABLED": "true",
+    "OTEL_TRACES_EXPORTER": "none",
+    "PORT": "8080",
+    "RELOAD_AGENTS": "false",
+    "SERVE_WEB_INTERFACE": "false",
+    "VERTEXAI_LOCATION": "",
+    "VERTEXAI_PROJECT": "",
+}
+EXPECTED_ENVIRONMENT = ALLOWED_ENVIRONMENT | FIXED_ENVIRONMENT
+ARBITRARY_ENVIRONMENT = {
+    "PYTHONPATH": "/hostile/python/path",
+    "LD_PRELOAD": "/hostile/preload.so",
+    "OTEL_EXPORTER_OTLP_ENDPOINT": "https://hostile-collector.example.test",
+}
+AMBIENT_SECRET_VALUES = {
+    "AMBIENT_SECRET": "ambient-process-secret-canary",
+    "GH_TOKEN": "ambient-github-secret-canary",
+    "HTTPS_PROXY": "https://ambient-proxy-secret-canary.example.test",
+}
+
+
+def _raw_candidate_configuration() -> dict[str, Any]:
+    """Load the committed YAML without Compose applying defaults."""
+    configuration = yaml.safe_load(CANDIDATE_COMPOSE_PATH.read_text(encoding="utf-8"))
+    assert isinstance(configuration, dict)
+    return configuration
+
+
+def _minimal_process_environment(tmp_path: Path) -> dict[str, str]:
+    """Return only the process settings needed to invoke Compose."""
+    return {
+        "COMPOSE_DISABLE_ENV_FILE": "1",
+        "HOME": os.environ.get("HOME", str(tmp_path)),
+        "LANG": "C",
+        "PATH": os.environ["PATH"],
+    }
+
+
+def _docker_with_compose(tmp_path: Path) -> str:
+    """Resolve the portable Compose boundary or skip like existing unit tests."""
+    docker = shutil.which("docker")
+    if docker is None:
+        pytest.skip("Docker CLI is unavailable")
+
+    result = subprocess.run(  # noqa: S603 - resolved Docker, fixed arguments
+        [docker, "compose", "version"],
+        env=_minimal_process_environment(tmp_path),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.skip("Docker Compose CLI is unavailable")
+    return docker
+
+
+def _write_candidate_environment(
+    tmp_path: Path,
+    *,
+    missing_name: str | None = None,
+) -> tuple[Path, set[str]]:
+    """Write allowed values plus controls that the candidate must reject."""
+    hostile_controls = {
+        name: f'hostile-{index}-$VALUE "quote" \\ slash'
+        for index, name in enumerate(FIXED_ENVIRONMENT)
+    }
+    file_environment = (
+        ALLOWED_ENVIRONMENT | hostile_controls | ARBITRARY_ENVIRONMENT
+    ).copy()
+    if missing_name in file_environment:
+        del file_environment[missing_name]
+
+    environment_path = tmp_path / "candidate.env"
+    write_compose_environment(
+        environment_path,
+        tuple(file_environment),
+        file_environment,
+    )
+    assert environment_path.stat().st_mode & 0o777 == 0o600
+    forbidden_values = set(hostile_controls.values()) | set(
+        ARBITRARY_ENVIRONMENT.values()
+    )
+    return environment_path, forbidden_values
+
+
+def _render_candidate_configuration(
+    tmp_path: Path,
+) -> tuple[dict[str, Any], str, set[str]]:
+    """Render canonical JSON with a private env file and minimal host state."""
+    docker = _docker_with_compose(tmp_path)
+    environment_path, hostile_values = _write_candidate_environment(tmp_path)
+    environment = (
+        _minimal_process_environment(tmp_path)
+        | AMBIENT_SECRET_VALUES
+        | {
+            "ENV_FILE": str(environment_path),
+            "IMAGE": CANDIDATE_IMAGE,
+        }
+    )
+    result = subprocess.run(  # noqa: S603 - resolved Docker, fixed arguments
+        [
+            docker,
+            "compose",
+            "--project-name",
+            "candidate-compose-contract",
+            "--env-file",
+            str(environment_path),
+            "-f",
+            str(CANDIDATE_COMPOSE_PATH),
+            "config",
+            "--format",
+            "json",
+        ],
+        cwd=tmp_path,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    configuration = json.loads(result.stdout)
+    assert isinstance(configuration, dict)
+    return configuration, result.stdout, hostile_values
+
+
+def test_raw_candidate_is_one_standalone_service() -> None:
+    """Keep the candidate independent from the production Compose model."""
+    document = CANDIDATE_COMPOSE_PATH.read_text(encoding="utf-8")
+    configuration = _raw_candidate_configuration()
+
+    assert set(configuration) == {"services", "x-candidate-environment-file"}
+    assert configuration["x-candidate-environment-file"] == (
+        "${ENV_FILE:?Set ENV_FILE to the candidate environment file}"
+    )
+    assert set(configuration["services"]) == {"agent"}
+    assert (
+        "# Interpolated values come only from a private serializer-produced "
+        "allowlist." in document
+    )
+
+
+def test_raw_candidate_requires_private_inputs_and_inherits_image_process() -> None:
+    """Require caller-owned inputs while preserving image ENTRYPOINT and CMD."""
+    service = _raw_candidate_configuration()["services"]["agent"]
+
+    assert service["image"] == "${IMAGE:?Set IMAGE to the candidate image}"
+    assert service["pull_policy"] == "never"
+    assert "env_file" not in service
+    assert "entrypoint" not in service
+    assert "command" not in service
+
+
+def test_raw_candidate_has_exact_isolation_and_privilege_model() -> None:
+    """Reject production resources and every supported privilege escape."""
+    service = _raw_candidate_configuration()["services"]["agent"]
+
+    assert FORBIDDEN_SERVICE_KEYS.isdisjoint(service)
+    assert service["network_mode"] == "none"
+    assert service["user"] == "1000:1000"
+    assert service["cap_drop"] == ["ALL"]
+    assert service["security_opt"] == ["no-new-privileges:true"]
+    assert service["restart"] == "no"
+    assert service["stop_grace_period"] == "10s"
+
+
+def test_raw_candidate_has_exact_environment_safety_model() -> None:
+    """Neutralize dotenv, data, model, memory, and telemetry boundaries."""
+    service = _raw_candidate_configuration()["services"]["agent"]
+
+    assert tuple(REQUIRED_ENVIRONMENT) == CANDIDATE_ENVIRONMENT_ALLOWLIST
+    assert service["environment"] == REQUIRED_ENVIRONMENT | FIXED_ENVIRONMENT
+    assert "MEM0_ENABLED" not in service["environment"]
+
+
+def test_raw_candidate_healthcheck_is_short_bounded_and_proxy_free() -> None:
+    """Probe only loopback readiness without honoring proxy configuration."""
+    healthcheck = _raw_candidate_configuration()["services"]["agent"]["healthcheck"]
+    probe = healthcheck["test"]
+
+    assert probe[:3] == ["CMD", "python", "-c"]
+    assert len(probe) == 4
+    assert "urllib.request.ProxyHandler({})" in probe[3]
+    assert "http://127.0.0.1:8080/ready" in probe[3]
+    assert "timeout=1" in probe[3]
+    assert "0.0.0.0" not in probe[3]  # noqa: S104 - rejected public bind
+    assert healthcheck == {
+        "test": probe,
+        "interval": "2s",
+        "timeout": "2s",
+        "retries": 10,
+        "start_period": "20s",
+    }
+
+
+@pytest.mark.parametrize(
+    "missing_name",
+    ["IMAGE", "ENV_FILE", *CANDIDATE_ENVIRONMENT_ALLOWLIST],
+)
+def test_compose_rejects_missing_required_input(
+    tmp_path: Path,
+    missing_name: str,
+) -> None:
+    """Fail canonical rendering when either caller-owned input is absent."""
+    docker = _docker_with_compose(tmp_path)
+    environment_path, hostile_values = _write_candidate_environment(
+        tmp_path,
+        missing_name=missing_name,
+    )
+    environment = _minimal_process_environment(tmp_path) | {
+        "ENV_FILE": str(environment_path),
+        "IMAGE": CANDIDATE_IMAGE,
+    }
+    environment.pop(missing_name, None)
+
+    result = subprocess.run(  # noqa: S603 - resolved Docker, fixed arguments
+        [
+            docker,
+            "compose",
+            "--project-name",
+            "candidate-required-input-contract",
+            "--env-file",
+            str(environment_path),
+            "-f",
+            str(CANDIDATE_COMPOSE_PATH),
+            "config",
+            "--format",
+            "json",
+        ],
+        cwd=tmp_path,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    output = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert missing_name in output
+    assert all(value not in output for value in hostile_values)
+
+
+def test_canonical_candidate_has_exact_safety_model(tmp_path: Path) -> None:
+    """Verify Compose resolves the same standalone, no-egress contract."""
+    configuration, _, _ = _render_candidate_configuration(tmp_path)
+    service = configuration["services"]["agent"]
+
+    assert set(configuration["services"]) == {"agent"}
+    assert service["image"] == CANDIDATE_IMAGE
+    assert service["pull_policy"] == "never"
+    assert service["environment"] == EXPECTED_ENVIRONMENT
+    assert service["network_mode"] == "none"
+    assert service["user"] == "1000:1000"
+    assert service["cap_drop"] == ["ALL"]
+    assert service["security_opt"] == ["no-new-privileges:true"]
+    assert service["restart"] == "no"
+    assert service["stop_grace_period"] == "10s"
+    canonical_forbidden_keys = FORBIDDEN_SERVICE_KEYS - {"command", "entrypoint"}
+    assert canonical_forbidden_keys.isdisjoint(service)
+    assert service["command"] is None
+    assert service["entrypoint"] is None
+
+    healthcheck = service["healthcheck"]
+    assert healthcheck["test"][:3] == ["CMD", "python", "-c"]
+    assert "urllib.request.ProxyHandler({})" in healthcheck["test"][3]
+    assert "http://127.0.0.1:8080/ready" in healthcheck["test"][3]
+    assert healthcheck["interval"] == "2s"
+    assert healthcheck["timeout"] == "2s"
+    assert healthcheck["retries"] == 10
+    assert healthcheck["start_period"] == "20s"
+
+
+def test_canonical_candidate_contains_no_ambient_secret_values(tmp_path: Path) -> None:
+    """Prove host and env-file canaries cannot enter the candidate model."""
+    _, canonical_json, hostile_values = _render_candidate_configuration(tmp_path)
+
+    forbidden_values = hostile_values | set(AMBIENT_SECRET_VALUES.values())
+    assert all(value not in canonical_json for value in forbidden_values)

--- a/tests/test_candidate_runtime.py
+++ b/tests/test_candidate_runtime.py
@@ -1,0 +1,1058 @@
+"""Opt-in real-Docker proof for the isolated candidate Compose contract."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import create_autospec
+
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+CANDIDATE_COMPOSE_PATH = REPOSITORY_ROOT / "compose.candidate.yaml"
+RUN_ENVIRONMENT_NAME = "RUN_CANDIDATE_INTEGRATION"
+PROJECT_PREFIX_ENVIRONMENT_NAME = "CANDIDATE_TEST_PROJECT_PREFIX"
+CANDIDATE_ENV_ALLOWLIST = (
+    "AGENT_NAME",
+    "ROOT_AGENT_MODEL",
+    "LOG_LEVEL",
+    "TELEMETRY_NAMESPACE",
+    "K_REVISION",
+    "CANDIDATE_ENV_CANARY",
+)
+HOSTILE_CANARY = (
+    "dollar$VAR${OTHER} quote\" single' backslash\\ tab\t "
+    "hash# ampersand& equals= unicode-हॅलो"
+)
+IMAGE_ID_PATTERN = re.compile(r"sha256:[0-9a-f]{64}\Z")
+PROJECT_PREFIX_PATTERN = re.compile(r"adk-candidate-[a-z0-9][a-z0-9-]{0,19}\Z")
+RESOURCE_NAME_PATTERN = re.compile(r"[a-z0-9][a-z0-9_.-]{0,62}\Z")
+EXPECTED_ENTRYPOINT = ("/app/entrypoint.sh",)
+HEALTHY_COMMAND = ("python", "-m", "agent.server")
+UNHEALTHY_COMMAND = ("python", "-c", "import time; time.sleep(300)")
+READY_PROBE = """\
+import json
+import urllib.request
+
+opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+with opener.open("http://127.0.0.1:8080/ready", timeout=3) as response:
+    payload = json.load(response)
+if payload != {
+    "status": "ready",
+    "checks": {"database": "not_configured"},
+}:
+    raise SystemExit("candidate-ready-contract-failed")
+print("candidate-ready")
+"""
+CANARY_HASH_PROBE = """\
+import hashlib
+import os
+
+value = os.environ["CANDIDATE_ENV_CANARY"].encode("utf-8")
+print(hashlib.sha256(value).hexdigest())
+"""
+
+
+@dataclass(frozen=True)
+class CandidateHarness:
+    """Validated local Docker boundary for one candidate proof."""
+
+    docker: str
+    environment: dict[str, str]
+    env_file: Path
+    resource_prefix: str
+    owned_projects: frozenset[str]
+
+    def __post_init__(self) -> None:
+        """Validate the immutable ownership boundary at construction."""
+        assert RESOURCE_NAME_PATTERN.fullmatch(self.resource_prefix)
+        assert self.owned_projects
+        for project in self.owned_projects:
+            self.assert_owned_project(project)
+
+    def assert_owned_project(self, project: str) -> None:
+        """Reject projects outside this exact per-run ownership boundary."""
+        assert RESOURCE_NAME_PATTERN.fullmatch(project)
+        assert project.startswith(f"{self.resource_prefix}-")
+        assert project in self.owned_projects
+
+    def compose_prefix(self, project: str) -> list[str]:
+        """Return the standalone exact-project Compose command."""
+        self.assert_owned_project(project)
+        return [
+            self.docker,
+            "compose",
+            "--project-name",
+            project,
+            "--env-file",
+            str(self.env_file),
+            "-f",
+            str(CANDIDATE_COMPOSE_PATH),
+        ]
+
+
+def _redact(output: str) -> str:
+    """Redact raw and common escaped representations of the synthetic canary."""
+    redacted = output
+    representations = {
+        HOSTILE_CANARY,
+        HOSTILE_CANARY.replace("$", "$$"),
+        json.dumps(HOSTILE_CANARY, ensure_ascii=False)[1:-1],
+        json.dumps(HOSTILE_CANARY, ensure_ascii=True)[1:-1],
+        repr(HOSTILE_CANARY)[1:-1],
+        repr(HOSTILE_CANARY.encode("utf-8"))[2:-1],
+    }
+    for representation in sorted(representations, key=len, reverse=True):
+        redacted = redacted.replace(representation, "[redacted]")
+    return redacted
+
+
+def _run(
+    command: list[str],
+    *,
+    environment: dict[str, str],
+    check: bool = True,
+    timeout: float = 180,
+) -> subprocess.CompletedProcess[str]:
+    """Run one fixed subprocess and redact every surfaced diagnostic."""
+    try:
+        result = subprocess.run(  # noqa: S603 - fixed resolved executables
+            command,
+            cwd=REPOSITORY_ROOT,
+            env=environment,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as error:
+        stdout = _redact(str(error.stdout or "")[-4_000:])
+        stderr = _redact(str(error.stderr or "")[-4_000:])
+        raise AssertionError(
+            f"{' '.join(command[:3])} exceeded {timeout:g} seconds\n"
+            f"stdout:\n{stdout}\nstderr:\n{stderr}"
+        ) from None
+
+    if check and result.returncode != 0:
+        stdout = _redact(result.stdout[-4_000:])
+        stderr = _redact(result.stderr[-4_000:])
+        raise AssertionError(
+            f"{' '.join(command[:3])} failed with {result.returncode}\n"
+            f"stdout:\n{stdout}\nstderr:\n{stderr}"
+        )
+    return result
+
+
+def _base_environment() -> dict[str, str]:
+    """Inherit only settings needed to reach the selected Docker daemon."""
+    inherited_names = (
+        "DOCKER_CONFIG",
+        "DOCKER_CONTEXT",
+        "DOCKER_HOST",
+        "HOME",
+        "PATH",
+        "SSL_CERT_DIR",
+        "SSL_CERT_FILE",
+        "XDG_RUNTIME_DIR",
+    )
+    environment = {
+        name: os.environ[name] for name in inherited_names if name in os.environ
+    }
+    environment.update(
+        {
+            "COMPOSE_DISABLE_ENV_FILE": "1",
+            "LANG": "C.UTF-8",
+        }
+    )
+    return environment
+
+
+def _require_docker(environment: dict[str, str]) -> str:
+    """Fail closed when an opted-in run lacks Compose or a reachable daemon."""
+    docker = shutil.which("docker", path=environment.get("PATH"))
+    assert docker is not None, "Docker CLI is required for the opted-in proof"
+    _run(
+        [docker, "compose", "version", "--short"],
+        environment=environment,
+        timeout=30,
+    )
+    daemon = _run(
+        [docker, "info", "--format", "{{.ServerVersion}}"],
+        environment=environment,
+        timeout=30,
+    )
+    assert daemon.stdout.strip(), "Docker returned no server version"
+    return docker
+
+
+def _validated_resource_prefix() -> str:
+    """Return one collision-resistant, Docker-safe resource prefix."""
+    configured_prefix = os.environ.get(
+        PROJECT_PREFIX_ENVIRONMENT_NAME,
+        f"adk-candidate-{os.getpid()}",
+    ).lower()
+    assert PROJECT_PREFIX_PATTERN.fullmatch(configured_prefix), (
+        f"{PROJECT_PREFIX_ENVIRONMENT_NAME} is invalid"
+    )
+    prefix = f"{configured_prefix}-{uuid.uuid4().hex[:8]}"
+    assert RESOURCE_NAME_PATTERN.fullmatch(prefix)
+    return prefix
+
+
+def _read_image_id(iid_file: Path) -> str:
+    """Read and validate one Docker-built immutable image ID."""
+    image_id = iid_file.read_text(encoding="ascii").strip()
+    assert IMAGE_ID_PATTERN.fullmatch(image_id), "Docker returned an invalid image ID"
+    return image_id
+
+
+def _build_image(
+    docker: str,
+    environment: dict[str, str],
+    *,
+    context: Path,
+    iid_file: Path,
+    tag: str,
+    dockerfile: Path | None = None,
+    build_arguments: tuple[str, ...] = (),
+) -> str:
+    """Build one uniquely tagged local image and return its exact ID."""
+    command = [
+        docker,
+        "build",
+        "--iidfile",
+        str(iid_file),
+        "--tag",
+        tag,
+    ]
+    if dockerfile is not None:
+        command.extend(["--file", str(dockerfile)])
+    for build_argument in build_arguments:
+        command.extend(["--build-arg", build_argument])
+    command.append(str(context))
+    _run(command, environment=environment, timeout=600)
+    try:
+        image_id = _read_image_id(iid_file)
+        inspected_id = _run(
+            [docker, "image", "inspect", "--format", "{{.Id}}", tag],
+            environment=environment,
+            timeout=30,
+        ).stdout.strip()
+        assert inspected_id == image_id
+        return image_id
+    except BaseException as error:
+        try:
+            cleanup = _run(
+                [docker, "image", "rm", tag],
+                environment=environment,
+                check=False,
+                timeout=60,
+            )
+        except BaseException as cleanup_error:
+            error.add_note(
+                "failed to clean image after post-build validation: "
+                f"{_redact(str(cleanup_error))}"
+            )
+        else:
+            if cleanup.returncode != 0:
+                error.add_note(
+                    "failed to clean image after post-build validation: "
+                    f"{_redact(cleanup.stderr[-2_000:])}"
+                )
+        raise
+
+
+def _write_candidate_environment(
+    environment: dict[str, str],
+    private_directory: Path,
+) -> Path:
+    """Create the candidate env only through the supported serializer CLI."""
+    env_file = private_directory / "candidate.env"
+    serializer_environment = environment | {
+        "AGENT_NAME": "candidate-runtime-agent",
+        "ROOT_AGENT_MODEL": "gemini-2.5-flash",
+        "LOG_LEVEL": "INFO",
+        "TELEMETRY_NAMESPACE": "candidate-runtime",
+        "K_REVISION": "candidate-runtime",
+        "CANDIDATE_ENV_CANARY": HOSTILE_CANARY,
+    }
+    _run(
+        [
+            sys.executable,
+            "-m",
+            "agent.compose_env",
+            str(env_file),
+            *CANDIDATE_ENV_ALLOWLIST,
+        ],
+        environment=serializer_environment,
+        timeout=30,
+    )
+    assert stat.S_IMODE(env_file.stat().st_mode) == 0o600
+    return env_file
+
+
+def _compose(
+    harness: CandidateHarness,
+    project: str,
+    image_id: str,
+    *arguments: str,
+    check: bool = True,
+    timeout: float = 180,
+) -> subprocess.CompletedProcess[str]:
+    """Run one standalone, exact-project candidate Compose operation."""
+    harness.assert_owned_project(project)
+    assert IMAGE_ID_PATTERN.fullmatch(image_id)
+    environment = harness.environment | {
+        "ENV_FILE": str(harness.env_file),
+        "IMAGE": image_id,
+    }
+    return _run(
+        [*harness.compose_prefix(project), *arguments],
+        environment=environment,
+        check=check,
+        timeout=timeout,
+    )
+
+
+def _container_id(
+    harness: CandidateHarness,
+    project: str,
+    image_id: str,
+) -> str:
+    """Resolve exactly one project-scoped candidate container."""
+    result = _compose(
+        harness,
+        project,
+        image_id,
+        "ps",
+        "--all",
+        "--quiet",
+        "agent",
+        timeout=30,
+    )
+    container_id = result.stdout.strip()
+    assert re.fullmatch(r"[0-9a-f]{12,64}", container_id), (
+        "Compose did not return exactly one candidate container"
+    )
+    return container_id
+
+
+def _inspect_container_field(
+    harness: CandidateHarness,
+    container_id: str,
+    template: str,
+) -> str:
+    """Inspect one non-environment container field."""
+    return _run(
+        [
+            harness.docker,
+            "container",
+            "inspect",
+            "--format",
+            template,
+            container_id,
+        ],
+        environment=harness.environment,
+        timeout=30,
+    ).stdout.strip()
+
+
+def _inspect_image_field(
+    harness: CandidateHarness,
+    image_id: str,
+    template: str,
+) -> str:
+    """Inspect one immutable local image configuration field."""
+    return _run(
+        [
+            harness.docker,
+            "image",
+            "inspect",
+            "--format",
+            template,
+            image_id,
+        ],
+        environment=harness.environment,
+        timeout=30,
+    ).stdout.strip()
+
+
+def _assert_runtime_isolation(
+    harness: CandidateHarness,
+    container_id: str,
+    image_id: str,
+    *,
+    expected_command: tuple[str, ...],
+    expected_health_status: str,
+) -> None:
+    """Prove the Docker daemon applied the tracked isolation boundary."""
+    assert (
+        _inspect_container_field(
+            harness,
+            container_id,
+            "{{.Image}}",
+        )
+        == image_id
+    )
+    assert (
+        _inspect_container_field(
+            harness,
+            container_id,
+            "{{.Config.User}}",
+        )
+        == "1000:1000"
+    )
+    assert json.loads(
+        _inspect_image_field(
+            harness,
+            image_id,
+            "{{json .Config.Entrypoint}}",
+        )
+    ) == list(EXPECTED_ENTRYPOINT)
+    assert json.loads(
+        _inspect_image_field(
+            harness,
+            image_id,
+            "{{json .Config.Cmd}}",
+        )
+    ) == list(expected_command)
+    assert json.loads(
+        _inspect_container_field(
+            harness,
+            container_id,
+            "{{json .Config.Entrypoint}}",
+        )
+    ) == list(EXPECTED_ENTRYPOINT)
+    assert json.loads(
+        _inspect_container_field(
+            harness,
+            container_id,
+            "{{json .Config.Cmd}}",
+        )
+    ) == list(expected_command)
+    assert (
+        _inspect_container_field(
+            harness,
+            container_id,
+            "{{.HostConfig.NetworkMode}}",
+        )
+        == "none"
+    )
+    assert json.loads(
+        _inspect_container_field(
+            harness,
+            container_id,
+            "{{json .HostConfig.PortBindings}}",
+        )
+    ) in (None, {})
+    assert (
+        json.loads(
+            _inspect_container_field(
+                harness,
+                container_id,
+                "{{json .Mounts}}",
+            )
+        )
+        == []
+    )
+    assert (
+        _inspect_container_field(
+            harness,
+            container_id,
+            "{{.HostConfig.RestartPolicy.Name}}",
+        )
+        == "no"
+    )
+    assert json.loads(
+        _inspect_container_field(
+            harness,
+            container_id,
+            "{{json .HostConfig.CapDrop}}",
+        )
+    ) == ["ALL"]
+    assert json.loads(
+        _inspect_container_field(
+            harness,
+            container_id,
+            "{{json .HostConfig.SecurityOpt}}",
+        )
+    ) == ["no-new-privileges:true"]
+    assert (
+        _inspect_container_field(
+            harness,
+            container_id,
+            "{{.State.Status}}",
+        )
+        == "running"
+    )
+    assert (
+        _inspect_container_field(
+            harness,
+            container_id,
+            "{{.State.Health.Status}}",
+        )
+        == expected_health_status
+    )
+
+
+def _assert_ready_and_canary(
+    harness: CandidateHarness,
+    project: str,
+    image_id: str,
+) -> None:
+    """Prove local readiness and the serializer's runtime byte contract."""
+    ready = _compose(
+        harness,
+        project,
+        image_id,
+        "exec",
+        "-T",
+        "agent",
+        "python",
+        "-c",
+        READY_PROBE,
+        timeout=30,
+    )
+    assert ready.stdout.strip() == "candidate-ready"
+
+    expected_hash = hashlib.sha256(HOSTILE_CANARY.encode("utf-8")).hexdigest()
+    actual_hash = _compose(
+        harness,
+        project,
+        image_id,
+        "exec",
+        "-T",
+        "agent",
+        "python",
+        "-c",
+        CANARY_HASH_PROBE,
+        timeout=30,
+    )
+    assert actual_hash.stdout.strip() == expected_hash
+    assert HOSTILE_CANARY not in actual_hash.stdout
+    assert HOSTILE_CANARY not in actual_hash.stderr
+
+
+def _down_candidate(
+    harness: CandidateHarness,
+    project: str,
+    image_id: str,
+) -> subprocess.CompletedProcess[str]:
+    """Remove only containers owned by one validated candidate project."""
+    harness.assert_owned_project(project)
+    return _compose(
+        harness,
+        project,
+        image_id,
+        "down",
+        "--remove-orphans",
+        "--timeout",
+        "30",
+        check=False,
+        timeout=60,
+    )
+
+
+def _identity(
+    docker: str,
+    environment: dict[str, str],
+    kind: str,
+    name: str,
+) -> str:
+    """Return one stable identity without inspecting sensitive configuration."""
+    templates = {
+        "container": "{{.Id}}",
+        "image": "{{.Id}}",
+        "network": "{{.Id}}",
+    }
+    return _run(
+        [docker, kind, "inspect", "--format", templates[kind], name],
+        environment=environment,
+        timeout=30,
+    ).stdout.strip()
+
+
+@dataclass(frozen=True)
+class VolumeIdentity:
+    """Stable sentinel volume metadata used to detect replacement."""
+
+    name: str
+    mountpoint: str
+    created_at: str
+
+
+def _volume_identity(
+    docker: str,
+    environment: dict[str, str],
+    name: str,
+) -> VolumeIdentity:
+    """Capture identity fields that change if a named volume is replaced."""
+    payload = json.loads(
+        _run(
+            [docker, "volume", "inspect", "--format", "{{json .}}", name],
+            environment=environment,
+            timeout=30,
+        ).stdout
+    )
+    identity = VolumeIdentity(
+        name=payload["Name"],
+        mountpoint=payload["Mountpoint"],
+        created_at=payload["CreatedAt"],
+    )
+    assert identity.name == name
+    assert identity.mountpoint
+    assert identity.created_at
+    return identity
+
+
+def test_require_docker_rejects_missing_cli(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An opted-in run must fail rather than silently skip without Docker."""
+    monkeypatch.setattr(shutil, "which", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(AssertionError, match="Docker CLI is required"):
+        _require_docker({"PATH": "/missing"})
+
+
+@pytest.mark.parametrize(
+    ("compose_exit", "daemon_exit"),
+    ((17, 0), (0, 19)),
+)
+def test_require_docker_rejects_missing_compose_or_daemon(
+    tmp_path: Path,
+    compose_exit: int,
+    daemon_exit: int,
+) -> None:
+    """Propagate either unavailable boundary as a hard opt-in failure."""
+    docker = tmp_path / "docker"
+    docker.write_text(
+        "#!/bin/sh\n"
+        "set -eu\n"
+        'if [ "$1" = "compose" ]; then\n'
+        '  [ "$FAKE_COMPOSE_EXIT" -eq 0 ] || exit "$FAKE_COMPOSE_EXIT"\n'
+        "  printf '2.40.3\\n'\n"
+        "  exit 0\n"
+        "fi\n"
+        'if [ "$1" = "info" ]; then\n'
+        '  [ "$FAKE_DAEMON_EXIT" -eq 0 ] || exit "$FAKE_DAEMON_EXIT"\n'
+        "  printf '29.1.3\\n'\n"
+        "  exit 0\n"
+        "fi\n"
+        "exit 99\n",
+        encoding="utf-8",
+    )
+    docker.chmod(0o755)
+    environment = {
+        "FAKE_COMPOSE_EXIT": str(compose_exit),
+        "FAKE_DAEMON_EXIT": str(daemon_exit),
+        "LANG": "C",
+        "PATH": str(tmp_path),
+    }
+
+    with pytest.raises(AssertionError):
+        _require_docker(environment)
+
+
+@pytest.mark.parametrize(
+    "representation",
+    (
+        HOSTILE_CANARY,
+        HOSTILE_CANARY.replace("$", "$$"),
+        json.dumps(HOSTILE_CANARY, ensure_ascii=False)[1:-1],
+        json.dumps(HOSTILE_CANARY, ensure_ascii=True)[1:-1],
+        repr(HOSTILE_CANARY)[1:-1],
+        repr(HOSTILE_CANARY.encode("utf-8"))[2:-1],
+    ),
+)
+def test_redact_covers_common_canary_serializations(representation: str) -> None:
+    """Remove each expected shell, JSON, text-repr, and byte-repr form."""
+    assert _redact(f"before:{representation}:after") == "before:[redacted]:after"
+
+
+def test_run_redacts_timeout_byte_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Do not surface the canary when TimeoutExpired carries byte output."""
+    canary_bytes = HOSTILE_CANARY.encode("utf-8")
+    timeout_error = subprocess.TimeoutExpired(
+        cmd=["docker", "info"],
+        timeout=1,
+        output=b"stdout:" + canary_bytes + b":end",
+        stderr=b"stderr:" + canary_bytes + b":end",
+    )
+    run_mock = create_autospec(
+        subprocess.run,
+        spec_set=True,
+        side_effect=timeout_error,
+    )
+    monkeypatch.setattr(subprocess, "run", run_mock)
+
+    with pytest.raises(AssertionError, match="exceeded") as raised:
+        _run(["docker", "info"], environment={}, timeout=1)
+
+    diagnostic = str(raised.value)
+    assert HOSTILE_CANARY not in diagnostic
+    assert repr(canary_bytes)[2:-1] not in diagnostic
+    assert diagnostic.count("[redacted]") == 2
+
+
+def test_candidate_harness_rejects_unowned_projects(tmp_path: Path) -> None:
+    """Require both exact prefix ownership and explicit project registration."""
+    prefix = "adk-candidate-unit-12345678"
+    healthy_project = f"{prefix}-healthy"
+    unhealthy_project = f"{prefix}-unhealthy"
+    harness = CandidateHarness(
+        docker="/usr/bin/docker",
+        environment={},
+        env_file=tmp_path / "candidate.env",
+        resource_prefix=prefix,
+        owned_projects=frozenset({healthy_project, unhealthy_project}),
+    )
+
+    assert healthy_project in harness.compose_prefix(healthy_project)
+    with pytest.raises(AssertionError):
+        harness.compose_prefix(f"{prefix}-unregistered")
+    with pytest.raises(AssertionError):
+        harness.compose_prefix("adk-candidate-foreign-12345678-healthy")
+    with pytest.raises(AssertionError):
+        CandidateHarness(
+            docker="/usr/bin/docker",
+            environment={},
+            env_file=tmp_path / "candidate.env",
+            resource_prefix=prefix,
+            owned_projects=frozenset({"adk-candidate-foreign-12345678-healthy"}),
+        )
+
+
+@pytest.mark.skipif(
+    os.environ.get(RUN_ENVIRONMENT_NAME) != "1",
+    reason="real candidate Docker proof is opt-in",
+)
+def test_candidate_runtime_is_isolated_and_fail_closed(tmp_path: Path) -> None:
+    """Prove isolated startup, env fidelity, rejection, and scoped cleanup."""
+    environment = _base_environment()
+    docker = _require_docker(environment)
+    prefix = _validated_resource_prefix()
+    private_directory = tmp_path / "candidate-private"
+    private_directory.mkdir(mode=0o700)
+    private_directory.chmod(0o700)
+    assert stat.S_IMODE(private_directory.stat().st_mode) == 0o700
+
+    healthy_project = f"{prefix}-healthy"
+    unhealthy_project = f"{prefix}-unhealthy"
+    healthy_tag = f"candidate-runtime-healthy:{prefix}"
+    unhealthy_tag = f"candidate-runtime-unhealthy:{prefix}"
+    sentinel_image_tag = f"candidate-runtime-sentinel:{prefix}"
+    sentinel_container = f"{prefix}-sentinel-container"
+    sentinel_volume = f"{prefix}-sentinel-volume"
+    sentinel_network = f"{prefix}-sentinel-network"
+
+    harness: CandidateHarness | None = None
+    cleanup_failures: list[str] = []
+    active_projects: dict[str, str] = {}
+    created_resources: list[list[str]] = []
+    primary_error: BaseException | None = None
+    try:
+        assert CANDIDATE_COMPOSE_PATH.is_file()
+        healthy_iid_file = private_directory / "healthy.iid"
+        healthy_image_id = _build_image(
+            docker,
+            environment,
+            context=REPOSITORY_ROOT,
+            iid_file=healthy_iid_file,
+            tag=healthy_tag,
+        )
+        created_resources.append([docker, "image", "rm", healthy_tag])
+        env_file = _write_candidate_environment(environment, private_directory)
+        harness = CandidateHarness(
+            docker=docker,
+            environment=environment,
+            env_file=env_file,
+            resource_prefix=prefix,
+            owned_projects=frozenset({healthy_project, unhealthy_project}),
+        )
+
+        sentinel_context = private_directory / "sentinel-context"
+        sentinel_context.mkdir(mode=0o700)
+        sentinel_dockerfile = sentinel_context / "Dockerfile"
+        sentinel_dockerfile.write_text(
+            f'FROM scratch\nLABEL candidate.runtime.sentinel="{prefix}"\n',
+            encoding="utf-8",
+        )
+        sentinel_image_id = _build_image(
+            docker,
+            environment,
+            context=sentinel_context,
+            iid_file=private_directory / "sentinel.iid",
+            tag=sentinel_image_tag,
+        )
+        created_resources.append([docker, "image", "rm", sentinel_image_tag])
+        sentinel_container_create = _run(
+            [
+                docker,
+                "container",
+                "create",
+                "--name",
+                sentinel_container,
+                "--network",
+                "none",
+                "--entrypoint",
+                "/bin/true",
+                healthy_image_id,
+            ],
+            environment=environment,
+            timeout=30,
+        )
+        created_resources.append([docker, "container", "rm", sentinel_container])
+        sentinel_container_id = sentinel_container_create.stdout.strip()
+        assert re.fullmatch(r"[0-9a-f]{12,64}", sentinel_container_id)
+        _run(
+            [docker, "container", "start", "--attach", sentinel_container],
+            environment=environment,
+            timeout=30,
+        )
+        assert (
+            _run(
+                [
+                    docker,
+                    "container",
+                    "inspect",
+                    "--format",
+                    "{{.State.Status}}",
+                    sentinel_container,
+                ],
+                environment=environment,
+                timeout=30,
+            ).stdout.strip()
+            == "exited"
+        )
+
+        created_volume_result = _run(
+            [docker, "volume", "create", sentinel_volume],
+            environment=environment,
+            timeout=30,
+        )
+        created_resources.append([docker, "volume", "rm", sentinel_volume])
+        created_volume = created_volume_result.stdout.strip()
+        assert created_volume == sentinel_volume
+        sentinel_volume_identity = _volume_identity(
+            docker,
+            environment,
+            sentinel_volume,
+        )
+        sentinel_network_create = _run(
+            [docker, "network", "create", sentinel_network],
+            environment=environment,
+            timeout=30,
+        )
+        created_resources.append([docker, "network", "rm", sentinel_network])
+        sentinel_network_id = sentinel_network_create.stdout.strip()
+        assert re.fullmatch(r"[0-9a-f]{12,64}", sentinel_network_id)
+
+        unhealthy_context = private_directory / "unhealthy-context"
+        unhealthy_context.mkdir(mode=0o700)
+        unhealthy_dockerfile = unhealthy_context / "Dockerfile"
+        unhealthy_dockerfile.write_text(
+            "ARG BASE_IMAGE\n"
+            "FROM ${BASE_IMAGE}\n"
+            f"CMD {json.dumps(UNHEALTHY_COMMAND)}\n",
+            encoding="utf-8",
+        )
+        unhealthy_image_id = _build_image(
+            docker,
+            environment,
+            context=unhealthy_context,
+            dockerfile=unhealthy_dockerfile,
+            iid_file=private_directory / "unhealthy.iid",
+            tag=unhealthy_tag,
+            build_arguments=(f"BASE_IMAGE={healthy_image_id}",),
+        )
+        created_resources.append([docker, "image", "rm", unhealthy_tag])
+
+        active_projects.update(
+            {
+                healthy_project: healthy_image_id,
+                unhealthy_project: unhealthy_image_id,
+            }
+        )
+        _compose(
+            harness,
+            healthy_project,
+            healthy_image_id,
+            "config",
+            "--quiet",
+            timeout=30,
+        )
+        _compose(
+            harness,
+            healthy_project,
+            healthy_image_id,
+            "up",
+            "--detach",
+            "--no-build",
+            "--pull",
+            "never",
+            "--wait",
+            "--wait-timeout",
+            "120",
+            "agent",
+            timeout=150,
+        )
+        healthy_container_id = _container_id(
+            harness,
+            healthy_project,
+            healthy_image_id,
+        )
+        _assert_runtime_isolation(
+            harness,
+            healthy_container_id,
+            healthy_image_id,
+            expected_command=HEALTHY_COMMAND,
+            expected_health_status="healthy",
+        )
+        _assert_ready_and_canary(
+            harness,
+            healthy_project,
+            healthy_image_id,
+        )
+        healthy_down = _down_candidate(
+            harness,
+            healthy_project,
+            healthy_image_id,
+        )
+        assert healthy_down.returncode == 0, _redact(healthy_down.stderr[-2_000:])
+        active_projects.pop(healthy_project)
+
+        started = time.monotonic()
+        unhealthy_up = _compose(
+            harness,
+            unhealthy_project,
+            unhealthy_image_id,
+            "up",
+            "--detach",
+            "--no-build",
+            "--pull",
+            "never",
+            "--wait",
+            "--wait-timeout",
+            "45",
+            "agent",
+            check=False,
+            timeout=60,
+        )
+        elapsed = time.monotonic() - started
+        assert unhealthy_up.returncode != 0, (
+            "The intentionally non-ready candidate unexpectedly passed"
+        )
+        assert elapsed < 60, "The intentionally non-ready candidate failed too slowly"
+        unhealthy_container_id = _container_id(
+            harness,
+            unhealthy_project,
+            unhealthy_image_id,
+        )
+        _assert_runtime_isolation(
+            harness,
+            unhealthy_container_id,
+            unhealthy_image_id,
+            expected_command=UNHEALTHY_COMMAND,
+            expected_health_status="unhealthy",
+        )
+        unhealthy_down = _down_candidate(
+            harness,
+            unhealthy_project,
+            unhealthy_image_id,
+        )
+        assert unhealthy_down.returncode == 0, _redact(unhealthy_down.stderr[-2_000:])
+        active_projects.pop(unhealthy_project)
+
+        assert (
+            _identity(
+                docker,
+                environment,
+                "container",
+                sentinel_container,
+            )
+            == sentinel_container_id
+        )
+        assert (
+            _identity(
+                docker,
+                environment,
+                "image",
+                sentinel_image_tag,
+            )
+            == sentinel_image_id
+        )
+        assert (
+            _volume_identity(
+                docker,
+                environment,
+                sentinel_volume,
+            )
+            == sentinel_volume_identity
+        )
+        assert (
+            _identity(
+                docker,
+                environment,
+                "network",
+                sentinel_network,
+            )
+            == sentinel_network_id
+        )
+    except BaseException as error:
+        primary_error = error
+        raise
+    finally:
+        if harness is not None:
+            for project, image_id in active_projects.items():
+                try:
+                    result = _down_candidate(harness, project, image_id)
+                except BaseException as cleanup_error:
+                    cleanup_failures.append(
+                        "candidate project cleanup failed: "
+                        f"{_redact(str(cleanup_error))}"
+                    )
+                else:
+                    if result.returncode != 0:
+                        cleanup_failures.append(
+                            "candidate project cleanup failed: "
+                            f"{_redact(result.stderr[-2_000:])}"
+                        )
+
+        for command in reversed(created_resources):
+            try:
+                result = _run(
+                    command,
+                    environment=environment,
+                    check=False,
+                    timeout=60,
+                )
+            except BaseException as cleanup_error:
+                cleanup_failures.append(
+                    f"exact resource cleanup failed: {_redact(str(cleanup_error))}"
+                )
+            else:
+                if result.returncode != 0:
+                    cleanup_failures.append(
+                        "exact resource cleanup failed: "
+                        f"{_redact(result.stderr[-2_000:])}"
+                    )
+
+        if cleanup_failures:
+            cleanup_message = "\n".join(cleanup_failures)
+            if primary_error is not None:
+                primary_error.add_note(cleanup_message)
+            else:
+                raise AssertionError(cleanup_message)

--- a/tests/test_candidate_runtime.py
+++ b/tests/test_candidate_runtime.py
@@ -876,7 +876,7 @@ def test_candidate_runtime_is_isolated_and_fail_closed(tmp_path: Path) -> None:
             dockerfile=unhealthy_dockerfile,
             iid_file=private_directory / "unhealthy.iid",
             tag=unhealthy_tag,
-            build_arguments=(f"BASE_IMAGE={healthy_image_id}",),
+            build_arguments=(f"BASE_IMAGE={healthy_tag}",),
         )
         created_resources.append([docker, "image", "rm", unhealthy_tag])
 

--- a/tests/test_candidate_workflow.py
+++ b/tests/test_candidate_workflow.py
@@ -1,0 +1,246 @@
+"""Static CI and safety contracts for the candidate runtime proof."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = REPOSITORY_ROOT / ".github" / "workflows" / "test-docker-compose.yml"
+RUNTIME_TEST_PATH = REPOSITORY_ROOT / "tests" / "test_candidate_runtime.py"
+CHECKOUT_PIN = "3d3c42e5aac5ba805825da76410c181273ba90b1"
+SETUP_UV_PIN = "d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86"
+EXPECTED_ENV_ALLOWLIST = (
+    "AGENT_NAME",
+    "ROOT_AGENT_MODEL",
+    "LOG_LEVEL",
+    "TELEMETRY_NAMESPACE",
+    "K_REVISION",
+    "CANDIDATE_ENV_CANARY",
+)
+
+
+def _job_block(document: str, job_name: str) -> str:
+    """Return one complete top-level workflow job."""
+    lines = document.splitlines()
+    start = lines.index(f"  {job_name}:")
+    block = [lines[start]]
+    for line in lines[start + 1 :]:
+        if line.startswith("  ") and not line.startswith("    ") and line.endswith(":"):
+            break
+        block.append(line)
+    return "\n".join(block)
+
+
+def _assigned_literal(source: str, name: str) -> object:
+    """Return one module-level literal assignment without importing the test."""
+    for node in ast.parse(source).body:
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+            assigned_value: ast.expr | None = node.value
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+            assigned_value = node.value
+        else:
+            continue
+        if any(
+            isinstance(target, ast.Name) and target.id == name for target in targets
+        ):
+            assert assigned_value is not None
+            return ast.literal_eval(assigned_value)
+    raise AssertionError(f"{name} is not assigned")
+
+
+def _function_source(source: str, name: str) -> str:
+    """Return exact source for one top-level function using its AST range."""
+    for node in ast.parse(source).body:
+        if (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == name
+        ):
+            assert node.end_lineno is not None
+            return "\n".join(source.splitlines()[node.lineno - 1 : node.end_lineno])
+    raise AssertionError(f"{name} is not defined")
+
+
+def _class_source(source: str, name: str) -> str:
+    """Return exact source for one top-level class using its AST range."""
+    for node in ast.parse(source).body:
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            assert node.end_lineno is not None
+            return "\n".join(source.splitlines()[node.lineno - 1 : node.end_lineno])
+    raise AssertionError(f"{name} is not defined")
+
+
+def test_candidate_job_inherits_read_only_least_privilege_context() -> None:
+    """Run on normal main changes without secrets or write permissions."""
+    document = WORKFLOW_PATH.read_text(encoding="utf-8")
+    candidate_job = _job_block(document, "candidate")
+
+    assert "pull_request_target" not in document
+    assert '  push:\n    branches: ["main"]' in document
+    assert '  pull_request:\n    branches: ["main"]' in document
+    assert "\npermissions:\n  contents: read\n" in document
+    assert "permissions:" not in candidate_job
+    assert ": write" not in candidate_job
+    assert "id-token:" not in candidate_job
+    assert "secrets." not in candidate_job
+    assert "github.token" not in candidate_job
+    assert "GITHUB_TOKEN" not in candidate_job
+    assert "runs-on: ubuntu-latest" in candidate_job
+    assert "timeout-minutes: 20" in candidate_job
+
+
+def test_candidate_job_uses_pinned_tools_and_one_focused_test() -> None:
+    """Keep the daemon-capable job immutable, locked, and narrowly scoped."""
+    document = WORKFLOW_PATH.read_text(encoding="utf-8")
+    candidate_job = _job_block(document, "candidate")
+
+    assert candidate_job.count("actions/checkout@") == 1
+    assert f"uses: actions/checkout@{CHECKOUT_PIN} # v7.0.1" in candidate_job
+    assert candidate_job.count("persist-credentials: false") == 1
+    assert candidate_job.count("astral-sh/setup-uv@") == 1
+    assert f"uses: astral-sh/setup-uv@{SETUP_UV_PIN} # v5" in candidate_job
+    assert "run: uv python install 3.13" in candidate_job
+    assert "run: uv sync --locked" in candidate_job
+    assert candidate_job.count("uv run pytest") == 1
+    assert "run: uv run pytest tests/test_candidate_runtime.py -q" in candidate_job
+    assert "docker/login-action" not in candidate_job
+    assert "push: true" not in candidate_job
+
+
+def test_candidate_job_explicitly_enables_a_unique_project_prefix() -> None:
+    """Turn on the real proof only in its isolated CI job."""
+    candidate_job = _job_block(
+        WORKFLOW_PATH.read_text(encoding="utf-8"),
+        "candidate",
+    )
+
+    assert 'RUN_CANDIDATE_INTEGRATION: "1"' in candidate_job
+    assert "adk-candidate-${{ github.run_id }}" in candidate_job
+    assert "github.run_attempt" not in candidate_job
+    assert "COMPOSE_PROJECT_NAME" not in candidate_job
+
+
+def test_candidate_runtime_uses_the_exact_environment_allowlist() -> None:
+    """Prevent unrelated host or production settings from entering the candidate."""
+    source = RUNTIME_TEST_PATH.read_text(encoding="utf-8")
+    assert (
+        _assigned_literal(source, "CANDIDATE_ENV_ALLOWLIST") == EXPECTED_ENV_ALLOWLIST
+    )
+
+    serializer_source = _function_source(source, "_write_candidate_environment")
+    assert '"agent.compose_env"' in serializer_source
+    assert "*CANDIDATE_ENV_ALLOWLIST" in serializer_source
+    assert "env_file.write" not in serializer_source
+    assert "OPENROUTER_API_KEY" not in source
+    assert "GOOGLE_API_KEY" not in source
+    assert "DATABASE_URL" not in source
+
+
+def test_candidate_runtime_cleanup_is_exact_and_non_destructive() -> None:
+    """Forbid broad Compose, image, volume, and daemon cleanup."""
+    source = RUNTIME_TEST_PATH.read_text(encoding="utf-8")
+    down_source = _function_source(source, "_down_candidate")
+
+    for forbidden in ("--volumes", "--rmi", "prune"):
+        assert forbidden not in source
+    assert '"down"' in down_source
+    assert '"--remove-orphans"' in down_source
+    assert '"--timeout"' in down_source
+    assert '"30"' in down_source
+    assert "check=False" in down_source
+
+
+def test_candidate_runtime_declares_both_project_ownership_guards() -> None:
+    """Statically require prefix and membership checks at Compose cleanup boundaries."""
+    source = RUNTIME_TEST_PATH.read_text(encoding="utf-8")
+    harness_source = _class_source(source, "CandidateHarness")
+    compose_source = _function_source(source, "_compose")
+    down_source = _function_source(source, "_down_candidate")
+
+    assert "resource_prefix: str" in harness_source
+    assert "owned_projects: frozenset[str]" in harness_source
+    assert 'project.startswith(f"{self.resource_prefix}-")' in harness_source
+    assert "project in self.owned_projects" in harness_source
+    assert "harness.assert_owned_project(project)" in compose_source
+    assert "harness.assert_owned_project(project)" in down_source
+
+
+def test_candidate_unhealthy_proof_checks_the_exact_running_contract() -> None:
+    """Statically keep the opt-in rejection path tied to the intended container."""
+    source = RUNTIME_TEST_PATH.read_text(encoding="utf-8")
+    runtime_source = _function_source(
+        source,
+        "test_candidate_runtime_is_isolated_and_fail_closed",
+    )
+    isolation_source = _function_source(source, "_assert_runtime_isolation")
+
+    assert _assigned_literal(source, "EXPECTED_ENTRYPOINT") == ("/app/entrypoint.sh",)
+    assert _assigned_literal(source, "UNHEALTHY_COMMAND") == (
+        "python",
+        "-c",
+        "import time; time.sleep(300)",
+    )
+    assert "assert unhealthy_up.returncode != 0" in runtime_source
+    assert "unhealthy_container_id = _container_id(" in runtime_source
+    assert "expected_command=UNHEALTHY_COMMAND" in runtime_source
+    assert 'expected_health_status="unhealthy"' in runtime_source
+    for inspected_field in (
+        "{{.Image}}",
+        "{{.Config.User}}",
+        "{{json .Config.Entrypoint}}",
+        "{{json .Config.Cmd}}",
+        "{{.HostConfig.NetworkMode}}",
+        "{{json .HostConfig.PortBindings}}",
+        "{{json .Mounts}}",
+        "{{.HostConfig.RestartPolicy.Name}}",
+        "{{json .HostConfig.CapDrop}}",
+        "{{json .HostConfig.SecurityOpt}}",
+        "{{.State.Status}}",
+        "{{.State.Health.Status}}",
+    ):
+        assert inspected_field in isolation_source
+    assert '== "running"' in isolation_source
+    assert "== expected_health_status" in isolation_source
+
+
+def test_candidate_volume_sentinel_uses_replacement_sensitive_identity() -> None:
+    """Keep the sentinel comparison stronger than volume-name existence."""
+    source = RUNTIME_TEST_PATH.read_text(encoding="utf-8")
+    identity_source = _function_source(source, "_volume_identity")
+    runtime_source = _function_source(
+        source,
+        "test_candidate_runtime_is_isolated_and_fail_closed",
+    )
+
+    for field in ('payload["Name"]', 'payload["Mountpoint"]', 'payload["CreatedAt"]'):
+        assert field in identity_source
+    assert "sentinel_volume_identity = _volume_identity(" in runtime_source
+    assert "== sentinel_volume_identity" in runtime_source
+
+
+def test_candidate_runtime_fails_closed_only_at_the_real_docker_boundary() -> None:
+    """Keep helper contracts runnable while opt-in governs only daemon work."""
+    source = RUNTIME_TEST_PATH.read_text(encoding="utf-8")
+    module = ast.parse(source)
+    runtime_test = next(
+        node
+        for node in module.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "test_candidate_runtime_is_isolated_and_fail_closed"
+    )
+
+    assert "pytestmark" not in source
+    assert any(
+        isinstance(decorator, ast.Call)
+        and isinstance(decorator.func, ast.Attribute)
+        and decorator.func.attr == "skipif"
+        for decorator in runtime_test.decorator_list
+    )
+    assert "def test_require_docker_rejects_missing_cli" in source
+    assert "def test_require_docker_rejects_missing_compose_or_daemon" in source
+    assert "_require_docker(environment)" in _function_source(
+        source,
+        runtime_test.name,
+    )

--- a/tests/test_candidate_workflow.py
+++ b/tests/test_candidate_workflow.py
@@ -186,6 +186,8 @@ def test_candidate_unhealthy_proof_checks_the_exact_running_contract() -> None:
     assert "unhealthy_container_id = _container_id(" in runtime_source
     assert "expected_command=UNHEALTHY_COMMAND" in runtime_source
     assert 'expected_health_status="unhealthy"' in runtime_source
+    assert 'build_arguments=(f"BASE_IMAGE={healthy_tag}",)' in runtime_source
+    assert 'build_arguments=(f"BASE_IMAGE={healthy_image_id}",)' not in runtime_source
     for inspected_field in (
         "{{.Image}}",
         "{{.Config.User}}",

--- a/tests/test_compose_workflow.py
+++ b/tests/test_compose_workflow.py
@@ -245,7 +245,7 @@ def test_workflow_checkout_is_immutable_and_drops_credentials() -> None:
     document = WORKFLOW_PATH.read_text(encoding="utf-8")
     checkout_uses = list(CHECKOUT_USES_PATTERN.finditer(document))
 
-    assert len(checkout_uses) == 2
+    assert len(checkout_uses) == 3
     for checkout_use in checkout_uses:
         checkout_reference = checkout_use.group("reference")
         assert re.fullmatch(r"[0-9a-f]{40}", checkout_reference)
@@ -254,7 +254,7 @@ def test_workflow_checkout_is_immutable_and_drops_credentials() -> None:
     assert {match.group("reference") for match in checkout_uses} == {
         "3d3c42e5aac5ba805825da76410c181273ba90b1"
     }
-    assert document.count("persist-credentials: false") == 2
+    assert document.count("persist-credentials: false") == 3
     assert "secrets." not in document
     assert "packages: write" not in document
     assert "docker/login-action" not in document


### PR DESCRIPTION
## What

Add a standalone, no-egress Docker Compose contract for validating an exact
candidate agent image before any deployment or promotion step.

## Why

The transactional VM deployment roadmap needs an isolated preflight boundary.
An image must prove that it can boot, become healthy, and fail observably
without inheriting production ports, volumes, credentials, or external
network access.

## How

- Require an explicit candidate image and disable pulling or building
- Pass only six allowlisted runtime values into the candidate container
- Override external integrations and run with no network, ports, or mounts
- Verify healthy and deliberately unhealthy images through real Docker
- Assert entrypoint, command, user, security, health, and isolation contracts
- Preserve unrelated Docker resources through owned-project cleanup guards
- Add a separate read-only, secret-free hosted candidate validation job

## Tests

- [x] `uv sync --locked`
- [x] `uv run ruff format`
- [x] `uv run ruff format --check`
- [x] `uv run ruff check --no-fix --output-format=github`
- [x] `uv run mypy .`
- [x] `uv run pytest --cov=src --cov-report=xml --cov-report=term-missing`
      (`677 passed, 7 skipped`; 100% statement and branch coverage)
- [x] Hosted `Validate isolated candidate runtime` Docker job

Local Docker runtime success is not claimed: the Docker CLI was available, but
the local daemon was unresponsive. The hosted Docker job is the required
independent runtime proof.

## Related Issues

Closes #115

Part of #111
