### PR TITLE
feat: add durable VM deployment state

### DIFF
--- a/.github/workflows/test-docker-compose.yml
+++ b/.github/workflows/test-docker-compose.yml
@@ -360,6 +360,36 @@ jobs:
       - name: Run isolated candidate proof
         run: uv run pytest tests/test_candidate_runtime.py -q
 
+  deployment-state:
+    name: Validate VM deployment-state adoption
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      RUN_DEPLOYMENT_STATE_INTEGRATION: "1"
+      DEPLOYMENT_STATE_TEST_PREFIX: >-
+        adk-state-${{ github.run_id }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Install Python
+        run: uv python install 3.13
+
+      - name: Install locked dependencies
+        run: uv sync --locked
+
+      - name: Run real VM deployment-state proof
+        run: uv run pytest tests/test_deployment_state_runtime.py -q
+
   trace-gateway:
     name: Validate trace-redaction gateway
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
 
 [project.scripts]
 server = "agent.server:main"
+deployment-state = "agent.deployment_state_cli:main"
 
 [dependency-groups]
 dev = [

--- a/src/agent/deployment_adoption.py
+++ b/src/agent/deployment_adoption.py
@@ -1,0 +1,433 @@
+"""Read-only proof of an existing Compose deployment before state adoption."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import stat
+import subprocess
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+_COMPOSE_NAME = re.compile(r"[a-z0-9][a-z0-9_-]{0,62}\Z")
+_CONTAINER_ID = re.compile(r"[0-9a-f]{12,64}\Z")
+_REVISION = re.compile(r"[0-9a-f]{40}\Z")
+_IMAGE_ID = re.compile(r"sha256:[0-9a-f]{64}\Z")
+_REPOSITORY_COMPONENT = r"[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*"
+_REGISTRY_LABEL = r"[a-z0-9](?:[a-z0-9-]*[a-z0-9])?"
+_IMAGE_REFERENCE = re.compile(
+    rf"(?=.{{1,255}}@sha256:)"
+    rf"(?:{_REGISTRY_LABEL}(?:\.{_REGISTRY_LABEL})*(?::[0-9]{{1,5}})?/)?"
+    rf"{_REPOSITORY_COMPONENT}(?:/{_REPOSITORY_COMPONENT})*"
+    r"@sha256:[0-9a-f]{64}\Z"
+)
+_GITHUB_ORIGIN = re.compile(r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\Z")
+_MAX_OUTPUT_BYTES = 256 * 1024
+
+
+class DeploymentAdoptionError(RuntimeError):
+    """Report a secret-free legacy deployment observation failure."""
+
+
+@dataclass(frozen=True, slots=True)
+class DeploymentObservation:
+    """Exact read-only facts required to adopt one existing deployment."""
+
+    checkout_path: Path
+    origin: str
+    revision: str
+    compose_project: str
+    compose_service: str
+    environment_path: Path
+    image_reference: str
+    image_id: str
+    oci_revision: str
+
+
+def _validated_name(value: str, field: str) -> str:
+    if _COMPOSE_NAME.fullmatch(value) is None:
+        raise DeploymentAdoptionError(f"adoption input is invalid: {field}")
+    return value
+
+
+def _validated_executable(path: Path, field: str) -> Path:
+    try:
+        resolved = path.resolve(strict=True)
+        metadata = resolved.stat()
+    except OSError:
+        raise DeploymentAdoptionError(
+            f"adoption executable is unavailable: {field}"
+        ) from None
+    if (
+        not path.is_absolute()
+        or not stat.S_ISREG(metadata.st_mode)
+        or not os.access(resolved, os.X_OK)
+    ):
+        raise DeploymentAdoptionError(f"adoption executable is invalid: {field}")
+    return resolved
+
+
+def _command_environment(
+    environment: Mapping[str, str] | None,
+) -> dict[str, str]:
+    source = os.environ if environment is None else environment
+    selected = {
+        key: value
+        for key, value in source.items()
+        if not key.startswith("GIT_") and key not in {"LC_ALL", "LANG"}
+    }
+    selected.update(
+        {
+            "GIT_OPTIONAL_LOCKS": "0",
+            "GIT_TERMINAL_PROMPT": "0",
+            "LC_ALL": "C",
+            "LANG": "C",
+        }
+    )
+    return selected
+
+
+def _run(
+    executable: Path,
+    arguments: Sequence[str],
+    *,
+    environment: Mapping[str, str],
+    cwd: Path | None = None,
+    accepted_returncodes: frozenset[int] = frozenset({0}),
+) -> subprocess.CompletedProcess[str]:
+    try:
+        result = subprocess.run(  # noqa: S603 - resolved executable, fixed arguments
+            [str(executable), *arguments],
+            cwd=cwd,
+            env=environment,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        raise DeploymentAdoptionError(
+            "legacy deployment observation command failed"
+        ) from None
+    if result.returncode not in accepted_returncodes:
+        raise DeploymentAdoptionError("legacy deployment observation command failed")
+    if len(result.stdout.encode()) > _MAX_OUTPUT_BYTES:
+        raise DeploymentAdoptionError(
+            "legacy deployment observation output is too large"
+        )
+    return result
+
+
+def _one_line(value: str, field: str) -> str:
+    selected = value[:-1] if value.endswith("\n") else value
+    if not selected or "\n" in selected or "\r" in selected or "\0" in selected:
+        raise DeploymentAdoptionError(f"legacy deployment output is invalid: {field}")
+    return selected
+
+
+def _json_document(value: str, field: str) -> dict[str, object]:
+    try:
+        decoded = json.loads(value)
+    except json.JSONDecodeError:
+        raise DeploymentAdoptionError(
+            f"legacy deployment output is invalid: {field}"
+        ) from None
+    if not isinstance(decoded, list) or len(decoded) != 1:
+        raise DeploymentAdoptionError(f"legacy deployment output is invalid: {field}")
+    document = decoded[0]
+    if not isinstance(document, dict):
+        raise DeploymentAdoptionError(f"legacy deployment output is invalid: {field}")
+    return document
+
+
+def _nested_mapping(
+    document: Mapping[str, object],
+    key: str,
+    field: str,
+) -> Mapping[str, object]:
+    value = document.get(key)
+    if not isinstance(value, dict):
+        raise DeploymentAdoptionError(f"legacy deployment output is invalid: {field}")
+    return value
+
+
+def _string_field(
+    document: Mapping[str, object],
+    key: str,
+    field: str,
+) -> str:
+    value = document.get(key)
+    if not isinstance(value, str):
+        raise DeploymentAdoptionError(f"legacy deployment output is invalid: {field}")
+    return value
+
+
+def _validate_checkout(path: Path) -> Path:
+    if not path.is_absolute():
+        raise DeploymentAdoptionError("adoption checkout path must be absolute")
+    try:
+        resolved = path.resolve(strict=True)
+        metadata = resolved.stat()
+    except OSError:
+        raise DeploymentAdoptionError("adoption checkout path is unavailable") from None
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise DeploymentAdoptionError("adoption checkout path is not a directory")
+    return resolved
+
+
+def _validate_environment(path: Path, checkout: Path) -> Path:
+    expected = checkout / ".env"
+    if not path.is_absolute() or path.resolve(strict=False) != expected:
+        raise DeploymentAdoptionError("legacy environment path must be checkout .env")
+    try:
+        metadata = path.lstat()
+    except OSError:
+        raise DeploymentAdoptionError(
+            "legacy environment file is unavailable"
+        ) from None
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or stat.S_IMODE(metadata.st_mode) != 0o600
+        or metadata.st_nlink != 1
+        or metadata.st_size <= 0
+    ):
+        raise DeploymentAdoptionError("legacy environment file is unsafe")
+    return path
+
+
+def _git_facts(
+    git: Path,
+    checkout: Path,
+    expected_origin: str,
+    environment: Mapping[str, str],
+) -> tuple[str, str]:
+    top_level_value = _one_line(
+        _run(
+            git,
+            ["-C", str(checkout), "rev-parse", "--show-toplevel"],
+            environment=environment,
+        ).stdout,
+        "checkout root",
+    )
+    try:
+        top_level = Path(top_level_value).resolve(strict=True)
+    except OSError:
+        raise DeploymentAdoptionError("legacy checkout root is unavailable") from None
+    if top_level != checkout:
+        raise DeploymentAdoptionError("legacy checkout root does not match")
+
+    origin = _one_line(
+        _run(
+            git,
+            ["-C", str(checkout), "remote", "get-url", "origin"],
+            environment=environment,
+        ).stdout,
+        "origin",
+    )
+    if origin not in {expected_origin, f"{expected_origin}.git"}:
+        raise DeploymentAdoptionError("legacy checkout origin does not match")
+
+    for arguments in (
+        ["-C", str(checkout), "diff", "--quiet", "--"],
+        ["-C", str(checkout), "diff", "--cached", "--quiet", "--"],
+    ):
+        result = _run(
+            git,
+            arguments,
+            environment=environment,
+            accepted_returncodes=frozenset({0, 1}),
+        )
+        if result.returncode == 1:
+            raise DeploymentAdoptionError("legacy checkout has tracked changes")
+
+    revision = _one_line(
+        _run(
+            git,
+            ["-C", str(checkout), "rev-parse", "--verify", "HEAD"],
+            environment=environment,
+        ).stdout,
+        "revision",
+    )
+    if _REVISION.fullmatch(revision) is None:
+        raise DeploymentAdoptionError("legacy checkout revision is invalid")
+    return expected_origin, revision
+
+
+def _container_ids(
+    docker: Path,
+    project: str,
+    service: str,
+    environment: Mapping[str, str],
+) -> tuple[str, ...]:
+    result = _run(
+        docker,
+        [
+            "container",
+            "ls",
+            "--all",
+            "--filter",
+            f"label=com.docker.compose.project={project}",
+            "--filter",
+            f"label=com.docker.compose.service={service}",
+            "--format",
+            "{{.ID}}",
+        ],
+        environment=environment,
+    )
+    lines = tuple(line for line in result.stdout.splitlines() if line)
+    if any(_CONTAINER_ID.fullmatch(line) is None for line in lines):
+        raise DeploymentAdoptionError("legacy container list is invalid")
+    return lines
+
+
+def _container_facts(
+    docker: Path,
+    container_id: str,
+    checkout: Path,
+    project: str,
+    service: str,
+    environment: Mapping[str, str],
+) -> tuple[str, str]:
+    document = _json_document(
+        _run(
+            docker,
+            ["container", "inspect", container_id],
+            environment=environment,
+        ).stdout,
+        "container",
+    )
+    full_id = _string_field(document, "Id", "container ID")
+    if (
+        len(full_id) != 64
+        or _CONTAINER_ID.fullmatch(full_id) is None
+        or not full_id.startswith(container_id)
+    ):
+        raise DeploymentAdoptionError("legacy container identity is invalid")
+
+    state = _nested_mapping(document, "State", "container state")
+    if _string_field(state, "Status", "container status") != "running":
+        raise DeploymentAdoptionError("legacy container is not running")
+    health = _nested_mapping(state, "Health", "container health")
+    if _string_field(health, "Status", "container health status") != "healthy":
+        raise DeploymentAdoptionError("legacy container is not healthy")
+
+    config = _nested_mapping(document, "Config", "container configuration")
+    image_reference = _string_field(config, "Image", "container image reference")
+    if _IMAGE_REFERENCE.fullmatch(image_reference) is None:
+        raise DeploymentAdoptionError("legacy container image is not immutable")
+    labels = _nested_mapping(config, "Labels", "container labels")
+    expected_labels = {
+        "com.docker.compose.project": project,
+        "com.docker.compose.service": service,
+        "com.docker.compose.project.working_dir": str(checkout),
+    }
+    for key, expected in expected_labels.items():
+        if labels.get(key) != expected:
+            raise DeploymentAdoptionError("legacy container labels do not match")
+
+    image_id = _string_field(document, "Image", "container image ID")
+    if _IMAGE_ID.fullmatch(image_id) is None:
+        raise DeploymentAdoptionError("legacy container image ID is invalid")
+    return image_reference, image_id
+
+
+def _image_revision(
+    docker: Path,
+    image_id: str,
+    image_reference: str,
+    environment: Mapping[str, str],
+) -> str:
+    document = _json_document(
+        _run(
+            docker,
+            ["image", "inspect", image_id],
+            environment=environment,
+        ).stdout,
+        "image",
+    )
+    inspected_id = _string_field(document, "Id", "image ID")
+    if inspected_id != image_id:
+        raise DeploymentAdoptionError("legacy image identity does not match")
+    repo_digests = document.get("RepoDigests")
+    if (
+        not isinstance(repo_digests, list)
+        or not all(isinstance(value, str) for value in repo_digests)
+        or image_reference not in repo_digests
+    ):
+        raise DeploymentAdoptionError("legacy image digest is not locally proven")
+    config = _nested_mapping(document, "Config", "image configuration")
+    labels = _nested_mapping(config, "Labels", "image labels")
+    revision = labels.get("org.opencontainers.image.revision")
+    if not isinstance(revision, str) or _REVISION.fullmatch(revision) is None:
+        raise DeploymentAdoptionError("legacy image OCI revision is invalid")
+    return revision
+
+
+def observe_legacy_deployment(
+    *,
+    checkout_path: Path,
+    expected_origin: str,
+    compose_project: str,
+    compose_service: str,
+    environment_path: Path,
+    git_executable: Path,
+    docker_executable: Path,
+    environment: Mapping[str, str] | None = None,
+) -> DeploymentObservation | None:
+    """Prove one existing deployment without mutating Git, Docker, or its env."""
+    checkout = _validate_checkout(checkout_path)
+    if _GITHUB_ORIGIN.fullmatch(expected_origin) is None or expected_origin.endswith(
+        ".git"
+    ):
+        raise DeploymentAdoptionError("expected GitHub origin is invalid")
+    project = _validated_name(compose_project, "compose_project")
+    service = _validated_name(compose_service, "compose_service")
+    git = _validated_executable(git_executable, "git")
+    docker = _validated_executable(docker_executable, "docker")
+    command_environment = _command_environment(environment)
+    origin, revision = _git_facts(
+        git,
+        checkout,
+        expected_origin,
+        command_environment,
+    )
+    container_ids = _container_ids(
+        docker,
+        project,
+        service,
+        command_environment,
+    )
+    if not container_ids:
+        return None
+    if len(container_ids) != 1:
+        raise DeploymentAdoptionError("legacy deployment is ambiguous")
+
+    selected_environment = _validate_environment(environment_path, checkout)
+    image_reference, image_id = _container_facts(
+        docker,
+        container_ids[0],
+        checkout,
+        project,
+        service,
+        command_environment,
+    )
+    oci_revision = _image_revision(
+        docker,
+        image_id,
+        image_reference,
+        command_environment,
+    )
+    return DeploymentObservation(
+        checkout_path=checkout,
+        origin=origin,
+        revision=revision,
+        compose_project=project,
+        compose_service=service,
+        environment_path=selected_environment,
+        image_reference=image_reference,
+        image_id=image_id,
+        oci_revision=oci_revision,
+    )

--- a/src/agent/deployment_state.py
+++ b/src/agent/deployment_state.py
@@ -1,0 +1,906 @@
+"""Crash-consistent private state for one POSIX VM deployment transaction."""
+
+from __future__ import annotations
+
+import errno
+import fcntl
+import hashlib
+import json
+import os
+import re
+import stat
+import tempfile
+import uuid
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager, suppress
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Final
+
+SCHEMA_VERSION: Final = 1
+MAX_ENVIRONMENT_BYTES: Final = 1024 * 1024
+MAX_JSON_BYTES: Final = 64 * 1024
+
+_COMPOSE_NAME = re.compile(r"[a-z0-9][a-z0-9_-]{0,62}\Z")
+_DEPLOYMENT_ID = re.compile(r"[a-z0-9][a-z0-9-]{0,63}\Z")
+_REVISION = re.compile(r"[0-9a-f]{40}\Z")
+_SHA256_HEX = re.compile(r"[0-9a-f]{64}\Z")
+_IMAGE_ID = re.compile(r"sha256:[0-9a-f]{64}\Z")
+_REPOSITORY_COMPONENT = r"[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*"
+_REGISTRY_LABEL = r"[a-z0-9](?:[a-z0-9-]*[a-z0-9])?"
+_IMAGE_REFERENCE = re.compile(
+    rf"(?=.{{1,255}}@sha256:)"
+    rf"(?:{_REGISTRY_LABEL}(?:\.{_REGISTRY_LABEL})*(?::[0-9]{{1,5}})?/)?"
+    rf"{_REPOSITORY_COMPONENT}(?:/{_REPOSITORY_COMPONENT})*"
+    r"@sha256:[0-9a-f]{64}\Z"
+)
+_RECORDED_AT = re.compile(
+    r"[0-9]{4}-[0-9]{2}-[0-9]{2}T"
+    r"[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}Z\Z"
+)
+_JOURNAL_NAME = re.compile(r"([0-9]{20})\.json\Z")
+_ENVIRONMENT_NAME = re.compile(r"[a-z0-9][a-z0-9-]{0,63}\.env\Z")
+_CURRENT_TEMPORARY_NAME = re.compile(r"\.deployment-current-[a-z0-9._-]+\.tmp\Z")
+_JOURNAL_TEMPORARY_NAME = re.compile(r"\.deployment-journal-[a-z0-9._-]+\.tmp\Z")
+_ENVIRONMENT_TEMPORARY_NAME = re.compile(
+    r"\.deployment-environment-[a-z0-9._-]+\.tmp\Z"
+)
+
+
+class DeploymentStateError(RuntimeError):
+    """Report a deterministic deployment-state contract failure."""
+
+
+class DeploymentLockBusyError(DeploymentStateError):
+    """Report that another process owns the VM deployment transaction."""
+
+
+@dataclass(frozen=True, slots=True)
+class DeploymentState:
+    """Secret-free metadata needed to identify and restore one deployment."""
+
+    deployment_id: str
+    recorded_at: str
+    compose_project: str
+    compose_service: str
+    source_revision: str
+    image_reference: str
+    image_id: str
+    oci_revision: str
+    environment_snapshot: str
+    environment_sha256: str
+    adopted: bool
+
+    def as_document(self) -> dict[str, object]:
+        """Return the exact persisted state schema."""
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "deployment_id": self.deployment_id,
+            "recorded_at": self.recorded_at,
+            "compose_project": self.compose_project,
+            "compose_service": self.compose_service,
+            "source_revision": self.source_revision,
+            "image_reference": self.image_reference,
+            "image_id": self.image_id,
+            "oci_revision": self.oci_revision,
+            "environment_snapshot": self.environment_snapshot,
+            "environment_sha256": self.environment_sha256,
+            "adopted": self.adopted,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class JournalEntry:
+    """One immutable, hash-chained deployment-state event."""
+
+    sequence: int
+    sha256: str
+    previous_sha256: str | None
+    event: str
+    state: DeploymentState
+
+    def as_document(self) -> dict[str, object]:
+        """Return the exact persisted journal schema, excluding its outer hash."""
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "sequence": self.sequence,
+            "previous_sha256": self.previous_sha256,
+            "event": self.event,
+            "state": self.state.as_document(),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CurrentDeployment:
+    """The current pointer bound to one immutable journal record."""
+
+    journal_sequence: int
+    journal_sha256: str
+    state: DeploymentState
+
+    def as_document(self) -> dict[str, object]:
+        """Return the exact persisted current-pointer schema."""
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "journal_sequence": self.journal_sequence,
+            "journal_sha256": self.journal_sha256,
+            "state": self.state.as_document(),
+        }
+
+
+def _validated_string(
+    document: Mapping[str, object],
+    key: str,
+    pattern: re.Pattern[str],
+) -> str:
+    value = document.get(key)
+    if not isinstance(value, str) or pattern.fullmatch(value) is None:
+        raise DeploymentStateError(f"deployment state field is invalid: {key}")
+    return value
+
+
+def _validate_timestamp(value: str) -> str:
+    if _RECORDED_AT.fullmatch(value) is None:
+        raise DeploymentStateError("deployment state field is invalid: recorded_at")
+    try:
+        datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=UTC)
+    except ValueError:
+        raise DeploymentStateError(
+            "deployment state field is invalid: recorded_at"
+        ) from None
+    return value
+
+
+def _validate_snapshot_path(value: object, deployment_id: str) -> str:
+    expected = f"environments/{deployment_id}.env"
+    if not isinstance(value, str) or value != expected:
+        raise DeploymentStateError(
+            "deployment state field is invalid: environment_snapshot"
+        )
+    return value
+
+
+def _state_from_document(document: object) -> DeploymentState:
+    if not isinstance(document, dict):
+        raise DeploymentStateError("deployment state document must be an object")
+    expected_keys = {
+        "schema_version",
+        "deployment_id",
+        "recorded_at",
+        "compose_project",
+        "compose_service",
+        "source_revision",
+        "image_reference",
+        "image_id",
+        "oci_revision",
+        "environment_snapshot",
+        "environment_sha256",
+        "adopted",
+    }
+    if (
+        set(document) != expected_keys
+        or document.get("schema_version") != SCHEMA_VERSION
+    ):
+        raise DeploymentStateError("deployment state schema is invalid")
+
+    deployment_id = _validated_string(document, "deployment_id", _DEPLOYMENT_ID)
+    adopted = document.get("adopted")
+    if adopted is not True:
+        raise DeploymentStateError("deployment state field is invalid: adopted")
+    return DeploymentState(
+        deployment_id=deployment_id,
+        recorded_at=_validate_timestamp(
+            _validated_string(document, "recorded_at", _RECORDED_AT)
+        ),
+        compose_project=_validated_string(
+            document,
+            "compose_project",
+            _COMPOSE_NAME,
+        ),
+        compose_service=_validated_string(
+            document,
+            "compose_service",
+            _COMPOSE_NAME,
+        ),
+        source_revision=_validated_string(
+            document,
+            "source_revision",
+            _REVISION,
+        ),
+        image_reference=_validated_string(
+            document,
+            "image_reference",
+            _IMAGE_REFERENCE,
+        ),
+        image_id=_validated_string(document, "image_id", _IMAGE_ID),
+        oci_revision=_validated_string(document, "oci_revision", _REVISION),
+        environment_snapshot=_validate_snapshot_path(
+            document.get("environment_snapshot"),
+            deployment_id,
+        ),
+        environment_sha256=_validated_string(
+            document,
+            "environment_sha256",
+            _SHA256_HEX,
+        ),
+        adopted=True,
+    )
+
+
+def _reject_duplicate_keys(pairs: Sequence[tuple[str, object]]) -> dict[str, object]:
+    document: dict[str, object] = {}
+    for key, value in pairs:
+        if key in document:
+            raise DeploymentStateError("deployment state JSON contains duplicate keys")
+        document[key] = value
+    return document
+
+
+def _canonical_json(document: Mapping[str, object]) -> bytes:
+    return (
+        json.dumps(
+            document,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode()
+
+
+def _decode_json(payload: bytes) -> dict[str, object]:
+    if not payload or len(payload) > MAX_JSON_BYTES:
+        raise DeploymentStateError("deployment state JSON size is invalid")
+    try:
+        decoded = json.loads(
+            payload.decode("utf-8"),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        raise DeploymentStateError("deployment state JSON is invalid") from None
+    if not isinstance(decoded, dict):
+        raise DeploymentStateError("deployment state JSON must be an object")
+    if _canonical_json(decoded) != payload:
+        raise DeploymentStateError("deployment state JSON is not canonical")
+    return decoded
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def _validate_secure_metadata(
+    metadata: os.stat_result,
+    *,
+    expected_mode: int,
+    directory: bool,
+    require_one_link: bool,
+) -> None:
+    expected_type = stat.S_ISDIR if directory else stat.S_ISREG
+    if not expected_type(metadata.st_mode):
+        raise DeploymentStateError("deployment state path has an unsafe file type")
+    if metadata.st_uid != os.geteuid():
+        raise DeploymentStateError("deployment state path has an unsafe owner")
+    if stat.S_IMODE(metadata.st_mode) != expected_mode:
+        raise DeploymentStateError("deployment state path has unsafe permissions")
+    if require_one_link and metadata.st_nlink != 1:
+        raise DeploymentStateError("deployment state file has unsafe links")
+
+
+def _validate_secure_path(
+    path: Path,
+    *,
+    expected_mode: int,
+    directory: bool,
+    require_one_link: bool = True,
+) -> os.stat_result:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        raise DeploymentStateError("deployment state path is missing") from None
+    _validate_secure_metadata(
+        metadata,
+        expected_mode=expected_mode,
+        directory=directory,
+        require_one_link=require_one_link,
+    )
+    return metadata
+
+
+def _ensure_secure_directory(path: Path) -> None:
+    missing: list[Path] = []
+    cursor = path
+    while True:
+        try:
+            existing = cursor.lstat()
+        except FileNotFoundError:
+            missing.append(cursor)
+            cursor = cursor.parent
+            continue
+        if not stat.S_ISDIR(existing.st_mode):
+            raise DeploymentStateError(
+                "deployment state ancestor has an unsafe file type"
+            )
+        break
+
+    for directory in reversed(missing):
+        with suppress(FileExistsError):
+            directory.mkdir(mode=0o700)
+        _validate_secure_path(
+            directory,
+            expected_mode=0o700,
+            directory=True,
+            require_one_link=False,
+        )
+        _sync_directory(directory.parent)
+
+    _validate_secure_path(
+        path,
+        expected_mode=0o700,
+        directory=True,
+        require_one_link=False,
+    )
+
+
+def _write_all(descriptor: int, payload: bytes) -> None:
+    remaining = memoryview(payload)
+    while remaining:
+        written = os.write(descriptor, remaining)
+        if written <= 0:
+            raise OSError("deployment state write made no progress")
+        remaining = remaining[written:]
+
+
+def _sync_directory(path: Path) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_DIRECTORY", 0)
+    descriptor = os.open(path, flags)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _publish_private_file(
+    path: Path,
+    payload: bytes,
+    *,
+    replace: bool,
+    prefix: str,
+) -> None:
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=prefix,
+        suffix=".tmp",
+        dir=path.parent,
+    )
+    temporary_path = Path(temporary_name)
+    try:
+        os.fchmod(descriptor, 0o600)
+        _write_all(descriptor, payload)
+        os.fsync(descriptor)
+        descriptor_to_close = descriptor
+        descriptor = -1
+        os.close(descriptor_to_close)
+        if replace:
+            temporary_path.replace(path)
+        else:
+            os.link(temporary_path, path, follow_symlinks=False)
+            temporary_path.unlink()
+        _sync_directory(path.parent)
+    finally:
+        try:
+            if descriptor >= 0:
+                os.close(descriptor)
+        finally:
+            temporary_path.unlink(missing_ok=True)
+
+
+def _metadata_identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_uid,
+        metadata.st_nlink,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
+def _read_private_file(path: Path, *, maximum_bytes: int) -> bytes:
+    before = _validate_secure_path(
+        path,
+        expected_mode=0o600,
+        directory=False,
+    )
+    if before.st_size <= 0 or before.st_size > maximum_bytes:
+        raise DeploymentStateError("private deployment file size is invalid")
+
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    try:
+        opened = os.fstat(descriptor)
+        _validate_secure_metadata(
+            opened,
+            expected_mode=0o600,
+            directory=False,
+            require_one_link=True,
+        )
+        identity = _metadata_identity(opened)
+        if _metadata_identity(before) != identity:
+            raise DeploymentStateError("private deployment file changed before read")
+        chunks: list[bytes] = []
+        total = 0
+        while True:
+            chunk = os.read(descriptor, min(64 * 1024, maximum_bytes + 1 - total))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            total += len(chunk)
+            if total > maximum_bytes:
+                raise DeploymentStateError("private deployment file size is invalid")
+        after = os.fstat(descriptor)
+        _validate_secure_metadata(
+            after,
+            expected_mode=0o600,
+            directory=False,
+            require_one_link=True,
+        )
+        if _metadata_identity(after) != identity:
+            raise DeploymentStateError("private deployment file changed while read")
+        pathname_after = _validate_secure_path(
+            path,
+            expected_mode=0o600,
+            directory=False,
+        )
+        if _metadata_identity(pathname_after) != identity:
+            raise DeploymentStateError("private deployment file changed while read")
+    finally:
+        os.close(descriptor)
+
+    payload = b"".join(chunks)
+    if len(payload) != before.st_size or not payload:
+        raise DeploymentStateError("private deployment file size is invalid")
+    return payload
+
+
+def _journal_from_document(
+    document: Mapping[str, object],
+    *,
+    payload_sha256: str,
+) -> JournalEntry:
+    expected_keys = {
+        "schema_version",
+        "sequence",
+        "previous_sha256",
+        "event",
+        "state",
+    }
+    if (
+        set(document) != expected_keys
+        or document.get("schema_version") != SCHEMA_VERSION
+    ):
+        raise DeploymentStateError("deployment journal schema is invalid")
+    sequence = document.get("sequence")
+    if type(sequence) is not int or sequence <= 0:
+        raise DeploymentStateError("deployment journal sequence is invalid")
+    previous = document.get("previous_sha256")
+    if previous is not None and (
+        not isinstance(previous, str) or _SHA256_HEX.fullmatch(previous) is None
+    ):
+        raise DeploymentStateError("deployment journal predecessor is invalid")
+    event = document.get("event")
+    if event != "adopted":
+        raise DeploymentStateError("deployment journal event is invalid")
+    return JournalEntry(
+        sequence=sequence,
+        sha256=payload_sha256,
+        previous_sha256=previous,
+        event="adopted",
+        state=_state_from_document(document.get("state")),
+    )
+
+
+def _current_from_document(document: Mapping[str, object]) -> CurrentDeployment:
+    expected_keys = {
+        "schema_version",
+        "journal_sequence",
+        "journal_sha256",
+        "state",
+    }
+    if (
+        set(document) != expected_keys
+        or document.get("schema_version") != SCHEMA_VERSION
+    ):
+        raise DeploymentStateError("current deployment schema is invalid")
+    sequence = document.get("journal_sequence")
+    if type(sequence) is not int or sequence <= 0:
+        raise DeploymentStateError("current deployment sequence is invalid")
+    journal_sha256 = document.get("journal_sha256")
+    if (
+        not isinstance(journal_sha256, str)
+        or _SHA256_HEX.fullmatch(journal_sha256) is None
+    ):
+        raise DeploymentStateError("current deployment journal hash is invalid")
+    return CurrentDeployment(
+        journal_sequence=sequence,
+        journal_sha256=journal_sha256,
+        state=_state_from_document(document.get("state")),
+    )
+
+
+class DeploymentStateStore:
+    """Own the private durable state paths for one Compose deployment."""
+
+    def __init__(self, path: Path) -> None:
+        if not path.is_absolute() or path != path.resolve(strict=False):
+            raise DeploymentStateError(
+                "deployment state directory must be an absolute normalized path"
+            )
+        self.path = path
+        self.journal_path = path / "journal"
+        self.environments_path = path / "environments"
+        self.lock_path = path / "deploy.lock"
+        self.current_path = path / "current.json"
+
+    def _prepare_layout(self) -> None:
+        _ensure_secure_directory(self.path)
+        _ensure_secure_directory(self.journal_path)
+        _ensure_secure_directory(self.environments_path)
+
+    def _open_lock(self) -> int:
+        flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_CLOEXEC", 0)
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(self.lock_path, flags, 0o600)
+        try:
+            _validate_secure_metadata(
+                os.fstat(descriptor),
+                expected_mode=0o600,
+                directory=False,
+                require_one_link=True,
+            )
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError as error:
+                if error.errno in {errno.EACCES, errno.EAGAIN}:
+                    raise DeploymentLockBusyError(
+                        "another deployment transaction holds the VM lock"
+                    ) from None
+                raise
+        except BaseException:
+            os.close(descriptor)
+            raise
+        return descriptor
+
+    @contextmanager
+    def transaction(self) -> Iterator[DeploymentStateTransaction]:
+        """Hold the exclusive VM lock for one complete transaction."""
+        self._prepare_layout()
+        descriptor = self._open_lock()
+        transaction = DeploymentStateTransaction(self)
+        try:
+            transaction._load_and_reconcile()
+            yield transaction
+        finally:
+            transaction._closed = True
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+            finally:
+                os.close(descriptor)
+
+    def read_current(self) -> CurrentDeployment | None:
+        """Read and reconcile the current state under the VM lock."""
+        with self.transaction() as transaction:
+            return transaction.current()
+
+    def read_journal(self) -> tuple[JournalEntry, ...]:
+        """Read the verified immutable journal under the VM lock."""
+        with self.transaction() as transaction:
+            return transaction.journal()
+
+
+class DeploymentStateTransaction:
+    """Lock-scoped operations over one verified deployment state store."""
+
+    def __init__(self, store: DeploymentStateStore) -> None:
+        self._store = store
+        self._closed = False
+        self._journal: tuple[JournalEntry, ...] = ()
+        self._current: CurrentDeployment | None = None
+
+    def _require_open(self) -> None:
+        if self._closed:
+            raise DeploymentStateError("deployment state transaction is closed")
+
+    def _journal_files(self) -> list[tuple[int, Path]]:
+        files: list[tuple[int, Path]] = []
+        for path in self._store.journal_path.iterdir():
+            match = _JOURNAL_NAME.fullmatch(path.name)
+            if match is not None:
+                files.append((int(match.group(1)), path))
+                continue
+            raise DeploymentStateError("deployment journal contains an unknown path")
+        return sorted(files)
+
+    def _recover_temporary_files(
+        self,
+        directory: Path,
+        *,
+        temporary_pattern: re.Pattern[str],
+        final_pattern: re.Pattern[str] | None = None,
+    ) -> None:
+        for temporary_path in sorted(directory.iterdir()):
+            if temporary_pattern.fullmatch(temporary_path.name) is None:
+                continue
+            temporary_metadata = _validate_secure_path(
+                temporary_path,
+                expected_mode=0o600,
+                directory=False,
+                require_one_link=False,
+            )
+            if temporary_metadata.st_nlink == 2 and final_pattern is not None:
+                matching_finals: list[Path] = []
+                for candidate in directory.iterdir():
+                    if (
+                        candidate == temporary_path
+                        or final_pattern.fullmatch(candidate.name) is None
+                    ):
+                        continue
+                    candidate_metadata = candidate.lstat()
+                    if (
+                        candidate_metadata.st_dev,
+                        candidate_metadata.st_ino,
+                    ) == (
+                        temporary_metadata.st_dev,
+                        temporary_metadata.st_ino,
+                    ):
+                        _validate_secure_metadata(
+                            candidate_metadata,
+                            expected_mode=0o600,
+                            directory=False,
+                            require_one_link=False,
+                        )
+                        matching_finals.append(candidate)
+                if len(matching_finals) != 1:
+                    raise DeploymentStateError(
+                        "deployment state temporary hard link is ambiguous"
+                    )
+            elif temporary_metadata.st_nlink != 1:
+                raise DeploymentStateError(
+                    "deployment state temporary file has unsafe links"
+                )
+            confirmed_metadata = _validate_secure_path(
+                temporary_path,
+                expected_mode=0o600,
+                directory=False,
+                require_one_link=False,
+            )
+            if _metadata_identity(confirmed_metadata) != _metadata_identity(
+                temporary_metadata
+            ):
+                raise DeploymentStateError(
+                    "deployment state temporary file changed during recovery"
+                )
+            temporary_path.unlink()
+            _sync_directory(directory)
+
+    def _load_journal(self) -> tuple[JournalEntry, ...]:
+        entries: list[JournalEntry] = []
+        previous_sha256: str | None = None
+        for expected_sequence, (sequence, path) in enumerate(
+            self._journal_files(),
+            start=1,
+        ):
+            if sequence != expected_sequence:
+                raise DeploymentStateError("deployment journal sequence has a gap")
+            payload = _read_private_file(path, maximum_bytes=MAX_JSON_BYTES)
+            payload_sha256 = hashlib.sha256(payload).hexdigest()
+            entry = _journal_from_document(
+                _decode_json(payload),
+                payload_sha256=payload_sha256,
+            )
+            if entry.sequence != sequence:
+                raise DeploymentStateError(
+                    "deployment journal filename and sequence disagree"
+                )
+            if entry.previous_sha256 != previous_sha256:
+                raise DeploymentStateError("deployment journal hash chain is invalid")
+            environment_payload = _read_private_file(
+                self._store.path / entry.state.environment_snapshot,
+                maximum_bytes=MAX_ENVIRONMENT_BYTES,
+            )
+            if (
+                hashlib.sha256(environment_payload).hexdigest()
+                != entry.state.environment_sha256
+            ):
+                raise DeploymentStateError(
+                    "deployment environment snapshot hash is invalid"
+                )
+            entries.append(entry)
+            previous_sha256 = payload_sha256
+        return tuple(entries)
+
+    def _desired_current(self) -> CurrentDeployment | None:
+        if not self._journal:
+            return None
+        latest = self._journal[-1]
+        return CurrentDeployment(
+            journal_sequence=latest.sequence,
+            journal_sha256=latest.sha256,
+            state=latest.state,
+        )
+
+    def _read_current_file(self) -> CurrentDeployment | None:
+        try:
+            payload = _read_private_file(
+                self._store.current_path,
+                maximum_bytes=MAX_JSON_BYTES,
+            )
+        except DeploymentStateError:
+            try:
+                self._store.current_path.lstat()
+            except FileNotFoundError:
+                return None
+            raise
+        return _current_from_document(_decode_json(payload))
+
+    def _publish_current(self, current: CurrentDeployment) -> None:
+        _publish_private_file(
+            self._store.current_path,
+            _canonical_json(current.as_document()),
+            replace=True,
+            prefix=".deployment-current-",
+        )
+
+    def _reconcile_current(self) -> CurrentDeployment | None:
+        desired = self._desired_current()
+        current = self._read_current_file()
+        if desired is None:
+            if current is not None:
+                raise DeploymentStateError(
+                    "current deployment exists ahead of the journal"
+                )
+            return None
+        if current is None:
+            self._publish_current(desired)
+            return desired
+        if current.journal_sequence > desired.journal_sequence:
+            raise DeploymentStateError("current deployment is ahead of the journal")
+        indexed = self._journal[current.journal_sequence - 1]
+        expected_existing = CurrentDeployment(
+            journal_sequence=indexed.sequence,
+            journal_sha256=indexed.sha256,
+            state=indexed.state,
+        )
+        if current != expected_existing:
+            raise DeploymentStateError("current deployment does not match the journal")
+        if current != desired:
+            self._publish_current(desired)
+            return desired
+        return current
+
+    def _load_and_reconcile(self) -> None:
+        self._recover_temporary_files(
+            self._store.path,
+            temporary_pattern=_CURRENT_TEMPORARY_NAME,
+        )
+        self._recover_temporary_files(
+            self._store.environments_path,
+            temporary_pattern=_ENVIRONMENT_TEMPORARY_NAME,
+            final_pattern=_ENVIRONMENT_NAME,
+        )
+        self._recover_temporary_files(
+            self._store.journal_path,
+            temporary_pattern=_JOURNAL_TEMPORARY_NAME,
+            final_pattern=_JOURNAL_NAME,
+        )
+        self._journal = self._load_journal()
+        self._current = self._reconcile_current()
+
+    def current(self) -> CurrentDeployment | None:
+        """Return the lock-scoped current deployment."""
+        self._require_open()
+        return self._current
+
+    def journal(self) -> tuple[JournalEntry, ...]:
+        """Return the verified lock-scoped journal."""
+        self._require_open()
+        return self._journal
+
+    def adopt(
+        self,
+        *,
+        compose_project: str,
+        compose_service: str,
+        source_revision: str,
+        image_reference: str,
+        image_id: str,
+        oci_revision: str,
+        environment_source: Path,
+        deployment_id: str | None = None,
+        recorded_at: str | None = None,
+    ) -> CurrentDeployment:
+        """Record one explicitly observed legacy deployment without overwriting."""
+        self._require_open()
+        if self._current is not None or self._journal:
+            raise DeploymentStateError("deployment state has already been initialized")
+
+        selected_id = uuid.uuid4().hex if deployment_id is None else deployment_id
+        selected_time = _now() if recorded_at is None else recorded_at
+        snapshot_relative = f"environments/{selected_id}.env"
+        provisional = {
+            "schema_version": SCHEMA_VERSION,
+            "deployment_id": selected_id,
+            "recorded_at": selected_time,
+            "compose_project": compose_project,
+            "compose_service": compose_service,
+            "source_revision": source_revision,
+            "image_reference": image_reference,
+            "image_id": image_id,
+            "oci_revision": oci_revision,
+            "environment_snapshot": snapshot_relative,
+            "environment_sha256": "0" * 64,
+            "adopted": True,
+        }
+        validated = _state_from_document(provisional)
+        environment_payload = _read_private_file(
+            environment_source,
+            maximum_bytes=MAX_ENVIRONMENT_BYTES,
+        )
+        environment_sha256 = hashlib.sha256(environment_payload).hexdigest()
+        state = DeploymentState(
+            deployment_id=validated.deployment_id,
+            recorded_at=validated.recorded_at,
+            compose_project=validated.compose_project,
+            compose_service=validated.compose_service,
+            source_revision=validated.source_revision,
+            image_reference=validated.image_reference,
+            image_id=validated.image_id,
+            oci_revision=validated.oci_revision,
+            environment_snapshot=validated.environment_snapshot,
+            environment_sha256=environment_sha256,
+            adopted=True,
+        )
+        snapshot_path = self._store.path / state.environment_snapshot
+        _publish_private_file(
+            snapshot_path,
+            environment_payload,
+            replace=False,
+            prefix=".deployment-environment-",
+        )
+
+        journal_document = {
+            "schema_version": SCHEMA_VERSION,
+            "sequence": 1,
+            "previous_sha256": None,
+            "event": "adopted",
+            "state": state.as_document(),
+        }
+        journal_payload = _canonical_json(journal_document)
+        journal_sha256 = hashlib.sha256(journal_payload).hexdigest()
+        journal_path = self._store.journal_path / "00000000000000000001.json"
+        _publish_private_file(
+            journal_path,
+            journal_payload,
+            replace=False,
+            prefix=".deployment-journal-",
+        )
+        entry = JournalEntry(
+            sequence=1,
+            sha256=journal_sha256,
+            previous_sha256=None,
+            event="adopted",
+            state=state,
+        )
+        current = CurrentDeployment(
+            journal_sequence=1,
+            journal_sha256=journal_sha256,
+            state=state,
+        )
+        self._journal = (entry,)
+        self._publish_current(current)
+        self._current = current
+        return current

--- a/src/agent/deployment_state_cli.py
+++ b/src/agent/deployment_state_cli.py
@@ -1,0 +1,165 @@
+"""Operator CLI for inspecting or explicitly adopting VM deployment state."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+from agent.deployment_adoption import (
+    DeploymentAdoptionError,
+    observe_legacy_deployment,
+)
+from agent.deployment_state import (
+    DeploymentLockBusyError,
+    DeploymentStateError,
+    DeploymentStateStore,
+)
+
+
+class DeploymentStateCliError(RuntimeError):
+    """Report a safe command-line boundary failure."""
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="deployment-state",
+        description="Inspect or adopt one private VM deployment state store.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    inspect_parser = subparsers.add_parser(
+        "inspect",
+        help="verify and print secret-free current state and journal metadata",
+    )
+    inspect_parser.add_argument("--state-dir", type=Path, required=True)
+
+    adopt_parser = subparsers.add_parser(
+        "adopt",
+        help="record one exact healthy legacy Compose deployment",
+    )
+    adopt_parser.add_argument("--state-dir", type=Path, required=True)
+    adopt_parser.add_argument("--checkout", type=Path, required=True)
+    adopt_parser.add_argument("--expected-origin", required=True)
+    adopt_parser.add_argument("--compose-project", required=True)
+    adopt_parser.add_argument("--compose-service", default="agent")
+    adopt_parser.add_argument("--environment-file", type=Path)
+    return parser
+
+
+def _resolved_executable(name: str) -> Path:
+    selected = shutil.which(name)
+    if selected is None:
+        raise DeploymentStateCliError(
+            "required deployment observation executable is unavailable"
+        )
+    return Path(selected).resolve(strict=True)
+
+
+def _emit(document: dict[str, object]) -> None:
+    print(
+        json.dumps(
+            document,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    )
+
+
+def _inspect(store: DeploymentStateStore) -> int:
+    with store.transaction() as transaction:
+        current = transaction.current()
+        journal = transaction.journal()
+        _emit(
+            {
+                "status": "empty" if current is None else "recorded",
+                "current": None if current is None else current.as_document(),
+                "journal": [
+                    {
+                        "sha256": entry.sha256,
+                        **entry.as_document(),
+                    }
+                    for entry in journal
+                ],
+            }
+        )
+    return 0
+
+
+def _adopt(arguments: argparse.Namespace, store: DeploymentStateStore) -> int:
+    checkout = arguments.checkout
+    environment_file = (
+        checkout / ".env"
+        if arguments.environment_file is None
+        else arguments.environment_file
+    )
+    with store.transaction() as transaction:
+        if transaction.current() is not None:
+            raise DeploymentStateCliError(
+                "deployment state has already been initialized"
+            )
+        observation = observe_legacy_deployment(
+            checkout_path=checkout,
+            expected_origin=arguments.expected_origin,
+            compose_project=arguments.compose_project,
+            compose_service=arguments.compose_service,
+            environment_path=environment_file,
+            git_executable=_resolved_executable("git"),
+            docker_executable=_resolved_executable("docker"),
+        )
+        if observation is None:
+            _emit(
+                {
+                    "status": "fresh",
+                    "current": None,
+                    "journal": [],
+                }
+            )
+            return 0
+        current = transaction.adopt(
+            compose_project=observation.compose_project,
+            compose_service=observation.compose_service,
+            source_revision=observation.revision,
+            image_reference=observation.image_reference,
+            image_id=observation.image_id,
+            oci_revision=observation.oci_revision,
+            environment_source=observation.environment_path,
+        )
+        _emit(
+            {
+                "status": "adopted",
+                "current": current.as_document(),
+            }
+        )
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run one state command and return a secret-free process status."""
+    arguments = _parser().parse_args(argv)
+    try:
+        store = DeploymentStateStore(arguments.state_dir)
+        if arguments.command == "inspect":
+            return _inspect(store)
+        return _adopt(arguments, store)
+    except DeploymentLockBusyError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 75
+    except (
+        DeploymentAdoptionError,
+        DeploymentStateCliError,
+        DeploymentStateError,
+    ) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    except OSError:
+        print("ERROR: deployment state operation failed", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_compose_workflow.py
+++ b/tests/test_compose_workflow.py
@@ -245,7 +245,7 @@ def test_workflow_checkout_is_immutable_and_drops_credentials() -> None:
     document = WORKFLOW_PATH.read_text(encoding="utf-8")
     checkout_uses = list(CHECKOUT_USES_PATTERN.finditer(document))
 
-    assert len(checkout_uses) == 3
+    assert len(checkout_uses) == 4
     for checkout_use in checkout_uses:
         checkout_reference = checkout_use.group("reference")
         assert re.fullmatch(r"[0-9a-f]{40}", checkout_reference)
@@ -254,7 +254,7 @@ def test_workflow_checkout_is_immutable_and_drops_credentials() -> None:
     assert {match.group("reference") for match in checkout_uses} == {
         "3d3c42e5aac5ba805825da76410c181273ba90b1"
     }
-    assert document.count("persist-credentials: false") == 3
+    assert document.count("persist-credentials: false") == 4
     assert "secrets." not in document
     assert "packages: write" not in document
     assert "docker/login-action" not in document

--- a/tests/test_deployment_adoption.py
+++ b/tests/test_deployment_adoption.py
@@ -1,0 +1,766 @@
+"""Read-only legacy Compose deployment observation tests."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import subprocess
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from unittest.mock import create_autospec, patch
+
+import pytest
+
+from agent import deployment_adoption as adoption_module
+from agent.deployment_adoption import (
+    DeploymentAdoptionError,
+    DeploymentObservation,
+    observe_legacy_deployment,
+)
+
+ORIGIN = "https://github.com/QueryPlanner/google-adk-on-bare-metal"
+REVISION = "a" * 40
+OCI_REVISION = "b" * 40
+CONTAINER_ID = "c" * 64
+SHORT_CONTAINER_ID = CONTAINER_ID[:12]
+IMAGE_ID = f"sha256:{'d' * 64}"
+IMAGE_REFERENCE = f"ghcr.io/queryplanner/agent@sha256:{'e' * 64}"
+PROJECT = "adk-template"
+SERVICE = "agent"
+SECRET_ENVIRONMENT = b'API_KEY="secret-observation-canary"\n'
+
+
+def _completed(
+    command: Sequence[str],
+    *,
+    stdout: str = "",
+    returncode: int = 0,
+    stderr: str = "",
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        command,
+        returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+@dataclass(slots=True)
+class ObservationBoundary:
+    """Deterministic external Git and Docker command boundary."""
+
+    checkout: Path
+    git: Path
+    docker: Path
+    top_level: Path | None = None
+    origin: str = ORIGIN
+    revision: str = REVISION
+    unstaged_returncode: int = 0
+    staged_returncode: int = 0
+    container_list: str = f"{SHORT_CONTAINER_ID}\n"
+    container_document: object = field(default_factory=dict)
+    image_document: object = field(default_factory=dict)
+    fail_command: tuple[str, ...] | None = None
+    calls: list[tuple[str, ...]] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.top_level is None:
+            self.top_level = self.checkout
+        if self.container_document == {}:
+            self.container_document = {
+                "Id": CONTAINER_ID,
+                "Image": IMAGE_ID,
+                "State": {
+                    "Status": "running",
+                    "Health": {"Status": "healthy"},
+                },
+                "Config": {
+                    "Image": IMAGE_REFERENCE,
+                    "Labels": {
+                        "com.docker.compose.project": PROJECT,
+                        "com.docker.compose.service": SERVICE,
+                        "com.docker.compose.project.working_dir": str(self.checkout),
+                    },
+                },
+            }
+        if self.image_document == {}:
+            self.image_document = {
+                "Id": IMAGE_ID,
+                "RepoDigests": [IMAGE_REFERENCE],
+                "Config": {
+                    "Labels": {
+                        "org.opencontainers.image.revision": OCI_REVISION,
+                    }
+                },
+            }
+
+    def run(
+        self,
+        command: list[str],
+        *,
+        cwd: Path | None,
+        env: dict[str, str],
+        text: bool,
+        capture_output: bool,
+        check: bool,
+        timeout: int,
+    ) -> subprocess.CompletedProcess[str]:
+        """Return one exact synthetic external response."""
+        assert cwd is None
+        assert text is True
+        assert capture_output is True
+        assert check is False
+        assert timeout == 30
+        assert env["GIT_OPTIONAL_LOCKS"] == "0"
+        assert env["GIT_TERMINAL_PROMPT"] == "0"
+        assert env["LC_ALL"] == "C"
+        assert env["LANG"] == "C"
+        assert "GIT_DIR" not in env
+        assert env["DOCKER_CONFIG"] == "/private/docker-config"
+
+        selected = tuple(command)
+        self.calls.append(selected)
+        if self.fail_command is not None and selected[1:] == self.fail_command:
+            return _completed(command, returncode=29, stderr="secret-boundary-error")
+
+        if command[0] == str(self.git):
+            arguments = command[1:]
+            if arguments == [
+                "-C",
+                str(self.checkout),
+                "rev-parse",
+                "--show-toplevel",
+            ]:
+                return _completed(command, stdout=f"{self.top_level}\n")
+            if arguments == [
+                "-C",
+                str(self.checkout),
+                "remote",
+                "get-url",
+                "origin",
+            ]:
+                return _completed(command, stdout=f"{self.origin}\n")
+            if arguments == [
+                "-C",
+                str(self.checkout),
+                "diff",
+                "--quiet",
+                "--",
+            ]:
+                return _completed(command, returncode=self.unstaged_returncode)
+            if arguments == [
+                "-C",
+                str(self.checkout),
+                "diff",
+                "--cached",
+                "--quiet",
+                "--",
+            ]:
+                return _completed(command, returncode=self.staged_returncode)
+            if arguments == [
+                "-C",
+                str(self.checkout),
+                "rev-parse",
+                "--verify",
+                "HEAD",
+            ]:
+                return _completed(command, stdout=f"{self.revision}\n")
+
+        if command[0] == str(self.docker):
+            arguments = command[1:]
+            if arguments[:2] == ["container", "ls"]:
+                return _completed(command, stdout=self.container_list)
+            if arguments == ["container", "inspect", SHORT_CONTAINER_ID]:
+                return _completed(
+                    command,
+                    stdout=json.dumps([self.container_document]),
+                )
+            if arguments == ["image", "inspect", IMAGE_ID]:
+                return _completed(
+                    command,
+                    stdout=json.dumps([self.image_document]),
+                )
+
+        return _completed(command, returncode=99, stderr="unexpected command")
+
+
+@dataclass(frozen=True, slots=True)
+class ObservationHarness:
+    """Private checkout, executables, inputs, and external boundary."""
+
+    checkout: Path
+    environment_path: Path
+    git: Path
+    docker: Path
+    boundary: ObservationBoundary
+
+    def arguments(self) -> dict[str, object]:
+        return {
+            "checkout_path": self.checkout,
+            "expected_origin": ORIGIN,
+            "compose_project": PROJECT,
+            "compose_service": SERVICE,
+            "environment_path": self.environment_path,
+            "git_executable": self.git,
+            "docker_executable": self.docker,
+            "environment": {
+                "PATH": "/usr/bin:/bin",
+                "DOCKER_CONFIG": "/private/docker-config",
+                "GIT_DIR": "secret-git-override",
+                "LANG": "host-locale",
+            },
+        }
+
+
+@pytest.fixture
+def observation_harness(tmp_path: Path) -> ObservationHarness:
+    """Build one safe legacy checkout with inert executable boundaries."""
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    environment_path = checkout / ".env"
+    environment_path.write_bytes(SECRET_ENVIRONMENT)
+    environment_path.chmod(0o600)
+    bin_directory = tmp_path / "bin"
+    bin_directory.mkdir()
+    git = bin_directory / "git"
+    docker = bin_directory / "docker"
+    for executable in (git, docker):
+        executable.write_text("#!/bin/sh\nexit 99\n", encoding="utf-8")
+        executable.chmod(0o755)
+    boundary = ObservationBoundary(checkout.resolve(), git.resolve(), docker.resolve())
+    return ObservationHarness(
+        checkout=checkout.resolve(),
+        environment_path=environment_path,
+        git=git,
+        docker=docker,
+        boundary=boundary,
+    )
+
+
+def _observe(
+    harness: ObservationHarness,
+    *,
+    arguments: dict[str, object] | None = None,
+) -> DeploymentObservation | None:
+    run = create_autospec(
+        subprocess.run,
+        spec_set=True,
+        side_effect=harness.boundary.run,
+    )
+    with patch("agent.deployment_adoption.subprocess.run", new=run):
+        return observe_legacy_deployment(
+            **(harness.arguments() if arguments is None else arguments)  # type: ignore[arg-type]
+        )
+
+
+def test_observe_exact_healthy_legacy_deployment(
+    observation_harness: ObservationHarness,
+) -> None:
+    """Return only proven metadata while never reading private env bytes."""
+    before = observation_harness.environment_path.read_bytes()
+
+    observation = _observe(observation_harness)
+
+    assert observation == DeploymentObservation(
+        checkout_path=observation_harness.checkout,
+        origin=ORIGIN,
+        revision=REVISION,
+        compose_project=PROJECT,
+        compose_service=SERVICE,
+        environment_path=observation_harness.environment_path,
+        image_reference=IMAGE_REFERENCE,
+        image_id=IMAGE_ID,
+        oci_revision=OCI_REVISION,
+    )
+    assert observation_harness.environment_path.read_bytes() == before
+    assert [
+        call[1:4]
+        for call in observation_harness.boundary.calls
+        if call[0].endswith("git")
+    ] == [
+        ("-C", str(observation_harness.checkout), "rev-parse"),
+        ("-C", str(observation_harness.checkout), "remote"),
+        ("-C", str(observation_harness.checkout), "diff"),
+        ("-C", str(observation_harness.checkout), "diff"),
+        ("-C", str(observation_harness.checkout), "rev-parse"),
+    ]
+    docker_commands = [
+        call[1:3]
+        for call in observation_harness.boundary.calls
+        if call[0].endswith("docker")
+    ]
+    assert docker_commands == [
+        ("container", "ls"),
+        ("container", "inspect"),
+        ("image", "inspect"),
+    ]
+    forbidden = {"start", "stop", "run", "create", "rm", "pull", "push", "tag"}
+    assert not forbidden.intersection(
+        argument for call in observation_harness.boundary.calls for argument in call
+    )
+
+
+def test_optional_dot_git_origin_is_normalized(
+    observation_harness: ObservationHarness,
+) -> None:
+    """Accept the one equivalent legacy HTTPS remote spelling."""
+    observation_harness.boundary.origin = f"{ORIGIN}.git"
+
+    observation = _observe(observation_harness)
+
+    assert observation is not None
+    assert observation.origin == ORIGIN
+
+
+def test_nested_directory_cannot_impersonate_checkout_root(
+    observation_harness: ObservationHarness,
+) -> None:
+    """Require the claimed checkout to be Git's exact work-tree root."""
+    nested = observation_harness.checkout / "nested"
+    nested.mkdir()
+    observation_harness.boundary.checkout = nested
+    observation_harness.boundary.top_level = observation_harness.checkout
+    arguments = observation_harness.arguments()
+    arguments["checkout_path"] = nested
+    arguments["environment_path"] = nested / ".env"
+
+    with pytest.raises(DeploymentAdoptionError, match="root does not match"):
+        _observe(observation_harness, arguments=arguments)
+
+    assert len(observation_harness.boundary.calls) == 1
+
+
+def test_reported_checkout_root_must_exist(
+    observation_harness: ObservationHarness,
+) -> None:
+    """Reject a Git root response that cannot be resolved to a directory."""
+    observation_harness.boundary.top_level = (
+        observation_harness.checkout / "missing-root"
+    )
+
+    with pytest.raises(DeploymentAdoptionError, match="root is unavailable"):
+        _observe(observation_harness)
+
+    assert len(observation_harness.boundary.calls) == 1
+
+
+def test_zero_containers_is_clean_first_install_without_env(
+    observation_harness: ObservationHarness,
+) -> None:
+    """Return no rollback target before requiring a legacy environment file."""
+    observation_harness.boundary.container_list = ""
+    observation_harness.environment_path.unlink()
+
+    assert _observe(observation_harness) is None
+    assert all(
+        call[1:3] != ("container", "inspect")
+        for call in observation_harness.boundary.calls
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("expected_origin", "git@github.com:owner/repo.git", "origin"),
+        ("expected_origin", f"{ORIGIN}.git", "origin"),
+        ("compose_project", "Invalid", "compose_project"),
+        ("compose_service", "-agent", "compose_service"),
+    ],
+)
+def test_invalid_public_inputs_fail_before_external_calls(
+    observation_harness: ObservationHarness,
+    field: str,
+    value: str,
+    message: str,
+) -> None:
+    """Reject ambiguous identifiers before consulting Git or Docker."""
+    arguments = observation_harness.arguments()
+    arguments[field] = value
+
+    with pytest.raises(DeploymentAdoptionError, match=message):
+        _observe(observation_harness, arguments=arguments)
+
+    assert observation_harness.boundary.calls == []
+
+
+@pytest.mark.parametrize("unsafe_kind", ["relative", "missing", "file"])
+def test_invalid_checkout_fails_before_external_calls(
+    observation_harness: ObservationHarness,
+    tmp_path: Path,
+    unsafe_kind: str,
+) -> None:
+    """Require one absolute existing checkout directory."""
+    arguments = observation_harness.arguments()
+    if unsafe_kind == "relative":
+        arguments["checkout_path"] = Path("relative")
+    elif unsafe_kind == "missing":
+        arguments["checkout_path"] = tmp_path / "missing"
+    else:
+        selected = tmp_path / "not-directory"
+        selected.write_text("file", encoding="utf-8")
+        arguments["checkout_path"] = selected
+
+    with pytest.raises(DeploymentAdoptionError, match="checkout"):
+        _observe(observation_harness, arguments=arguments)
+
+    assert observation_harness.boundary.calls == []
+
+
+@pytest.mark.parametrize(
+    ("field", "unsafe_kind"),
+    [
+        ("git_executable", "relative"),
+        ("git_executable", "missing"),
+        ("git_executable", "directory"),
+        ("git_executable", "not-executable"),
+        ("docker_executable", "relative"),
+    ],
+)
+def test_invalid_executable_fails_closed(
+    observation_harness: ObservationHarness,
+    tmp_path: Path,
+    field: str,
+    unsafe_kind: str,
+) -> None:
+    """Resolve fixed external boundaries instead of searching an ambient PATH."""
+    arguments = observation_harness.arguments()
+    if unsafe_kind == "relative":
+        selected = Path("git")
+    elif unsafe_kind == "missing":
+        selected = tmp_path / "missing"
+    elif unsafe_kind == "directory":
+        selected = tmp_path / "directory"
+        selected.mkdir()
+    else:
+        selected = tmp_path / "not-executable"
+        selected.write_text("no", encoding="utf-8")
+        selected.chmod(0o600)
+    arguments[field] = selected
+
+    with pytest.raises(DeploymentAdoptionError, match="executable"):
+        _observe(observation_harness, arguments=arguments)
+
+    assert observation_harness.boundary.calls == []
+
+
+@pytest.mark.parametrize(
+    ("origin", "message"),
+    [
+        ("https://github.com/other/repository", "does not match"),
+        ("", "origin"),
+        (f"{ORIGIN}\nsecond", "origin"),
+        (f"{ORIGIN}\0suffix", "origin"),
+    ],
+)
+def test_git_origin_must_be_one_exact_safe_line(
+    observation_harness: ObservationHarness,
+    origin: str,
+    message: str,
+) -> None:
+    """Do not infer identity from a different or malformed remote."""
+    observation_harness.boundary.origin = origin
+
+    with pytest.raises(DeploymentAdoptionError, match=message):
+        _observe(observation_harness)
+
+
+@pytest.mark.parametrize("dirty_field", ["unstaged_returncode", "staged_returncode"])
+def test_dirty_checkout_is_rejected(
+    observation_harness: ObservationHarness,
+    dirty_field: str,
+) -> None:
+    """Require the recorded source revision to describe tracked checkout bytes."""
+    setattr(observation_harness.boundary, dirty_field, 1)
+
+    with pytest.raises(DeploymentAdoptionError, match="tracked changes"):
+        _observe(observation_harness)
+
+
+def test_git_command_failure_is_secret_free(
+    observation_harness: ObservationHarness,
+) -> None:
+    """Do not reflect external stderr in adoption diagnostics."""
+    observation_harness.boundary.fail_command = (
+        "-C",
+        str(observation_harness.checkout),
+        "remote",
+        "get-url",
+        "origin",
+    )
+
+    with pytest.raises(DeploymentAdoptionError, match="command failed") as error:
+        _observe(observation_harness)
+
+    assert "secret-boundary-error" not in str(error.value)
+
+
+@pytest.mark.parametrize("revision", ["A" * 40, "a" * 39, "a" * 40 + "\nextra"])
+def test_invalid_git_revision_is_rejected(
+    observation_harness: ObservationHarness,
+    revision: str,
+) -> None:
+    """Require one exact lowercase commit identity."""
+    observation_harness.boundary.revision = revision
+
+    with pytest.raises(DeploymentAdoptionError, match="revision"):
+        _observe(observation_harness)
+
+
+@pytest.mark.parametrize(
+    "container_list",
+    [
+        "not-a-container\n",
+        f"{SHORT_CONTAINER_ID}\n{'f' * 12}\n",
+    ],
+)
+def test_container_selection_rejects_invalid_or_ambiguous_results(
+    observation_harness: ObservationHarness,
+    container_list: str,
+) -> None:
+    """Never guess between malformed or multiple matching containers."""
+    observation_harness.boundary.container_list = container_list
+
+    with pytest.raises(DeploymentAdoptionError, match="invalid|ambiguous"):
+        _observe(observation_harness)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda document: document.update(Id="short"), "identity"),
+        (lambda document: document.update(Id="f" * 64), "identity"),
+        (lambda document: document.pop("State"), "container state"),
+        (
+            lambda document: document["State"].update(Status="exited"),
+            "not running",
+        ),
+        (
+            lambda document: document["State"].update(Status=7),
+            "container status",
+        ),
+        (
+            lambda document: document["State"].pop("Health"),
+            "container health",
+        ),
+        (
+            lambda document: document["State"]["Health"].update(Status="starting"),
+            "not healthy",
+        ),
+        (lambda document: document.pop("Config"), "configuration"),
+        (
+            lambda document: document["Config"].update(Image="agent:latest"),
+            "not immutable",
+        ),
+        (
+            lambda document: document["Config"].update(
+                Image=(f"ghcr.io/queryplanner/agent:latest@sha256:{'e' * 64}")
+            ),
+            "not immutable",
+        ),
+        (
+            lambda document: document["Config"].update(
+                Image=f"ghcr.io/queryplanner//agent@sha256:{'e' * 64}"
+            ),
+            "not immutable",
+        ),
+        (
+            lambda document: document["Config"].pop("Labels"),
+            "container labels",
+        ),
+        (
+            lambda document: document["Config"]["Labels"].update(
+                {"com.docker.compose.project": "other"}
+            ),
+            "labels do not match",
+        ),
+        (lambda document: document.update(Image="sha256:short"), "image ID"),
+    ],
+)
+def test_container_contract_fails_closed(
+    observation_harness: ObservationHarness,
+    mutation: object,
+    message: str,
+) -> None:
+    """Require exact running, health, label, reference, and image identity."""
+    document = copy.deepcopy(observation_harness.boundary.container_document)
+    mutation(document)  # type: ignore[operator]
+    observation_harness.boundary.container_document = document
+
+    with pytest.raises(DeploymentAdoptionError, match=message):
+        _observe(observation_harness)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda document: document.update(Id=f"sha256:{'f' * 64}"), "identity"),
+        (lambda document: document.update(RepoDigests=None), "digest"),
+        (lambda document: document.update(RepoDigests=[7]), "digest"),
+        (
+            lambda document: document.update(
+                RepoDigests=[f"ghcr.io/other/image@sha256:{'e' * 64}"]
+            ),
+            "digest",
+        ),
+        (lambda document: document.pop("Config"), "image configuration"),
+        (lambda document: document["Config"].pop("Labels"), "image labels"),
+        (
+            lambda document: document["Config"]["Labels"].update(
+                {"org.opencontainers.image.revision": "invalid"}
+            ),
+            "OCI revision",
+        ),
+    ],
+)
+def test_image_contract_fails_closed(
+    observation_harness: ObservationHarness,
+    mutation: object,
+    message: str,
+) -> None:
+    """Bind the running container to a local digest and valid OCI revision."""
+    document = copy.deepcopy(observation_harness.boundary.image_document)
+    mutation(document)  # type: ignore[operator]
+    observation_harness.boundary.image_document = document
+
+    with pytest.raises(DeploymentAdoptionError, match=message):
+        _observe(observation_harness)
+
+
+@pytest.mark.parametrize(
+    "unsafe_kind",
+    [
+        "wrong-path",
+        "missing",
+        "directory",
+        "symlink",
+        "mode",
+        "hardlink",
+        "empty",
+        "owner",
+    ],
+)
+def test_environment_metadata_must_be_private_and_stable(
+    observation_harness: ObservationHarness,
+    tmp_path: Path,
+    unsafe_kind: str,
+) -> None:
+    """Validate recovery-file metadata without reading or logging its contents."""
+    arguments = observation_harness.arguments()
+    environment_path = observation_harness.environment_path
+    owner_patch = None
+    if unsafe_kind == "wrong-path":
+        selected = tmp_path / ".env"
+        selected.write_bytes(SECRET_ENVIRONMENT)
+        selected.chmod(0o600)
+        arguments["environment_path"] = selected
+    elif unsafe_kind == "missing":
+        environment_path.unlink()
+    elif unsafe_kind == "directory":
+        environment_path.unlink()
+        environment_path.mkdir(mode=0o700)
+    elif unsafe_kind == "symlink":
+        environment_path.unlink()
+        target = tmp_path / "target.env"
+        target.write_bytes(SECRET_ENVIRONMENT)
+        target.chmod(0o600)
+        environment_path.symlink_to(target)
+    elif unsafe_kind == "mode":
+        environment_path.chmod(0o640)
+    elif unsafe_kind == "hardlink":
+        os.link(environment_path, tmp_path / "second-name")
+    elif unsafe_kind == "empty":
+        environment_path.write_bytes(b"")
+        environment_path.chmod(0o600)
+    else:
+        owner_patch = patch(
+            "agent.deployment_adoption.os.geteuid",
+            new=create_autospec(os.geteuid, spec_set=True, return_value=1),
+        )
+
+    context = owner_patch if owner_patch is not None else patch.dict({}, {})
+    with context, pytest.raises(DeploymentAdoptionError, match="environment"):
+        _observe(observation_harness, arguments=arguments)
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ("not-json", "invalid"),
+        ("[]", "invalid"),
+        ("[{},{}]", "invalid"),
+        ("[7]", "invalid"),
+    ],
+)
+def test_json_boundary_requires_exactly_one_object(
+    payload: str,
+    message: str,
+) -> None:
+    """Reject malformed or ambiguous Docker inspect responses."""
+    with pytest.raises(DeploymentAdoptionError, match=message):
+        adoption_module._json_document(payload, "synthetic")
+
+
+def test_oversized_external_output_is_rejected(
+    observation_harness: ObservationHarness,
+) -> None:
+    """Bound memory used for external command responses."""
+    observation_harness.boundary.origin = "x" * (adoption_module._MAX_OUTPUT_BYTES + 1)
+
+    with pytest.raises(DeploymentAdoptionError, match="too large"):
+        _observe(observation_harness)
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        OSError("secret-os-error"),
+        subprocess.TimeoutExpired(["git"], 30, output="secret-timeout-output"),
+    ],
+)
+def test_external_execution_failures_are_redacted(
+    observation_harness: ObservationHarness,
+    failure: BaseException,
+) -> None:
+    """Convert launch and timeout details into one secret-free diagnostic."""
+    run = create_autospec(subprocess.run, spec_set=True, side_effect=failure)
+    with (
+        patch("agent.deployment_adoption.subprocess.run", new=run),
+        pytest.raises(DeploymentAdoptionError, match="command failed") as error,
+    ):
+        observe_legacy_deployment(
+            **observation_harness.arguments()  # type: ignore[arg-type]
+        )
+
+    assert "secret" not in str(error.value)
+
+
+def test_default_process_environment_is_sanitized(
+    observation_harness: ObservationHarness,
+) -> None:
+    """Exercise the production environment path without preserving Git overrides."""
+    arguments = observation_harness.arguments()
+    arguments["environment"] = None
+
+    with patch.dict(
+        os.environ,
+        {
+            "DOCKER_CONFIG": "/private/docker-config",
+            "GIT_WORK_TREE": "secret",
+        },
+        clear=True,
+    ):
+        observation = _observe(observation_harness, arguments=arguments)
+
+    assert observation is not None
+
+
+def test_nonzero_dirty_check_error_is_not_misreported_as_dirty(
+    observation_harness: ObservationHarness,
+) -> None:
+    """Distinguish an unreadable checkout from a clean/dirty result."""
+    observation_harness.boundary.unstaged_returncode = 2
+
+    with pytest.raises(DeploymentAdoptionError, match="command failed"):
+        _observe(observation_harness)

--- a/tests/test_deployment_state.py
+++ b/tests/test_deployment_state.py
@@ -1,0 +1,1369 @@
+"""Durable VM deployment state and lock contract tests."""
+
+from __future__ import annotations
+
+import errno
+import fcntl
+import hashlib
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import create_autospec, patch
+
+import pytest
+
+from agent import deployment_state as state_module
+from agent.deployment_state import (
+    CurrentDeployment,
+    DeploymentLockBusyError,
+    DeploymentStateError,
+    DeploymentStateStore,
+)
+
+REVISION = "a" * 40
+OCI_REVISION = "b" * 40
+IMAGE_ID = f"sha256:{'c' * 64}"
+IMAGE_REFERENCE = f"ghcr.io/queryplanner/agent@sha256:{'d' * 64}"
+DEPLOYMENT_ID = "adopt-0123456789abcdef"
+RECORDED_AT = "2026-07-28T12:34:56.123456Z"
+ENVIRONMENT_BYTES = b'API_KEY="secret-$-canary"\nEMPTY=""\n'
+
+
+def _write_private(path: Path, payload: bytes) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
+    path.chmod(0o600)
+    return path
+
+
+def _environment(tmp_path: Path) -> Path:
+    return _write_private(tmp_path / "legacy.env", ENVIRONMENT_BYTES)
+
+
+def _adopt(
+    store: DeploymentStateStore,
+    environment: Path,
+    *,
+    deployment_id: str | None = DEPLOYMENT_ID,
+    recorded_at: str | None = RECORDED_AT,
+) -> CurrentDeployment:
+    with store.transaction() as transaction:
+        return transaction.adopt(
+            compose_project="adk-template",
+            compose_service="agent",
+            source_revision=REVISION,
+            image_reference=IMAGE_REFERENCE,
+            image_id=IMAGE_ID,
+            oci_revision=OCI_REVISION,
+            environment_source=environment,
+            deployment_id=deployment_id,
+            recorded_at=recorded_at,
+        )
+
+
+def _journal_path(store: DeploymentStateStore, sequence: int = 1) -> Path:
+    return store.journal_path / f"{sequence:020d}.json"
+
+
+def _read_document(path: Path) -> dict[str, object]:
+    decoded = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(decoded, dict)
+    return decoded
+
+
+def _write_document(path: Path, document: dict[str, object]) -> None:
+    _write_private(path, state_module._canonical_json(document))
+
+
+def _append_second_record(store: DeploymentStateStore) -> dict[str, object]:
+    first_payload = _journal_path(store).read_bytes()
+    first = _read_document(_journal_path(store))
+    second = {
+        "schema_version": 1,
+        "sequence": 2,
+        "previous_sha256": hashlib.sha256(first_payload).hexdigest(),
+        "event": "adopted",
+        "state": first["state"],
+    }
+    _write_document(_journal_path(store, 2), second)
+    return second
+
+
+def test_adoption_round_trips_private_crash_consistent_state(
+    tmp_path: Path,
+) -> None:
+    """Persist exact recovery bytes while journals remain secret-free."""
+    store = DeploymentStateStore(tmp_path / "state")
+    environment = _environment(tmp_path)
+
+    with store.transaction() as transaction:
+        assert transaction.current() is None
+        assert transaction.journal() == ()
+        current = transaction.adopt(
+            compose_project="adk-template",
+            compose_service="agent",
+            source_revision=REVISION,
+            image_reference=IMAGE_REFERENCE,
+            image_id=IMAGE_ID,
+            oci_revision=OCI_REVISION,
+            environment_source=environment,
+            deployment_id=DEPLOYMENT_ID,
+            recorded_at=RECORDED_AT,
+        )
+        assert transaction.current() == current
+        assert transaction.journal()[0].sha256 == current.journal_sha256
+        assert transaction.journal()[0].state == current.state
+
+    snapshot = store.path / current.state.environment_snapshot
+    assert snapshot.read_bytes() == ENVIRONMENT_BYTES
+    assert (
+        current.state.environment_sha256
+        == hashlib.sha256(ENVIRONMENT_BYTES).hexdigest()
+    )
+    assert store.read_current() == current
+    assert store.read_journal()[0].state == current.state
+
+    for directory in (store.path, store.journal_path, store.environments_path):
+        assert stat.S_IMODE(directory.stat().st_mode) == 0o700
+    for private_file in (
+        store.lock_path,
+        store.current_path,
+        _journal_path(store),
+        snapshot,
+    ):
+        assert stat.S_IMODE(private_file.stat().st_mode) == 0o600
+        assert private_file.stat().st_nlink == 1
+
+    public_bytes = store.current_path.read_bytes() + _journal_path(store).read_bytes()
+    assert b"secret-$-canary" not in public_bytes
+    assert str(environment).encode() not in public_bytes
+    assert current.state.environment_snapshot.encode() in public_bytes
+
+
+def test_default_identity_and_timestamp_are_canonical(tmp_path: Path) -> None:
+    """Generate safe defaults without weakening deterministic caller overrides."""
+    current = _adopt(
+        DeploymentStateStore(tmp_path / "state"),
+        _environment(tmp_path),
+        deployment_id=None,
+        recorded_at=None,
+    )
+
+    assert len(current.state.deployment_id) == 32
+    assert current.state.deployment_id.isalnum()
+    assert current.state.recorded_at.endswith("Z")
+    assert len(current.state.recorded_at) == 27
+
+
+def test_transaction_object_fails_after_lock_release(tmp_path: Path) -> None:
+    """Prevent lock-scoped state from being reused after its descriptor closes."""
+    store = DeploymentStateStore(tmp_path / "state")
+    with store.transaction() as transaction:
+        assert transaction.current() is None
+
+    with pytest.raises(DeploymentStateError, match="transaction is closed"):
+        transaction.current()
+    with pytest.raises(DeploymentStateError, match="transaction is closed"):
+        transaction.journal()
+    with pytest.raises(DeploymentStateError, match="transaction is closed"):
+        transaction.adopt(
+            compose_project="adk-template",
+            compose_service="agent",
+            source_revision=REVISION,
+            image_reference=IMAGE_REFERENCE,
+            image_id=IMAGE_ID,
+            oci_revision=OCI_REVISION,
+            environment_source=_environment(tmp_path),
+        )
+
+
+def test_adoption_never_overwrites_initialized_state(tmp_path: Path) -> None:
+    """Require promotion logic instead of silently replacing the recovery base."""
+    store = DeploymentStateStore(tmp_path / "state")
+    environment = _environment(tmp_path)
+    original = _adopt(store, environment)
+
+    with (
+        store.transaction() as transaction,
+        pytest.raises(DeploymentStateError, match="already been initialized"),
+    ):
+        transaction.adopt(
+            compose_project="adk-template",
+            compose_service="agent",
+            source_revision="e" * 40,
+            image_reference=IMAGE_REFERENCE,
+            image_id=IMAGE_ID,
+            oci_revision=OCI_REVISION,
+            environment_source=environment,
+        )
+
+    assert store.read_current() == original
+    assert len(store.read_journal()) == 1
+
+
+@pytest.mark.parametrize(
+    ("override", "value", "field"),
+    [
+        ("compose_project", "Invalid", "compose_project"),
+        ("compose_service", "-agent", "compose_service"),
+        ("source_revision", "A" * 40, "source_revision"),
+        ("image_reference", "agent:latest", "image_reference"),
+        (
+            "image_reference",
+            f"ghcr.io/queryplanner/agent:latest@sha256:{'d' * 64}",
+            "image_reference",
+        ),
+        (
+            "image_reference",
+            f"ghcr.io/queryplanner//agent@sha256:{'d' * 64}",
+            "image_reference",
+        ),
+        ("image_id", "sha256:short", "image_id"),
+        ("oci_revision", "g" * 40, "oci_revision"),
+        ("deployment_id", "../escape", "deployment_id"),
+        ("recorded_at", "2026-02-30T12:34:56.123456Z", "recorded_at"),
+    ],
+)
+def test_adoption_rejects_invalid_metadata_before_snapshot(
+    tmp_path: Path,
+    override: str,
+    value: str,
+    field: str,
+) -> None:
+    """Validate all public metadata before copying private environment bytes."""
+    store = DeploymentStateStore(tmp_path / override / "state")
+    environment = _environment(tmp_path)
+    arguments = {
+        "compose_project": "adk-template",
+        "compose_service": "agent",
+        "source_revision": REVISION,
+        "image_reference": IMAGE_REFERENCE,
+        "image_id": IMAGE_ID,
+        "oci_revision": OCI_REVISION,
+        "environment_source": environment,
+        "deployment_id": DEPLOYMENT_ID,
+        "recorded_at": RECORDED_AT,
+    }
+    arguments[override] = value
+
+    with (
+        store.transaction() as transaction,
+        pytest.raises(DeploymentStateError, match=field),
+    ):
+        transaction.adopt(**arguments)  # type: ignore[arg-type]
+
+    assert list(store.environments_path.iterdir()) == []
+    assert list(store.journal_path.iterdir()) == []
+    assert not store.current_path.exists()
+
+
+@pytest.mark.parametrize(
+    "path_factory",
+    [
+        lambda root: Path("relative-state"),
+        lambda root: root / "nested" / ".." / "state",
+    ],
+)
+def test_store_requires_absolute_normalized_path(
+    tmp_path: Path,
+    path_factory: object,
+) -> None:
+    """Keep transaction identity independent of caller working directory."""
+    selected = path_factory(tmp_path)  # type: ignore[operator]
+    with pytest.raises(DeploymentStateError, match="absolute normalized"):
+        DeploymentStateStore(selected)
+
+
+def test_nested_state_parent_is_created_privately(tmp_path: Path) -> None:
+    """Create every missing state directory with owner-only permissions."""
+    state_path = tmp_path / "missing" / "nested" / "state"
+    store = DeploymentStateStore(state_path)
+
+    with store.transaction() as transaction:
+        assert transaction.current() is None
+
+    for path in (
+        tmp_path / "missing",
+        tmp_path / "missing" / "nested",
+        state_path,
+        store.journal_path,
+        store.environments_path,
+    ):
+        assert stat.S_IMODE(path.stat().st_mode) == 0o700
+
+
+def test_new_state_hierarchy_syncs_every_parent_directory(tmp_path: Path) -> None:
+    """Make each newly published directory entry durable before continuing."""
+    state_path = tmp_path / "missing" / "nested" / "state"
+    real_fsync = os.fsync
+    directory_syncs = 0
+
+    def record_fsync(descriptor: int) -> None:
+        nonlocal directory_syncs
+        if stat.S_ISDIR(os.fstat(descriptor).st_mode):
+            directory_syncs += 1
+        real_fsync(descriptor)
+
+    fsync_spy = create_autospec(
+        os.fsync,
+        spec_set=True,
+        side_effect=record_fsync,
+    )
+    with (
+        patch("agent.deployment_state.os.fsync", new=fsync_spy),
+        DeploymentStateStore(state_path).transaction(),
+    ):
+        pass
+
+    assert directory_syncs == 5
+
+
+@pytest.mark.parametrize("unsafe_kind", ["file", "symlink", "mode", "owner"])
+def test_state_root_rejects_unsafe_metadata(
+    tmp_path: Path,
+    unsafe_kind: str,
+) -> None:
+    """Fail before acquiring a lock through an unsafe state boundary."""
+    state_path = tmp_path / "state"
+    owner_patch = None
+    if unsafe_kind == "file":
+        state_path.write_text("not-a-directory", encoding="utf-8")
+    elif unsafe_kind == "symlink":
+        target = tmp_path / "target"
+        target.mkdir(mode=0o700)
+        state_path.symlink_to(target, target_is_directory=True)
+    else:
+        state_path.mkdir(mode=0o700)
+        if unsafe_kind == "mode":
+            state_path.chmod(0o755)
+        else:
+            owner_patch = patch(
+                "agent.deployment_state.os.geteuid",
+                new=create_autospec(os.geteuid, spec_set=True, return_value=1),
+            )
+
+    context = owner_patch if owner_patch is not None else patch.dict({}, {})
+    with (
+        context,
+        pytest.raises(DeploymentStateError, match="unsafe|absolute normalized"),
+        DeploymentStateStore(state_path).transaction(),
+    ):
+        pytest.fail("unsafe state root acquired a deployment lock")
+
+
+@pytest.mark.parametrize("unsafe_kind", ["mode", "hardlink", "symlink"])
+def test_lock_file_rejects_unsafe_metadata(
+    tmp_path: Path,
+    unsafe_kind: str,
+) -> None:
+    """Reject lock paths that can be observed or redirected by another user."""
+    store = DeploymentStateStore(tmp_path / "state")
+    with store.transaction():
+        pass
+
+    if unsafe_kind == "mode":
+        store.lock_path.chmod(0o644)
+    elif unsafe_kind == "hardlink":
+        os.link(store.lock_path, tmp_path / "second-lock-name")
+    else:
+        store.lock_path.unlink()
+        target = _write_private(tmp_path / "target-lock", b"lock")
+        store.lock_path.symlink_to(target)
+
+    with pytest.raises((DeploymentStateError, OSError)), store.transaction():
+        pytest.fail("unsafe lock file acquired")
+
+
+def test_lock_contention_is_nonblocking_and_cross_process(tmp_path: Path) -> None:
+    """Prove a separate process cannot enter until the descriptor is released."""
+    store = DeploymentStateStore(tmp_path / "state")
+    child = (
+        "from pathlib import Path\n"
+        "from agent.deployment_state import "
+        "DeploymentLockBusyError,DeploymentStateStore\n"
+        "store=DeploymentStateStore(Path(__import__('sys').argv[1]))\n"
+        "try:\n"
+        "  with store.transaction(): print('acquired')\n"
+        "except DeploymentLockBusyError:\n"
+        "  print('busy')\n"
+    )
+
+    with store.transaction():
+        blocked = subprocess.run(  # noqa: S603 - current interpreter, fixed code
+            [sys.executable, "-c", child, str(store.path)],
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        assert blocked.stdout.strip() == "busy"
+
+    acquired = subprocess.run(  # noqa: S603 - current interpreter, fixed code
+        [sys.executable, "-c", child, str(store.path)],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    assert acquired.stdout.strip() == "acquired"
+
+
+@pytest.mark.parametrize("error_number", [errno.EAGAIN, errno.EACCES])
+def test_lock_busy_error_is_secret_free(
+    tmp_path: Path,
+    error_number: int,
+) -> None:
+    """Map both portable nonblocking lock errors to one stable exception."""
+    lock_failure = create_autospec(
+        fcntl.flock,
+        spec_set=True,
+        side_effect=OSError(error_number, "secret-kernel-detail"),
+    )
+
+    with (
+        patch("agent.deployment_state.fcntl.flock", new=lock_failure),
+        pytest.raises(DeploymentLockBusyError, match="another deployment"),
+        DeploymentStateStore(tmp_path / "state").transaction(),
+    ):
+        pytest.fail("busy lock unexpectedly acquired")
+
+
+def test_unexpected_lock_error_propagates_and_closes_descriptor(
+    tmp_path: Path,
+) -> None:
+    """Do not misclassify an actual filesystem or kernel failure as contention."""
+    lock_failure = create_autospec(
+        fcntl.flock,
+        spec_set=True,
+        side_effect=OSError(errno.EIO, "synthetic lock I/O failure"),
+    )
+
+    with (
+        patch("agent.deployment_state.fcntl.flock", new=lock_failure),
+        pytest.raises(OSError, match="synthetic lock"),
+        DeploymentStateStore(tmp_path / "state").transaction(),
+    ):
+        pytest.fail("failed lock unexpectedly acquired")
+
+
+def test_missing_current_is_recovered_from_durable_journal(tmp_path: Path) -> None:
+    """Treat the journal as authoritative after a crash before pointer publish."""
+    store = DeploymentStateStore(tmp_path / "state")
+    adopted = _adopt(store, _environment(tmp_path))
+    store.current_path.unlink()
+
+    recovered = store.read_current()
+
+    assert recovered == adopted
+    assert _read_document(store.current_path) == adopted.as_document()
+
+
+def test_stale_current_is_advanced_to_latest_valid_journal(tmp_path: Path) -> None:
+    """Recover a committed journal record that became durable before current."""
+    store = DeploymentStateStore(tmp_path / "state")
+    _adopt(store, _environment(tmp_path))
+    second = _append_second_record(store)
+
+    recovered = store.read_current()
+
+    assert recovered is not None
+    assert recovered.journal_sequence == 2
+    assert recovered.state.as_document() == second["state"]
+    assert len(store.read_journal()) == 2
+
+
+def test_orphaned_recognized_journal_temp_is_removed(tmp_path: Path) -> None:
+    """Remove a private unpublished temp file before journal validation."""
+    store = DeploymentStateStore(tmp_path / "state")
+    adopted = _adopt(store, _environment(tmp_path))
+    temporary_path = _write_private(
+        store.journal_path / ".deployment-journal-orphan.tmp",
+        b"partial",
+    )
+
+    assert store.read_current() == adopted
+    assert len(store.read_journal()) == 1
+    assert not temporary_path.exists()
+
+
+@pytest.mark.parametrize("record_kind", ["journal", "environment"])
+def test_published_hard_link_crash_residue_is_recovered(
+    tmp_path: Path,
+    record_kind: str,
+) -> None:
+    """Remove the stale temp name left between link and directory fsync."""
+    store = DeploymentStateStore(tmp_path / "state")
+    adopted = _adopt(store, _environment(tmp_path))
+    if record_kind == "journal":
+        final_path = _journal_path(store)
+        temporary_path = store.journal_path / ".deployment-journal-crash.tmp"
+    else:
+        final_path = store.path / adopted.state.environment_snapshot
+        temporary_path = store.environments_path / ".deployment-environment-crash.tmp"
+    os.link(final_path, temporary_path)
+    assert final_path.stat().st_nlink == 2
+
+    assert store.read_current() == adopted
+    assert not temporary_path.exists()
+    assert final_path.stat().st_nlink == 1
+
+
+def test_orphaned_current_temp_is_removed(tmp_path: Path) -> None:
+    """Discard a pre-replace current temp without trusting its contents."""
+    store = DeploymentStateStore(tmp_path / "state")
+    adopted = _adopt(store, _environment(tmp_path))
+    temporary_path = _write_private(
+        store.path / ".deployment-current-orphan.tmp",
+        b"partial",
+    )
+
+    assert store.read_current() == adopted
+    assert not temporary_path.exists()
+
+
+def test_current_temp_hard_link_is_rejected(tmp_path: Path) -> None:
+    """Do not unlink a temp hard link without an exact published counterpart."""
+    store = DeploymentStateStore(tmp_path / "state")
+    _adopt(store, _environment(tmp_path))
+    target = _write_private(tmp_path / "current-temp-target", b"private")
+    temporary_path = store.path / ".deployment-current-linked.tmp"
+    os.link(target, temporary_path)
+
+    with pytest.raises(DeploymentStateError, match="unsafe links"):
+        store.read_current()
+
+
+def test_temporary_file_change_during_recovery_is_rejected(
+    tmp_path: Path,
+) -> None:
+    """Bind cleanup to the exact private inode metadata that was validated."""
+    store = DeploymentStateStore(tmp_path / "state")
+    _adopt(store, _environment(tmp_path))
+    temporary_path = _write_private(
+        store.path / ".deployment-current-changing.tmp",
+        b"partial",
+    )
+    real_lstat = Path.lstat
+    temporary_lstats = 0
+
+    def change_after_first_lstat(selected: Path) -> os.stat_result:
+        nonlocal temporary_lstats
+        metadata = real_lstat(selected)
+        if selected == temporary_path:
+            temporary_lstats += 1
+            if temporary_lstats == 1:
+                temporary_path.write_bytes(b"changed-after-validation")
+        return metadata
+
+    lstat_boundary = create_autospec(
+        Path.lstat,
+        spec_set=True,
+        side_effect=change_after_first_lstat,
+    )
+    with (
+        patch("pathlib.Path.lstat", new=lstat_boundary),
+        pytest.raises(DeploymentStateError, match="changed during recovery"),
+    ):
+        store.read_current()
+    assert temporary_lstats == 2
+
+
+@pytest.mark.parametrize(
+    "unsafe_kind",
+    ["directory", "symlink", "mode", "unrelated-hardlink"],
+)
+def test_recognized_journal_temp_rejects_unsafe_metadata(
+    tmp_path: Path,
+    unsafe_kind: str,
+) -> None:
+    """Never ignore a temp-shaped path with untrusted metadata or identity."""
+    store = DeploymentStateStore(tmp_path / "state")
+    _adopt(store, _environment(tmp_path))
+    temporary_path = store.journal_path / ".deployment-journal-unsafe.tmp"
+    if unsafe_kind == "directory":
+        temporary_path.mkdir(mode=0o700)
+    elif unsafe_kind == "symlink":
+        target = _write_private(tmp_path / "temporary-target", b"private")
+        temporary_path.symlink_to(target)
+    elif unsafe_kind == "mode":
+        _write_private(temporary_path, b"private").chmod(0o644)
+    else:
+        target = _write_private(tmp_path / "unrelated-target", b"private")
+        os.link(target, temporary_path)
+
+    with pytest.raises(DeploymentStateError, match="unsafe|ambiguous"):
+        store.read_current()
+
+
+def test_unknown_journal_path_fails_closed(tmp_path: Path) -> None:
+    """Do not silently ignore operator files or attacker-controlled records."""
+    store = DeploymentStateStore(tmp_path / "state")
+    _adopt(store, _environment(tmp_path))
+    _write_private(store.journal_path / "notes.txt", b"unknown")
+
+    with pytest.raises(DeploymentStateError, match="unknown path"):
+        store.read_journal()
+
+
+def test_journal_gap_fails_closed(tmp_path: Path) -> None:
+    """Reject deletion or reordering in the immutable history."""
+    store = DeploymentStateStore(tmp_path / "state")
+    _adopt(store, _environment(tmp_path))
+    _journal_path(store).rename(_journal_path(store, 2))
+
+    with pytest.raises(DeploymentStateError, match="sequence has a gap"):
+        store.read_journal()
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda doc: doc.update(sequence=2), "filename and sequence"),
+        (lambda doc: doc.update(previous_sha256="0" * 64), "hash chain"),
+        (lambda doc: doc.update(previous_sha256="invalid"), "predecessor"),
+        (lambda doc: doc.update(event="promoted"), "event"),
+        (lambda doc: doc.update(schema_version=2), "schema"),
+        (lambda doc: doc.update(sequence=True), "sequence"),
+    ],
+)
+def test_corrupt_journal_record_fails_closed(
+    tmp_path: Path,
+    mutation: object,
+    message: str,
+) -> None:
+    """Reject schema, sequence, event, and hash-chain tampering."""
+    store = DeploymentStateStore(tmp_path / "state")
+    _adopt(store, _environment(tmp_path))
+    document = _read_document(_journal_path(store))
+    mutation(document)  # type: ignore[operator]
+    _write_document(_journal_path(store), document)
+
+    with pytest.raises(DeploymentStateError, match=message):
+        store.read_journal()
+
+
+def test_environment_snapshot_tampering_fails_closed(tmp_path: Path) -> None:
+    """Bind the journal to the exact private rollback bytes."""
+    store = DeploymentStateStore(tmp_path / "state")
+    current = _adopt(store, _environment(tmp_path))
+    snapshot = store.path / current.state.environment_snapshot
+    snapshot.write_bytes(b"changed-secret\n")
+    snapshot.chmod(0o600)
+
+    with pytest.raises(DeploymentStateError, match="snapshot hash"):
+        store.read_current()
+
+
+def test_missing_environment_snapshot_fails_closed(tmp_path: Path) -> None:
+    """Never claim rollback material exists when its private file is gone."""
+    store = DeploymentStateStore(tmp_path / "state")
+    current = _adopt(store, _environment(tmp_path))
+    (store.path / current.state.environment_snapshot).unlink()
+
+    with pytest.raises(DeploymentStateError, match="path is missing"):
+        store.read_journal()
+
+
+def test_journal_entry_document_matches_persisted_schema(tmp_path: Path) -> None:
+    """Expose a stable secret-free journal representation to future tooling."""
+    store = DeploymentStateStore(tmp_path / "state")
+    _adopt(store, _environment(tmp_path))
+    entry = store.read_journal()[0]
+
+    assert entry.as_document() == _read_document(_journal_path(store))
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda document: None, "must be an object"),
+        (lambda document: document.update(extra="unknown"), "schema"),
+        (lambda document: document.update(schema_version=2), "schema"),
+        (lambda document: document.update(adopted=False), "adopted"),
+        (
+            lambda document: document.update(
+                environment_snapshot="environments/other.env"
+            ),
+            "environment_snapshot",
+        ),
+    ],
+)
+def test_state_document_parser_rejects_schema_ambiguity(
+    tmp_path: Path,
+    mutation: object,
+    message: str,
+) -> None:
+    """Reject unknown fields, unsafe snapshots, and non-adoption state."""
+    store = DeploymentStateStore(tmp_path / "state")
+    current = _adopt(store, _environment(tmp_path))
+    document: object = current.state.as_document()
+    if message == "must be an object":
+        document = None
+    else:
+        mutation(document)  # type: ignore[operator]
+
+    with pytest.raises(DeploymentStateError, match=message):
+        state_module._state_from_document(document)
+
+
+def test_timestamp_validator_rejects_wrong_shape() -> None:
+    """Keep public timestamps in one canonical UTC representation."""
+    with pytest.raises(DeploymentStateError, match="recorded_at"):
+        state_module._validate_timestamp("2026-07-28T12:34:56Z")
+
+
+@pytest.mark.parametrize("mode", [0o000, 0o640])
+def test_nonprivate_environment_source_is_rejected(
+    tmp_path: Path,
+    mode: int,
+) -> None:
+    """Require an exact owner-only rollback source before copying bytes."""
+    environment = _environment(tmp_path)
+    environment.chmod(mode)
+    store = DeploymentStateStore(tmp_path / "state")
+
+    with (
+        store.transaction() as transaction,
+        pytest.raises(DeploymentStateError, match="unsafe permissions"),
+    ):
+        transaction.adopt(
+            compose_project="adk-template",
+            compose_service="agent",
+            source_revision=REVISION,
+            image_reference=IMAGE_REFERENCE,
+            image_id=IMAGE_ID,
+            oci_revision=OCI_REVISION,
+            environment_source=environment,
+            deployment_id=DEPLOYMENT_ID,
+            recorded_at=RECORDED_AT,
+        )
+
+
+@pytest.mark.parametrize(
+    "unsafe_kind", ["missing", "empty", "directory", "symlink", "hardlink"]
+)
+def test_unsafe_environment_source_is_rejected(
+    tmp_path: Path,
+    unsafe_kind: str,
+) -> None:
+    """Reject absent, empty, linked, or non-regular recovery inputs."""
+    environment = tmp_path / "legacy.env"
+    if unsafe_kind == "empty":
+        _write_private(environment, b"")
+    elif unsafe_kind == "directory":
+        environment.mkdir(mode=0o700)
+    elif unsafe_kind == "symlink":
+        target = _write_private(tmp_path / "target.env", ENVIRONMENT_BYTES)
+        environment.symlink_to(target)
+    elif unsafe_kind == "hardlink":
+        target = _write_private(tmp_path / "target.env", ENVIRONMENT_BYTES)
+        os.link(target, environment)
+
+    store = DeploymentStateStore(tmp_path / "state")
+    with (
+        store.transaction() as transaction,
+        pytest.raises(DeploymentStateError),
+    ):
+        transaction.adopt(
+            compose_project="adk-template",
+            compose_service="agent",
+            source_revision=REVISION,
+            image_reference=IMAGE_REFERENCE,
+            image_id=IMAGE_ID,
+            oci_revision=OCI_REVISION,
+            environment_source=environment,
+            deployment_id=DEPLOYMENT_ID,
+            recorded_at=RECORDED_AT,
+        )
+
+
+def test_oversized_environment_source_is_rejected(tmp_path: Path) -> None:
+    """Bound private recovery memory and disk consumption."""
+    environment = _write_private(
+        tmp_path / "legacy.env",
+        b"x" * (state_module.MAX_ENVIRONMENT_BYTES + 1),
+    )
+    store = DeploymentStateStore(tmp_path / "state")
+
+    with (
+        store.transaction() as transaction,
+        pytest.raises(DeploymentStateError, match="size is invalid"),
+    ):
+        transaction.adopt(
+            compose_project="adk-template",
+            compose_service="agent",
+            source_revision=REVISION,
+            image_reference=IMAGE_REFERENCE,
+            image_id=IMAGE_ID,
+            oci_revision=OCI_REVISION,
+            environment_source=environment,
+            deployment_id=DEPLOYMENT_ID,
+            recorded_at=RECORDED_AT,
+        )
+
+
+def test_environment_change_during_read_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Detect a non-cooperating writer racing the adoption snapshot."""
+    environment = _environment(tmp_path)
+    real_fstat = os.fstat
+    source_descriptor: int | None = None
+    calls = 0
+
+    def changed_fstat(descriptor: int) -> os.stat_result:
+        nonlocal calls, source_descriptor
+        metadata = real_fstat(descriptor)
+        if stat.S_ISREG(metadata.st_mode) and metadata.st_size == len(
+            ENVIRONMENT_BYTES
+        ):
+            source_descriptor = descriptor
+            calls += 1
+            if calls == 2:
+                values = list(metadata)
+                values[8] = metadata.st_mtime + 1
+                return os.stat_result(values)
+        return metadata
+
+    monkeypatch.setattr(os, "fstat", changed_fstat)
+    store = DeploymentStateStore(tmp_path / "state")
+
+    with (
+        store.transaction() as transaction,
+        pytest.raises(DeploymentStateError, match="changed while read"),
+    ):
+        transaction.adopt(
+            compose_project="adk-template",
+            compose_service="agent",
+            source_revision=REVISION,
+            image_reference=IMAGE_REFERENCE,
+            image_id=IMAGE_ID,
+            oci_revision=OCI_REVISION,
+            environment_source=environment,
+            deployment_id=DEPLOYMENT_ID,
+            recorded_at=RECORDED_AT,
+        )
+    assert source_descriptor is not None
+
+
+def test_environment_replacement_before_open_is_rejected(tmp_path: Path) -> None:
+    """Bind the validated pathname inode to the descriptor that is read."""
+    environment = _environment(tmp_path)
+    replacement = _write_private(
+        tmp_path / "replacement.env",
+        b"X" * len(ENVIRONMENT_BYTES),
+    )
+    real_open = os.open
+    replaced = False
+
+    def replace_then_open(
+        path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        nonlocal replaced
+        if Path(os.fsdecode(path)) == environment and not replaced:
+            environment.unlink()
+            replacement.replace(environment)
+            replaced = True
+        return real_open(path, flags, mode, dir_fd=dir_fd)
+
+    open_boundary = create_autospec(
+        os.open,
+        spec_set=True,
+        side_effect=replace_then_open,
+    )
+    with (
+        patch("agent.deployment_state.os.open", new=open_boundary),
+        pytest.raises(DeploymentStateError, match="changed before read"),
+    ):
+        state_module._read_private_file(
+            environment,
+            maximum_bytes=state_module.MAX_ENVIRONMENT_BYTES,
+        )
+    assert replaced
+
+
+def test_environment_path_replacement_after_read_is_rejected(
+    tmp_path: Path,
+) -> None:
+    """Recheck that the pathname still identifies the descriptor after reading."""
+    environment = _environment(tmp_path)
+    original_path = tmp_path / "original.env"
+    replacement = _write_private(
+        tmp_path / "replacement.env",
+        b"X" * len(ENVIRONMENT_BYTES),
+    )
+    real_lstat = Path.lstat
+    environment_lstats = 0
+
+    def replace_before_final_lstat(selected: Path) -> os.stat_result:
+        nonlocal environment_lstats
+        if selected == environment:
+            environment_lstats += 1
+        if selected == environment and environment_lstats == 2:
+            environment.replace(original_path)
+            replacement.replace(environment)
+        return real_lstat(selected)
+
+    lstat_boundary = create_autospec(
+        Path.lstat,
+        spec_set=True,
+        side_effect=replace_before_final_lstat,
+    )
+    with (
+        patch("pathlib.Path.lstat", new=lstat_boundary),
+        pytest.raises(DeploymentStateError, match="changed while read"),
+    ):
+        state_module._read_private_file(
+            environment,
+            maximum_bytes=state_module.MAX_ENVIRONMENT_BYTES,
+        )
+    assert environment_lstats == 2
+
+
+def test_environment_hard_link_created_during_read_is_rejected(
+    tmp_path: Path,
+) -> None:
+    """Revalidate private-file link count after all bytes have been read."""
+    environment = _environment(tmp_path)
+    extra_link = tmp_path / "linked.env"
+    real_read = os.read
+    linked = False
+
+    def read_then_link(descriptor: int, length: int) -> bytes:
+        nonlocal linked
+        payload = real_read(descriptor, length)
+        if payload and not linked:
+            os.link(environment, extra_link)
+            linked = True
+        return payload
+
+    read_boundary = create_autospec(
+        os.read,
+        spec_set=True,
+        side_effect=read_then_link,
+    )
+    with (
+        patch("agent.deployment_state.os.read", new=read_boundary),
+        pytest.raises(DeploymentStateError, match="unsafe links"),
+    ):
+        state_module._read_private_file(
+            environment,
+            maximum_bytes=state_module.MAX_ENVIRONMENT_BYTES,
+        )
+    assert linked
+
+
+def test_environment_growth_beyond_bound_is_rejected(
+    tmp_path: Path,
+) -> None:
+    """Fail if a source grows after its pre-open size validation."""
+    environment = _environment(tmp_path)
+    oversized_read = create_autospec(
+        os.read,
+        spec_set=True,
+        return_value=b"x" * (state_module.MAX_ENVIRONMENT_BYTES + 1),
+    )
+
+    with (
+        patch("agent.deployment_state.os.read", new=oversized_read),
+        pytest.raises(DeploymentStateError, match="size is invalid"),
+    ):
+        state_module._read_private_file(
+            environment,
+            maximum_bytes=state_module.MAX_ENVIRONMENT_BYTES,
+        )
+
+
+def test_environment_truncation_during_read_is_rejected(
+    tmp_path: Path,
+) -> None:
+    """Fail when the payload length no longer matches its validated metadata."""
+    environment = _environment(tmp_path)
+    empty_read = create_autospec(os.read, spec_set=True, return_value=b"")
+
+    with (
+        patch("agent.deployment_state.os.read", new=empty_read),
+        pytest.raises(DeploymentStateError, match="size is invalid"),
+    ):
+        state_module._read_private_file(
+            environment,
+            maximum_bytes=state_module.MAX_ENVIRONMENT_BYTES,
+        )
+
+
+def test_successful_short_writes_publish_complete_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exercise the complete-write loop without exposing a partial pathname."""
+    real_write = os.write
+    calls = 0
+
+    def one_byte(descriptor: int, payload: bytes | memoryview) -> int:
+        nonlocal calls
+        calls += 1
+        return real_write(descriptor, bytes(payload[:1]))
+
+    monkeypatch.setattr(os, "write", one_byte)
+    store = DeploymentStateStore(tmp_path / "state")
+    current = _adopt(store, _environment(tmp_path))
+
+    assert calls > 4
+    assert store.read_current() == current
+
+
+def test_stalled_write_leaves_no_published_record(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Remove private temporary files when a write stops making progress."""
+    real_write = os.write
+    calls = 0
+
+    def partial_then_zero(descriptor: int, payload: bytes | memoryview) -> int:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return real_write(descriptor, bytes(payload[:1]))
+        return 0
+
+    monkeypatch.setattr(os, "write", partial_then_zero)
+    store = DeploymentStateStore(tmp_path / "state")
+    with (
+        store.transaction() as transaction,
+        pytest.raises(OSError, match="made no progress"),
+    ):
+        transaction.adopt(
+            compose_project="adk-template",
+            compose_service="agent",
+            source_revision=REVISION,
+            image_reference=IMAGE_REFERENCE,
+            image_id=IMAGE_ID,
+            oci_revision=OCI_REVISION,
+            environment_source=_environment(tmp_path),
+            deployment_id=DEPLOYMENT_ID,
+            recorded_at=RECORDED_AT,
+        )
+
+    assert list(store.environments_path.iterdir()) == []
+    assert list(store.journal_path.iterdir()) == []
+    assert not store.current_path.exists()
+
+
+def test_journal_publish_failure_does_not_advance_current(
+    tmp_path: Path,
+) -> None:
+    """Leave only recoverable orphan env bytes when journal durability fails."""
+    store = DeploymentStateStore(tmp_path / "state")
+    real_link = os.link
+
+    def reject_journal_link(
+        source: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        destination: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        *,
+        src_dir_fd: int | None = None,
+        dst_dir_fd: int | None = None,
+        follow_symlinks: bool = True,
+    ) -> None:
+        if str(destination).endswith(".json"):
+            raise OSError("synthetic journal link failure")
+        real_link(
+            source,
+            destination,
+            src_dir_fd=src_dir_fd,
+            dst_dir_fd=dst_dir_fd,
+            follow_symlinks=follow_symlinks,
+        )
+
+    with (
+        patch("agent.deployment_state.os.link", new=reject_journal_link),
+        store.transaction() as transaction,
+        pytest.raises(OSError, match="journal link"),
+    ):
+        transaction.adopt(
+            compose_project="adk-template",
+            compose_service="agent",
+            source_revision=REVISION,
+            image_reference=IMAGE_REFERENCE,
+            image_id=IMAGE_ID,
+            oci_revision=OCI_REVISION,
+            environment_source=_environment(tmp_path),
+            deployment_id=DEPLOYMENT_ID,
+            recorded_at=RECORDED_AT,
+        )
+
+    assert len(list(store.environments_path.iterdir())) == 1
+    assert list(store.journal_path.iterdir()) == []
+    assert not store.current_path.exists()
+
+
+def test_current_publish_failure_recovers_from_committed_journal(
+    tmp_path: Path,
+) -> None:
+    """Recover after a crash-equivalent failure between journal and pointer."""
+    store = DeploymentStateStore(tmp_path / "state")
+    real_replace = Path.replace
+
+    def reject_current(source: Path, target: Path) -> Path:
+        if target.name == "current.json":
+            raise OSError("synthetic current replace failure")
+        return real_replace(source, target)
+
+    with (
+        patch("pathlib.Path.replace", new=reject_current),
+        store.transaction() as transaction,
+        pytest.raises(OSError, match="current replace"),
+    ):
+        transaction.adopt(
+            compose_project="adk-template",
+            compose_service="agent",
+            source_revision=REVISION,
+            image_reference=IMAGE_REFERENCE,
+            image_id=IMAGE_ID,
+            oci_revision=OCI_REVISION,
+            environment_source=_environment(tmp_path),
+            deployment_id=DEPLOYMENT_ID,
+            recorded_at=RECORDED_AT,
+        )
+
+    assert _journal_path(store).exists()
+    assert not store.current_path.exists()
+    assert store.read_current() is not None
+
+
+def test_prepublication_fsync_failure_leaves_no_environment_snapshot(
+    tmp_path: Path,
+) -> None:
+    """Do not link a private temp file before its contents are synchronized."""
+    sync_failure = create_autospec(
+        os.fsync,
+        spec_set=True,
+        side_effect=OSError("synthetic file fsync failure"),
+    )
+    store = DeploymentStateStore(tmp_path / "state")
+    with store.transaction():
+        pass
+
+    with (
+        patch("agent.deployment_state.os.fsync", new=sync_failure),
+        store.transaction() as transaction,
+        pytest.raises(OSError, match="file fsync"),
+    ):
+        transaction.adopt(
+            compose_project="adk-template",
+            compose_service="agent",
+            source_revision=REVISION,
+            image_reference=IMAGE_REFERENCE,
+            image_id=IMAGE_ID,
+            oci_revision=OCI_REVISION,
+            environment_source=_environment(tmp_path),
+            deployment_id=DEPLOYMENT_ID,
+            recorded_at=RECORDED_AT,
+        )
+
+    assert list(store.environments_path.iterdir()) == []
+
+
+def test_prepublication_close_failure_leaves_no_environment_snapshot(
+    tmp_path: Path,
+) -> None:
+    """Remove the unpublished temp file when its descriptor cannot be closed."""
+    store = DeploymentStateStore(tmp_path / "state")
+    with store.transaction():
+        pass
+    close_failure = create_autospec(
+        os.close,
+        spec_set=True,
+        side_effect=OSError("synthetic file close failure"),
+    )
+
+    with (
+        store.transaction() as transaction,
+        patch("agent.deployment_state.os.close", new=close_failure),
+        pytest.raises(OSError, match="file close"),
+    ):
+        transaction.adopt(
+            compose_project="adk-template",
+            compose_service="agent",
+            source_revision=REVISION,
+            image_reference=IMAGE_REFERENCE,
+            image_id=IMAGE_ID,
+            oci_revision=OCI_REVISION,
+            environment_source=_environment(tmp_path),
+            deployment_id=DEPLOYMENT_ID,
+            recorded_at=RECORDED_AT,
+        )
+
+    assert list(store.environments_path.iterdir()) == []
+    assert list(store.journal_path.iterdir()) == []
+    assert not store.current_path.exists()
+
+
+@pytest.mark.parametrize(
+    ("failed_directory_sync", "committed_journal"),
+    [(1, False), (2, True), (3, True)],
+)
+def test_directory_fsync_failures_never_advance_beyond_journal(
+    tmp_path: Path,
+    failed_directory_sync: int,
+    committed_journal: bool,
+) -> None:
+    """Recover safely across snapshot, journal, and current directory failures."""
+    store = DeploymentStateStore(tmp_path / "state")
+    with store.transaction():
+        pass
+    real_fsync = os.fsync
+    directory_syncs = 0
+
+    def fail_selected_directory(descriptor: int) -> None:
+        nonlocal directory_syncs
+        if stat.S_ISDIR(os.fstat(descriptor).st_mode):
+            directory_syncs += 1
+            if directory_syncs == failed_directory_sync:
+                raise OSError(
+                    f"synthetic directory fsync {failed_directory_sync} failure"
+                )
+        real_fsync(descriptor)
+
+    fsync_boundary = create_autospec(
+        os.fsync,
+        spec_set=True,
+        side_effect=fail_selected_directory,
+    )
+    with (
+        patch("agent.deployment_state.os.fsync", new=fsync_boundary),
+        store.transaction() as transaction,
+        pytest.raises(
+            OSError,
+            match=f"directory fsync {failed_directory_sync}",
+        ),
+    ):
+        transaction.adopt(
+            compose_project="adk-template",
+            compose_service="agent",
+            source_revision=REVISION,
+            image_reference=IMAGE_REFERENCE,
+            image_id=IMAGE_ID,
+            oci_revision=OCI_REVISION,
+            environment_source=_environment(tmp_path),
+            deployment_id=DEPLOYMENT_ID,
+            recorded_at=RECORDED_AT,
+        )
+
+    assert directory_syncs == failed_directory_sync
+    assert _journal_path(store).exists() is committed_journal
+    if not committed_journal:
+        assert store.read_current() is None
+        assert not store.current_path.exists()
+        return
+
+    store.current_path.unlink(missing_ok=True)
+    recovered = store.read_current()
+    assert recovered is not None
+    assert recovered.journal_sequence == 1
+    assert _read_document(store.current_path) == recovered.as_document()
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        (b"", "size"),
+        (b"x" * (state_module.MAX_JSON_BYTES + 1), "size"),
+        (b"\xff", "JSON is invalid"),
+        (b"{not-json}\n", "JSON is invalid"),
+        (b"[]\n", "must be an object"),
+        (b'{"a":1,"a":2}\n', "duplicate"),
+        (b'{ "a":1 }\n', "not canonical"),
+    ],
+)
+def test_json_decoder_rejects_ambiguous_or_noncanonical_bytes(
+    payload: bytes,
+    message: str,
+) -> None:
+    """Keep hashes and schema meaning byte-for-byte deterministic."""
+    with pytest.raises(DeploymentStateError, match=message):
+        state_module._decode_json(payload)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda doc: doc.update(journal_sequence=2), "ahead"),
+        (lambda doc: doc.update(journal_sha256="0" * 64), "does not match"),
+        (lambda doc: doc.update(schema_version=2), "schema"),
+        (lambda doc: doc.update(journal_sequence=True), "sequence"),
+        (lambda doc: doc.update(journal_sha256="bad"), "journal hash"),
+    ],
+)
+def test_corrupt_current_pointer_fails_closed(
+    tmp_path: Path,
+    mutation: object,
+    message: str,
+) -> None:
+    """Reject a pointer that cannot be proven against immutable history."""
+    store = DeploymentStateStore(tmp_path / "state")
+    _adopt(store, _environment(tmp_path))
+    document = _read_document(store.current_path)
+    mutation(document)  # type: ignore[operator]
+    _write_document(store.current_path, document)
+
+    with pytest.raises(DeploymentStateError, match=message):
+        store.read_current()
+
+
+def test_current_without_journal_fails_closed(tmp_path: Path) -> None:
+    """Never treat a mutable pointer as authoritative on its own."""
+    store = DeploymentStateStore(tmp_path / "state")
+    adopted = _adopt(store, _environment(tmp_path))
+    _journal_path(store).unlink()
+
+    with pytest.raises(DeploymentStateError, match="ahead of the journal"):
+        store.read_current()
+    assert adopted.journal_sequence == 1
+
+
+def test_noncanonical_current_file_fails_closed(tmp_path: Path) -> None:
+    """Do not repair a corrupt pointer unless its prior journal identity is proven."""
+    store = DeploymentStateStore(tmp_path / "state")
+    _adopt(store, _environment(tmp_path))
+    document = _read_document(store.current_path)
+    store.current_path.write_text(
+        json.dumps(document, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    store.current_path.chmod(0o600)
+
+    with pytest.raises(DeploymentStateError, match="not canonical"):
+        store.read_current()
+
+
+def test_insecure_existing_current_file_is_not_silently_repaired(
+    tmp_path: Path,
+) -> None:
+    """Re-raise unsafe metadata when the current pathname still exists."""
+    store = DeploymentStateStore(tmp_path / "state")
+    _adopt(store, _environment(tmp_path))
+    store.current_path.chmod(0o644)
+
+    with pytest.raises(DeploymentStateError, match="unsafe permissions"):
+        store.read_current()
+
+
+def test_dangling_current_symlink_is_not_silently_repaired(tmp_path: Path) -> None:
+    """Treat a dangling pointer symlink as unsafe rather than absent."""
+    store = DeploymentStateStore(tmp_path / "state")
+    _adopt(store, _environment(tmp_path))
+    missing_target = tmp_path / "missing-current-target"
+    store.current_path.unlink()
+    store.current_path.symlink_to(missing_target)
+
+    with pytest.raises(DeploymentStateError, match="unsafe file type"):
+        store.read_current()
+    assert store.current_path.is_symlink()
+    assert not missing_target.exists()

--- a/tests/test_deployment_state_cli.py
+++ b/tests/test_deployment_state_cli.py
@@ -1,0 +1,501 @@
+"""Operator CLI tests for VM deployment state inspection and adoption."""
+
+from __future__ import annotations
+
+import errno
+import fcntl
+import json
+import runpy
+import shutil
+import subprocess
+import sys
+import tomllib
+import warnings
+from dataclasses import dataclass, field
+from pathlib import Path
+from unittest.mock import create_autospec, patch
+
+import pytest
+
+from agent.deployment_state import DeploymentStateStore
+from agent.deployment_state_cli import main
+
+ORIGIN = "https://github.com/QueryPlanner/google-adk-on-bare-metal"
+REVISION = "a" * 40
+OCI_REVISION = "b" * 40
+CONTAINER_ID = "e" * 64
+SHORT_CONTAINER_ID = CONTAINER_ID[:12]
+IMAGE_ID = f"sha256:{'c' * 64}"
+IMAGE_REFERENCE = f"ghcr.io/queryplanner/agent@sha256:{'d' * 64}"
+SECRET_BYTES = b'API_KEY="secret-cli-canary"\n'
+
+
+def _checkout(tmp_path: Path) -> tuple[Path, Path]:
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    environment = checkout / ".env"
+    environment.write_bytes(SECRET_BYTES)
+    environment.chmod(0o600)
+    return checkout.resolve(), environment
+
+
+@dataclass(slots=True)
+class CliExternalBoundary:
+    """Deterministic Git and Docker subprocess boundary for the real probe."""
+
+    checkout: Path
+    git: Path
+    docker: Path
+    container_list: str = f"{SHORT_CONTAINER_ID}\n"
+    health: str = "healthy"
+    calls: list[tuple[str, ...]] = field(default_factory=list)
+
+    def run(
+        self,
+        command: list[str],
+        *,
+        cwd: Path | None,
+        env: dict[str, str],
+        text: bool,
+        capture_output: bool,
+        check: bool,
+        timeout: int,
+    ) -> subprocess.CompletedProcess[str]:
+        """Return exact external responses without replacing application logic."""
+        assert cwd is None
+        assert text is True
+        assert capture_output is True
+        assert check is False
+        assert timeout == 30
+        assert env["GIT_OPTIONAL_LOCKS"] == "0"
+        assert env["GIT_TERMINAL_PROMPT"] == "0"
+        selected = tuple(command)
+        self.calls.append(selected)
+
+        if command[0] == str(self.git):
+            arguments = command[1:]
+            if arguments == [
+                "-C",
+                str(self.checkout),
+                "rev-parse",
+                "--show-toplevel",
+            ]:
+                return _completed(command, stdout=f"{self.checkout}\n")
+            if arguments == [
+                "-C",
+                str(self.checkout),
+                "remote",
+                "get-url",
+                "origin",
+            ]:
+                return _completed(command, stdout=f"{ORIGIN}\n")
+            if arguments in (
+                ["-C", str(self.checkout), "diff", "--quiet", "--"],
+                [
+                    "-C",
+                    str(self.checkout),
+                    "diff",
+                    "--cached",
+                    "--quiet",
+                    "--",
+                ],
+            ):
+                return _completed(command)
+            if arguments == [
+                "-C",
+                str(self.checkout),
+                "rev-parse",
+                "--verify",
+                "HEAD",
+            ]:
+                return _completed(command, stdout=f"{REVISION}\n")
+
+        if command[0] == str(self.docker):
+            arguments = command[1:]
+            if arguments[:2] == ["container", "ls"]:
+                return _completed(command, stdout=self.container_list)
+            if arguments == ["container", "inspect", SHORT_CONTAINER_ID]:
+                return _completed(
+                    command,
+                    stdout=json.dumps(
+                        [
+                            {
+                                "Id": CONTAINER_ID,
+                                "Image": IMAGE_ID,
+                                "State": {
+                                    "Status": "running",
+                                    "Health": {"Status": self.health},
+                                },
+                                "Config": {
+                                    "Image": IMAGE_REFERENCE,
+                                    "Labels": {
+                                        "com.docker.compose.project": ("adk-template"),
+                                        "com.docker.compose.service": "agent",
+                                        "com.docker.compose.project.working_dir": (
+                                            str(self.checkout)
+                                        ),
+                                    },
+                                },
+                            }
+                        ]
+                    ),
+                )
+            if arguments == ["image", "inspect", IMAGE_ID]:
+                return _completed(
+                    command,
+                    stdout=json.dumps(
+                        [
+                            {
+                                "Id": IMAGE_ID,
+                                "RepoDigests": [IMAGE_REFERENCE],
+                                "Config": {
+                                    "Labels": {
+                                        "org.opencontainers.image.revision": (
+                                            OCI_REVISION
+                                        )
+                                    }
+                                },
+                            }
+                        ]
+                    ),
+                )
+
+        return _completed(command, returncode=99, stderr="unexpected command")
+
+
+def _completed(
+    command: list[str],
+    *,
+    stdout: str = "",
+    returncode: int = 0,
+    stderr: str = "",
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        command,
+        returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def _adopt_arguments(
+    state_dir: Path,
+    checkout: Path,
+    *,
+    environment_file: Path | None = None,
+) -> list[str]:
+    arguments = [
+        "adopt",
+        "--state-dir",
+        str(state_dir),
+        "--checkout",
+        str(checkout),
+        "--expected-origin",
+        ORIGIN,
+        "--compose-project",
+        "adk-template",
+    ]
+    if environment_file is not None:
+        arguments.extend(["--environment-file", str(environment_file)])
+    return arguments
+
+
+def _external_boundary(
+    tmp_path: Path,
+    checkout: Path,
+) -> CliExternalBoundary:
+    bin_directory = tmp_path / "bin"
+    bin_directory.mkdir()
+    git = bin_directory / "git"
+    docker = bin_directory / "docker"
+    for executable in (git, docker):
+        executable.write_text("#!/bin/sh\nexit 99\n", encoding="utf-8")
+        executable.chmod(0o755)
+    return CliExternalBoundary(
+        checkout=checkout,
+        git=git.resolve(),
+        docker=docker.resolve(),
+    )
+
+
+def _resolved_which_mock(boundary: CliExternalBoundary) -> object:
+    def selected(name: str) -> str:
+        assert name in {"git", "docker"}
+        return str(boundary.git if name == "git" else boundary.docker)
+
+    return create_autospec(
+        shutil.which,
+        spec_set=True,
+        side_effect=selected,
+    )
+
+
+def _run_adoption(
+    arguments: list[str],
+    boundary: CliExternalBoundary,
+) -> int:
+    run = create_autospec(
+        subprocess.run,
+        spec_set=True,
+        side_effect=boundary.run,
+    )
+    with (
+        patch("agent.deployment_adoption.subprocess.run", new=run),
+        patch(
+            "agent.deployment_state_cli.shutil.which",
+            new=_resolved_which_mock(boundary),
+        ),
+    ):
+        return main(arguments)
+
+
+def test_inspect_empty_state_is_secret_free_json(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Create and verify an empty private store without claiming rollback state."""
+    state_dir = tmp_path / "state"
+
+    assert main(["inspect", "--state-dir", str(state_dir)]) == 0
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == {
+        "status": "empty",
+        "current": None,
+        "journal": [],
+    }
+    assert captured.err == ""
+    assert stat_mode(state_dir) == 0o700
+
+
+def stat_mode(path: Path) -> int:
+    """Return only portable permission bits for one test path."""
+    return path.stat().st_mode & 0o777
+
+
+def test_adopt_then_inspect_exact_state(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Combine the observation and durable state APIs through the real CLI."""
+    checkout, environment = _checkout(tmp_path)
+    state_dir = tmp_path / "state"
+    boundary = _external_boundary(tmp_path, checkout)
+
+    assert _run_adoption(_adopt_arguments(state_dir, checkout), boundary) == 0
+
+    adopted_output = capsys.readouterr()
+    adopted = json.loads(adopted_output.out)
+    assert adopted["status"] == "adopted"
+    assert adopted["current"]["state"]["image_reference"] == IMAGE_REFERENCE
+    assert "secret-cli-canary" not in adopted_output.out
+    assert any(call[0] == str(boundary.git) for call in boundary.calls)
+    assert any(call[0] == str(boundary.docker) for call in boundary.calls)
+    snapshot = state_dir / adopted["current"]["state"]["environment_snapshot"]
+    assert snapshot.read_bytes() == environment.read_bytes()
+
+    assert main(["inspect", "--state-dir", str(state_dir)]) == 0
+    inspected_output = capsys.readouterr()
+    inspected = json.loads(inspected_output.out)
+    assert inspected["status"] == "recorded"
+    assert inspected["current"] == adopted["current"]
+    assert len(inspected["journal"]) == 1
+    assert inspected["journal"][0]["sha256"] == adopted["current"]["journal_sha256"]
+    assert "secret-cli-canary" not in inspected_output.out
+
+
+def test_explicit_environment_file_is_forwarded(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Allow an explicit absolute path while the probe enforces checkout .env."""
+    checkout, environment = _checkout(tmp_path)
+    boundary = _external_boundary(tmp_path, checkout)
+    state_dir = tmp_path / "state"
+
+    assert (
+        _run_adoption(
+            _adopt_arguments(
+                state_dir,
+                checkout,
+                environment_file=environment,
+            ),
+            boundary,
+        )
+        == 0
+    )
+
+    adopted = json.loads(capsys.readouterr().out)
+    snapshot = state_dir / adopted["current"]["state"]["environment_snapshot"]
+    assert snapshot.read_bytes() == environment.read_bytes()
+
+
+def test_zero_container_observation_records_nothing(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Report a fresh install without manufacturing a rollback target."""
+    checkout, _ = _checkout(tmp_path)
+    state_dir = tmp_path / "state"
+    boundary = _external_boundary(tmp_path, checkout)
+    boundary.container_list = ""
+
+    assert _run_adoption(_adopt_arguments(state_dir, checkout), boundary) == 0
+
+    assert json.loads(capsys.readouterr().out) == {
+        "status": "fresh",
+        "current": None,
+        "journal": [],
+    }
+    assert DeploymentStateStore(state_dir).read_current() is None
+    assert DeploymentStateStore(state_dir).read_journal() == ()
+
+
+def test_existing_state_fails_before_reobservation(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Never reinterpret or overwrite an initialized recovery boundary."""
+    checkout, _ = _checkout(tmp_path)
+    state_dir = tmp_path / "state"
+    boundary = _external_boundary(tmp_path, checkout)
+    assert _run_adoption(_adopt_arguments(state_dir, checkout), boundary) == 0
+    capsys.readouterr()
+
+    forbidden_which = create_autospec(
+        shutil.which,
+        spec_set=True,
+        side_effect=AssertionError("external observation should not run"),
+    )
+    with patch(
+        "agent.deployment_state_cli.shutil.which",
+        new=forbidden_which,
+    ):
+        assert main(_adopt_arguments(state_dir, checkout)) == 1
+
+    captured = capsys.readouterr()
+    assert "already been initialized" in captured.err
+    assert captured.out == ""
+    forbidden_which.assert_not_called()
+
+
+def test_missing_executable_returns_safe_error(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Fail before observation when the fixed Git/Docker boundary is absent."""
+    checkout, _ = _checkout(tmp_path)
+    which = create_autospec(shutil.which, spec_set=True, return_value=None)
+
+    with patch("agent.deployment_state_cli.shutil.which", new=which):
+        assert main(_adopt_arguments(tmp_path / "state", checkout)) == 1
+
+    captured = capsys.readouterr()
+    assert "executable is unavailable" in captured.err
+    assert captured.out == ""
+
+
+def test_observation_contract_error_returns_one(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Surface the probe's deterministic safe reason without a traceback."""
+    checkout, _ = _checkout(tmp_path)
+    boundary = _external_boundary(tmp_path, checkout)
+    boundary.health = "unhealthy"
+
+    assert _run_adoption(_adopt_arguments(tmp_path / "state", checkout), boundary) == 1
+
+    captured = capsys.readouterr()
+    assert captured.err == "ERROR: legacy container is not healthy\n"
+    assert captured.out == ""
+
+
+def test_unexpected_os_error_is_redacted(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Do not expose filesystem or external process details from the CLI."""
+    checkout, _ = _checkout(tmp_path)
+    missing = create_autospec(
+        shutil.which,
+        spec_set=True,
+        return_value="/missing/secret-os-detail",
+    )
+
+    with patch("agent.deployment_state_cli.shutil.which", new=missing):
+        assert main(_adopt_arguments(tmp_path / "state", checkout)) == 1
+
+    captured = capsys.readouterr()
+    assert captured.err == "ERROR: deployment state operation failed\n"
+    assert "secret-os-detail" not in captured.err
+
+
+def test_lock_contention_returns_temporary_failure(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Give automation a distinct retryable exit status for lock contention."""
+    lock_failure = create_autospec(
+        fcntl.flock,
+        spec_set=True,
+        side_effect=OSError(errno.EAGAIN, "busy"),
+    )
+
+    with patch("agent.deployment_state.fcntl.flock", new=lock_failure):
+        assert main(["inspect", "--state-dir", str(tmp_path / "state")]) == 75
+
+    captured = capsys.readouterr()
+    assert "another deployment transaction" in captured.err
+    assert captured.out == ""
+
+
+def test_usage_error_is_distinct(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Let argparse return its conventional usage status before touching state."""
+    with pytest.raises(SystemExit) as error:
+        main(["unknown"])
+
+    assert error.value.code == 2
+    captured = capsys.readouterr()
+    assert "usage:" in captured.err
+
+
+def test_module_entrypoint_exits_with_main_status(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Keep `python -m agent.deployment_state_cli` executable."""
+    with (
+        patch.object(
+            sys,
+            "argv",
+            [
+                "deployment-state",
+                "inspect",
+                "--state-dir",
+                str(tmp_path / "state"),
+            ],
+        ),
+        warnings.catch_warnings(),
+        pytest.raises(SystemExit) as error,
+    ):
+        warnings.simplefilter("ignore", RuntimeWarning)
+        runpy.run_module("agent.deployment_state_cli", run_name="__main__")
+
+    assert error.value.code == 0
+    assert json.loads(capsys.readouterr().out)["status"] == "empty"
+
+
+def test_project_registers_operator_cli() -> None:
+    """Expose the reviewed module through the installed project command."""
+    pyproject = tomllib.loads(
+        (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert pyproject["project"]["scripts"]["deployment-state"] == (
+        "agent.deployment_state_cli:main"
+    )

--- a/tests/test_deployment_state_runtime.py
+++ b/tests/test_deployment_state_runtime.py
@@ -1,0 +1,1215 @@
+"""Opt-in real-Docker proof for legacy VM deployment-state adoption."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import time
+import uuid
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from unittest.mock import create_autospec, patch
+from urllib.error import URLError
+from urllib.request import ProxyHandler, build_opener
+
+import pytest
+
+from agent.compose_env import write_compose_environment
+from agent.deployment_state import DeploymentStateStore
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+CANDIDATE_COMPOSE_PATH = REPOSITORY_ROOT / "compose.candidate.yaml"
+RUN_ENVIRONMENT_NAME = "RUN_DEPLOYMENT_STATE_INTEGRATION"
+PREFIX_ENVIRONMENT_NAME = "DEPLOYMENT_STATE_TEST_PREFIX"
+PREFIX_PATTERN = re.compile(r"adk-state-[a-z0-9][a-z0-9-]{0,31}\Z")
+IMAGE_ID_PATTERN = re.compile(r"sha256:[0-9a-f]{64}\Z")
+IMAGE_REFERENCE_PATTERN = re.compile(
+    r"127\.0\.0\.1:[0-9]+/[a-z0-9-]+/agent@sha256:[0-9a-f]{64}\Z"
+)
+PRIVATE_CANARY = 'state-secret-$-हॅलो-"-\\-canary'
+EXPECTED_ORIGIN = "https://github.com/QueryPlanner/google-adk-on-bare-metal"
+REGISTRY_IMAGE_REFERENCE = (
+    "registry@sha256:1be55279f18a2fe1a74edf2664cac61c1bea305b7b4642dab412e7affdcb3e33"
+)
+ALLOWED_ENVIRONMENT = (
+    "AGENT_NAME",
+    "ROOT_AGENT_MODEL",
+    "LOG_LEVEL",
+    "TELEMETRY_NAMESPACE",
+    "K_REVISION",
+    "CANDIDATE_ENV_CANARY",
+)
+
+
+def _redact(value: str) -> str:
+    redacted = value
+    for candidate in (
+        PRIVATE_CANARY,
+        PRIVATE_CANARY.replace("$", "$$"),
+        json.dumps(PRIVATE_CANARY, ensure_ascii=False)[1:-1],
+        json.dumps(PRIVATE_CANARY, ensure_ascii=True)[1:-1],
+        repr(PRIVATE_CANARY),
+        repr(PRIVATE_CANARY.encode()),
+    ):
+        redacted = redacted.replace(candidate, "[REDACTED]")
+    return redacted
+
+
+def _run(
+    command: Sequence[str],
+    *,
+    environment: Mapping[str, str],
+    cwd: Path = REPOSITORY_ROOT,
+    check: bool = True,
+    timeout: float = 180,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        result = subprocess.run(  # noqa: S603 - resolved/fixed test executables
+            list(command),
+            cwd=cwd,
+            env=environment,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as error:
+        stdout = _redact(str(error.stdout or "")[-4_000:])
+        stderr = _redact(str(error.stderr or "")[-4_000:])
+        raise AssertionError(
+            f"{' '.join(command[:3])} exceeded {timeout:g} seconds\n"
+            f"stdout:\n{stdout}\nstderr:\n{stderr}"
+        ) from None
+    if check and result.returncode != 0:
+        stdout = _redact(result.stdout[-4_000:])
+        stderr = _redact(result.stderr[-4_000:])
+        raise AssertionError(
+            f"{' '.join(command[:3])} failed with {result.returncode}\n"
+            f"stdout:\n{stdout}\nstderr:\n{stderr}"
+        )
+    return result
+
+
+def _owned_mutation[MutationResult](
+    cleanup_commands: list[list[str]],
+    cleanup_command: Sequence[str],
+    operation: Callable[[], MutationResult],
+) -> MutationResult:
+    cleanup_commands.append(list(cleanup_command))
+    return operation()
+
+
+def _execute_exact_cleanup(
+    cleanup_commands: Sequence[Sequence[str]],
+    environment: Mapping[str, str],
+) -> list[str]:
+    failures: list[str] = []
+    for command in reversed(cleanup_commands):
+        try:
+            result = _run(
+                command,
+                environment=environment,
+                check=False,
+                timeout=60,
+            )
+        except (AssertionError, OSError) as error:
+            failures.append(_redact(str(error)[-1_000:]))
+            continue
+        if result.returncode != 0 and "No such" not in result.stderr:
+            failures.append(_redact(result.stderr[-1_000:]))
+    return failures
+
+
+def _capture_cleanup_operation(
+    operation: Callable[[], subprocess.CompletedProcess[str]],
+) -> list[str]:
+    try:
+        result = operation()
+    except (AssertionError, OSError) as error:
+        return [_redact(str(error)[-1_000:])]
+    if result.returncode != 0:
+        return [_redact(result.stderr[-1_000:])]
+    return []
+
+
+def _report_cleanup_failures(
+    failures: Sequence[str],
+    primary_error: BaseException | None,
+) -> None:
+    if not failures:
+        return
+    cleanup_message = "deployment-state cleanup failed: " + " | ".join(failures)
+    if primary_error is None:
+        raise AssertionError(cleanup_message)
+    primary_error.add_note(cleanup_message)
+
+
+def _base_environment() -> dict[str, str]:
+    environment = {
+        key: value
+        for key, value in os.environ.items()
+        if key not in {"COMPOSE_FILE", "COMPOSE_PROJECT_NAME", "ENV_FILE", "IMAGE"}
+    }
+    environment.update(
+        {
+            "COMPOSE_DISABLE_ENV_FILE": "1",
+            "LANG": "C.UTF-8",
+        }
+    )
+    return environment
+
+
+def _require_docker(environment: Mapping[str, str]) -> tuple[str, str]:
+    docker = shutil.which("docker")
+    git = shutil.which("git")
+    if docker is None or git is None:
+        raise AssertionError("Docker and Git executables are required")
+    _run([docker, "version"], environment=environment, timeout=30)
+    _run([docker, "compose", "version"], environment=environment, timeout=30)
+    return docker, git
+
+
+def _resource_prefix() -> str:
+    configured = os.environ.get(PREFIX_ENVIRONMENT_NAME, f"adk-state-{os.getpid()}")
+    normalized = configured.lower()
+    if PREFIX_PATTERN.fullmatch(normalized) is None:
+        raise AssertionError("deployment-state Docker prefix is invalid")
+    return f"{normalized}-{uuid.uuid4().hex[:8]}"
+
+
+def _git(
+    git: str,
+    environment: Mapping[str, str],
+    *arguments: str,
+    cwd: Path,
+) -> str:
+    return _run(
+        [git, *arguments],
+        environment=environment,
+        cwd=cwd,
+        timeout=30,
+    ).stdout.strip()
+
+
+def _initialize_checkout(
+    git: str,
+    environment: Mapping[str, str],
+    project_directory: Path,
+) -> str:
+    project_directory.mkdir(mode=0o700)
+    shutil.copy2(CANDIDATE_COMPOSE_PATH, project_directory / "compose.candidate.yaml")
+    (project_directory / ".gitignore").write_text(".env\n", encoding="utf-8")
+    _git(git, environment, "init", cwd=project_directory)
+    _git(
+        git,
+        environment,
+        "config",
+        "user.email",
+        "runtime@example.invalid",
+        cwd=project_directory,
+    )
+    _git(
+        git,
+        environment,
+        "config",
+        "user.name",
+        "Runtime Contract",
+        cwd=project_directory,
+    )
+    _git(
+        git,
+        environment,
+        "remote",
+        "add",
+        "origin",
+        EXPECTED_ORIGIN,
+        cwd=project_directory,
+    )
+    _git(
+        git,
+        environment,
+        "add",
+        ".gitignore",
+        "compose.candidate.yaml",
+        cwd=project_directory,
+    )
+    _git(
+        git,
+        environment,
+        "commit",
+        "-m",
+        "runtime fixture",
+        cwd=project_directory,
+    )
+    revision = _git(git, environment, "rev-parse", "HEAD", cwd=project_directory)
+    assert re.fullmatch(r"[0-9a-f]{40}", revision)
+    return revision
+
+
+def _build_image(
+    docker: str,
+    environment: Mapping[str, str],
+    *,
+    tag: str,
+    revision: str,
+    iid_file: Path,
+) -> str:
+    _run(
+        [
+            docker,
+            "build",
+            "--iidfile",
+            str(iid_file),
+            "--tag",
+            tag,
+            "--label",
+            f"org.opencontainers.image.revision={revision}",
+            str(REPOSITORY_ROOT),
+        ],
+        environment=environment,
+        timeout=600,
+    )
+    image_id = iid_file.read_text(encoding="ascii").strip()
+    assert IMAGE_ID_PATTERN.fullmatch(image_id)
+    inspected = _run(
+        [docker, "image", "inspect", "--format", "{{.Id}}", tag],
+        environment=environment,
+        timeout=30,
+    ).stdout.strip()
+    assert inspected == image_id
+    return image_id
+
+
+def _ensure_registry_image(
+    docker: str,
+    environment: Mapping[str, str],
+    cleanup_commands: list[list[str]],
+) -> str:
+    existing = _run(
+        [
+            docker,
+            "image",
+            "inspect",
+            "--format",
+            "{{.Id}}",
+            REGISTRY_IMAGE_REFERENCE,
+        ],
+        environment=environment,
+        check=False,
+        timeout=30,
+    )
+    created = existing.returncode != 0
+    if created:
+
+        def pull_and_inspect() -> str:
+            _run(
+                [docker, "image", "pull", REGISTRY_IMAGE_REFERENCE],
+                environment=environment,
+                timeout=180,
+            )
+            return _image_identity(
+                docker,
+                environment,
+                REGISTRY_IMAGE_REFERENCE,
+            )
+
+        image_id = _owned_mutation(
+            cleanup_commands,
+            [docker, "image", "rm", REGISTRY_IMAGE_REFERENCE],
+            pull_and_inspect,
+        )
+    else:
+        image_id = existing.stdout.strip()
+    assert IMAGE_ID_PATTERN.fullmatch(image_id)
+    return image_id
+
+
+def _create_registry(
+    docker: str,
+    environment: Mapping[str, str],
+    *,
+    name: str,
+    image_id: str,
+) -> None:
+    _run(
+        [
+            docker,
+            "container",
+            "create",
+            "--name",
+            name,
+            "--publish",
+            "127.0.0.1::5000",
+            "--env",
+            "OTEL_TRACES_EXPORTER=none",
+            image_id,
+        ],
+        environment=environment,
+        timeout=30,
+    )
+
+
+def _start_registry(
+    docker: str,
+    environment: Mapping[str, str],
+    *,
+    name: str,
+) -> str:
+    _run(
+        [docker, "container", "start", name],
+        environment=environment,
+        timeout=30,
+    )
+    published = _run(
+        [docker, "container", "port", name, "5000/tcp"],
+        environment=environment,
+        timeout=30,
+    ).stdout.strip()
+    match = re.fullmatch(r"127\.0\.0\.1:([0-9]+)", published)
+    assert match is not None
+    endpoint = f"127.0.0.1:{match.group(1)}"
+    opener = build_opener(ProxyHandler({}))
+    deadline = time.monotonic() + 30
+    while True:
+        try:
+            with opener.open(f"http://{endpoint}/v2/", timeout=1) as response:
+                if response.status == 200:
+                    return endpoint
+        except (OSError, URLError):
+            pass
+        if time.monotonic() >= deadline:
+            raise AssertionError("local registry did not become ready")
+        time.sleep(0.2)
+
+
+def _push_exact_image(
+    docker: str,
+    environment: Mapping[str, str],
+    *,
+    source_image_id: str,
+    repository_tag: str,
+) -> str:
+    _run(
+        [docker, "image", "tag", source_image_id, repository_tag],
+        environment=environment,
+        timeout=30,
+    )
+    _run(
+        [docker, "image", "push", repository_tag],
+        environment=environment,
+        timeout=180,
+    )
+    repo_digests = json.loads(
+        _run(
+            [
+                docker,
+                "image",
+                "inspect",
+                "--format",
+                "{{json .RepoDigests}}",
+                repository_tag,
+            ],
+            environment=environment,
+            timeout=30,
+        ).stdout
+    )
+    assert isinstance(repo_digests, list)
+    exact = [
+        value
+        for value in repo_digests
+        if isinstance(value, str)
+        and value.startswith(f"{repository_tag.rsplit(':', 1)[0]}@sha256:")
+    ]
+    assert len(exact) == 1
+    assert IMAGE_REFERENCE_PATTERN.fullmatch(exact[0])
+    return exact[0]
+
+
+def _write_environment(path: Path, revision: str) -> None:
+    values = {
+        "AGENT_NAME": "deployment-state-runtime",
+        "ROOT_AGENT_MODEL": "openrouter/openai/gpt-4.1-mini",
+        "LOG_LEVEL": "INFO",
+        "TELEMETRY_NAMESPACE": "deployment-state-runtime",
+        "K_REVISION": revision,
+        "CANDIDATE_ENV_CANARY": PRIVATE_CANARY,
+    }
+    write_compose_environment(path, ALLOWED_ENVIRONMENT, values)
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def _compose(
+    docker: str,
+    environment: Mapping[str, str],
+    *,
+    project_directory: Path,
+    project: str,
+    env_file: Path,
+    image_reference: str,
+    arguments: Sequence[str],
+    check: bool = True,
+    timeout: float = 180,
+) -> subprocess.CompletedProcess[str]:
+    if not project.startswith("adk-state-"):
+        raise AssertionError("refusing an unowned Compose project")
+    selected_environment = dict(environment)
+    selected_environment.update(
+        {
+            "ENV_FILE": str(env_file),
+            "IMAGE": image_reference,
+        }
+    )
+    return _run(
+        [
+            docker,
+            "compose",
+            "--project-name",
+            project,
+            "--env-file",
+            str(env_file),
+            "-f",
+            str(project_directory / "compose.candidate.yaml"),
+            *arguments,
+        ],
+        environment=selected_environment,
+        cwd=project_directory,
+        check=check,
+        timeout=timeout,
+    )
+
+
+def _cli(
+    environment: Mapping[str, str],
+    *arguments: str,
+    cwd: Path = REPOSITORY_ROOT,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    return _run(
+        [sys.executable, "-m", "agent.deployment_state_cli", *arguments],
+        environment=environment,
+        cwd=cwd,
+        check=check,
+        timeout=60,
+    )
+
+
+def _container_identity(
+    docker: str,
+    environment: Mapping[str, str],
+    name: str,
+) -> tuple[str, str]:
+    document = json.loads(
+        _run(
+            [docker, "container", "inspect", name],
+            environment=environment,
+            timeout=30,
+        ).stdout
+    )
+    assert isinstance(document, list) and len(document) == 1
+    return document[0]["Id"], document[0]["State"]["Status"]
+
+
+def _volume_identity(
+    docker: str,
+    environment: Mapping[str, str],
+    name: str,
+) -> tuple[str, str, str]:
+    document = json.loads(
+        _run(
+            [docker, "volume", "inspect", name],
+            environment=environment,
+            timeout=30,
+        ).stdout
+    )
+    assert isinstance(document, list) and len(document) == 1
+    return (
+        document[0]["Name"],
+        document[0]["Mountpoint"],
+        document[0]["CreatedAt"],
+    )
+
+
+def _docker_names(
+    docker: str,
+    environment: Mapping[str, str],
+    resource: str,
+) -> frozenset[str]:
+    result = _run(
+        [docker, resource, "ls", "--format", "{{.Name}}"],
+        environment=environment,
+        timeout=30,
+    )
+    return frozenset(line for line in result.stdout.splitlines() if line)
+
+
+def _image_identity(
+    docker: str,
+    environment: Mapping[str, str],
+    reference: str,
+) -> str:
+    identity = _run(
+        [docker, "image", "inspect", "--format", "{{.Id}}", reference],
+        environment=environment,
+        timeout=30,
+    ).stdout.strip()
+    assert IMAGE_ID_PATTERN.fullmatch(identity)
+    return identity
+
+
+def _compose_container_id(
+    docker: str,
+    environment: Mapping[str, str],
+    *,
+    project: str,
+) -> str:
+    result = _run(
+        [
+            docker,
+            "container",
+            "ls",
+            "--all",
+            "--filter",
+            f"label=com.docker.compose.project={project}",
+            "--filter",
+            "label=com.docker.compose.service=agent",
+            "--format",
+            "{{.ID}}",
+        ],
+        environment=environment,
+        timeout=30,
+    )
+    identities = result.stdout.splitlines()
+    assert len(identities) == 1
+    assert re.fullmatch(r"[0-9a-f]{12,64}", identities[0])
+    return identities[0]
+
+
+def _assert_container_name_is_unused(
+    docker: str,
+    environment: Mapping[str, str],
+    name: str,
+) -> None:
+    result = _run(
+        [
+            docker,
+            "container",
+            "ls",
+            "--all",
+            "--filter",
+            f"name=^/{name}$",
+            "--format",
+            "{{.ID}}",
+        ],
+        environment=environment,
+        timeout=30,
+    )
+    assert result.stdout.strip() == ""
+
+
+def test_runtime_prefix_rejects_unsafe_external_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prevent a CI input from broadening Docker cleanup ownership."""
+    monkeypatch.setenv(PREFIX_ENVIRONMENT_NAME, "../foreign")
+    with pytest.raises(AssertionError, match="prefix is invalid"):
+        _resource_prefix()
+
+
+def test_compose_guard_rejects_unowned_project(tmp_path: Path) -> None:
+    """Refuse cleanup or startup outside the unique test namespace."""
+    with pytest.raises(AssertionError, match="unowned"):
+        _compose(
+            "/usr/bin/docker",
+            {},
+            project_directory=tmp_path,
+            project="production",
+            env_file=tmp_path / ".env",
+            image_reference=IMAGE_REFERENCE_PATTERN.pattern,
+            arguments=("down",),
+        )
+
+
+def test_runtime_runner_redacts_timeout_bytes() -> None:
+    """Never expose the canary through a timed-out subprocess diagnostic."""
+    timeout = subprocess.TimeoutExpired(
+        ["docker", "compose", "up"],
+        1,
+        output=PRIVATE_CANARY.encode(),
+        stderr=PRIVATE_CANARY.encode(),
+    )
+    runner = create_autospec(
+        subprocess.run,
+        spec_set=True,
+        side_effect=timeout,
+    )
+    with (
+        patch.object(subprocess, "run", runner),
+        pytest.raises(AssertionError) as error,
+    ):
+        _run(["docker", "compose", "up"], environment={}, timeout=1)
+    assert PRIVATE_CANARY not in str(error.value)
+
+
+def test_owned_mutation_arms_exact_cleanup_before_timeout() -> None:
+    """Register recoverable cleanup before an external mutation can half-succeed."""
+    cleanup_commands: list[list[str]] = []
+    cleanup_command = ["docker", "container", "rm", "owned-resource"]
+
+    def time_out_after_daemon_acceptance() -> None:
+        assert cleanup_commands == [cleanup_command]
+        raise subprocess.TimeoutExpired(["docker", "container", "create"], 1)
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        _owned_mutation(
+            cleanup_commands,
+            cleanup_command,
+            time_out_after_daemon_acceptance,
+        )
+
+    assert cleanup_commands == [cleanup_command]
+
+
+def test_exact_cleanup_reverses_order_ignores_absence_and_redacts() -> None:
+    """Clean only registered resources without leaking failed-command output."""
+    first = ["docker", "image", "rm", "first"]
+    second = ["docker", "container", "rm", "second"]
+    third = ["docker", "volume", "rm", "third"]
+    runner = create_autospec(
+        subprocess.run,
+        spec_set=True,
+        side_effect=[
+            subprocess.TimeoutExpired(
+                third,
+                1,
+                output=PRIVATE_CANARY.encode(),
+                stderr=PRIVATE_CANARY.encode(),
+            ),
+            subprocess.CompletedProcess(
+                second,
+                1,
+                stdout="",
+                stderr="No such container",
+            ),
+            subprocess.CompletedProcess(
+                first,
+                29,
+                stdout="",
+                stderr=PRIVATE_CANARY,
+            ),
+        ],
+    )
+
+    with patch.object(subprocess, "run", runner):
+        failures = _execute_exact_cleanup([first, second, third], {})
+
+    assert [selected.args[0] for selected in runner.call_args_list] == [
+        third,
+        second,
+        first,
+    ]
+    assert len(failures) == 2
+    assert all(PRIVATE_CANARY not in failure for failure in failures)
+    assert all("[REDACTED]" in failure for failure in failures)
+
+
+def test_compose_timeout_continues_exact_cleanup_and_preserves_primary() -> None:
+    """Preserve the test failure while every registered cleanup still runs."""
+    first = ["docker", "image", "rm", "first"]
+    second = ["docker", "container", "rm", "second"]
+    compose = ["docker", "compose", "down"]
+    runner = create_autospec(
+        subprocess.run,
+        spec_set=True,
+        side_effect=[
+            subprocess.TimeoutExpired(
+                compose,
+                1,
+                output=PRIVATE_CANARY.encode(),
+                stderr=PRIVATE_CANARY.encode(),
+            ),
+            subprocess.CompletedProcess(second, 0, stdout="", stderr=""),
+            subprocess.CompletedProcess(first, 0, stdout="", stderr=""),
+        ],
+    )
+    primary_error = RuntimeError("primary integration failure")
+
+    with patch.object(subprocess, "run", runner):
+        cleanup_failures = _capture_cleanup_operation(
+            lambda: _run(compose, environment={}, check=False, timeout=1)
+        )
+        cleanup_failures.extend(_execute_exact_cleanup([first, second], {}))
+        _report_cleanup_failures(cleanup_failures, primary_error)
+
+    assert [selected.args[0] for selected in runner.call_args_list] == [
+        compose,
+        second,
+        first,
+    ]
+    assert str(primary_error) == "primary integration failure"
+    assert len(primary_error.__notes__) == 1
+    assert "deployment-state cleanup failed" in primary_error.__notes__[0]
+    assert PRIVATE_CANARY not in primary_error.__notes__[0]
+    assert "[REDACTED]" in primary_error.__notes__[0]
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        pytest.param(
+            lambda: (_ for _ in ()).throw(OSError(PRIVATE_CANARY)),
+            id="operating-system-error",
+        ),
+        pytest.param(
+            lambda: subprocess.CompletedProcess(
+                ["docker", "compose", "down"],
+                1,
+                stdout="",
+                stderr=PRIVATE_CANARY,
+            ),
+            id="nonzero-result",
+        ),
+    ],
+)
+def test_compose_cleanup_failures_are_redacted(
+    operation: Callable[[], subprocess.CompletedProcess[str]],
+) -> None:
+    """Capture all expected teardown failures without exposing environment data."""
+    failures = _capture_cleanup_operation(operation)
+
+    assert len(failures) == 1
+    assert PRIVATE_CANARY not in failures[0]
+    assert "[REDACTED]" in failures[0]
+
+
+def test_cleanup_failure_without_primary_error_fails_the_proof() -> None:
+    """Fail the integration proof when teardown alone is unsuccessful."""
+    with pytest.raises(AssertionError, match="deployment-state cleanup failed"):
+        _report_cleanup_failures(["compose teardown failed"], None)
+
+
+@pytest.mark.skipif(
+    os.environ.get(RUN_ENVIRONMENT_NAME) != "1",
+    reason="real deployment-state Docker proof is opt-in",
+)
+def test_real_docker_adopts_exact_healthy_compose_state(tmp_path: Path) -> None:
+    """Prove real Git/Docker adoption, locking, durability, and non-mutation."""
+    environment = _base_environment()
+    docker, git = _require_docker(environment)
+    prefix = _resource_prefix()
+    registry_name = f"{prefix}-registry"
+    compose_project = f"{prefix}-legacy"
+    zero_project = f"{prefix}-zero"
+    source_tag = f"{prefix}-source:runtime"
+    repository_name = f"{prefix}/agent"
+    sentinel_image = f"{prefix}-sentinel-image:keep"
+    sentinel_container = f"{prefix}-sentinel-container"
+    sentinel_volume = f"{prefix}-sentinel-volume"
+    sentinel_network = f"{prefix}-sentinel-network"
+    project_directory = tmp_path / "legacy-checkout"
+    state_directory = tmp_path / "deployment-state"
+    zero_state_directory = tmp_path / "zero-state"
+    env_file = project_directory / ".env"
+    baseline_volumes = _docker_names(docker, environment, "volume")
+
+    cleanup_commands: list[list[str]] = []
+    compose_cleanup_required = False
+    exact_reference: str | None = None
+    primary_error: BaseException | None = None
+    try:
+        revision = _initialize_checkout(
+            git,
+            environment,
+            project_directory,
+        )
+        image_id = _owned_mutation(
+            cleanup_commands,
+            [docker, "image", "rm", source_tag],
+            lambda: _build_image(
+                docker,
+                environment,
+                tag=source_tag,
+                revision=revision,
+                iid_file=tmp_path / "source.iid",
+            ),
+        )
+        registry_image_id = _ensure_registry_image(
+            docker,
+            environment,
+            cleanup_commands,
+        )
+        _assert_container_name_is_unused(
+            docker,
+            environment,
+            registry_name,
+        )
+        _owned_mutation(
+            cleanup_commands,
+            [
+                docker,
+                "container",
+                "rm",
+                "--force",
+                "--volumes",
+                registry_name,
+            ],
+            lambda: _create_registry(
+                docker,
+                environment,
+                name=registry_name,
+                image_id=registry_image_id,
+            ),
+        )
+        endpoint = _start_registry(
+            docker,
+            environment,
+            name=registry_name,
+        )
+        _owned_mutation(
+            cleanup_commands,
+            [docker, "image", "rm", sentinel_image],
+            lambda: _run(
+                [docker, "image", "tag", registry_image_id, sentinel_image],
+                environment=environment,
+                timeout=30,
+            ),
+        )
+        sentinel_image_identity = _image_identity(
+            docker,
+            environment,
+            sentinel_image,
+        )
+
+        repository_tag = f"{endpoint}/{repository_name}:runtime"
+        exact_reference = _owned_mutation(
+            cleanup_commands,
+            [docker, "image", "rm", repository_tag],
+            lambda: _push_exact_image(
+                docker,
+                environment,
+                source_image_id=image_id,
+                repository_tag=repository_tag,
+            ),
+        )
+        cleanup_commands.append([docker, "image", "rm", exact_reference])
+        _write_environment(env_file, revision)
+        environment_before = env_file.read_bytes()
+        environment_metadata_before = (
+            env_file.stat().st_dev,
+            env_file.stat().st_ino,
+            env_file.stat().st_size,
+            env_file.stat().st_mtime_ns,
+            env_file.stat().st_mode,
+            env_file.stat().st_nlink,
+        )
+
+        compose_cleanup_required = True
+        _compose(
+            docker,
+            environment,
+            project_directory=project_directory,
+            project=compose_project,
+            env_file=env_file,
+            image_reference=exact_reference,
+            arguments=(
+                "up",
+                "--detach",
+                "--no-build",
+                "--pull",
+                "never",
+                "--wait",
+                "--wait-timeout",
+                "120",
+                "agent",
+            ),
+            timeout=150,
+        )
+        deployed_container = _compose_container_id(
+            docker,
+            environment,
+            project=compose_project,
+        )
+        deployed_container_identity = _container_identity(
+            docker,
+            environment,
+            deployed_container,
+        )
+        deployed_image_identity = _image_identity(
+            docker,
+            environment,
+            exact_reference,
+        )
+        assert deployed_container_identity[1] == "running"
+        assert deployed_image_identity == image_id
+
+        _owned_mutation(
+            cleanup_commands,
+            [docker, "container", "rm", sentinel_container],
+            lambda: _run(
+                [
+                    docker,
+                    "container",
+                    "create",
+                    "--name",
+                    sentinel_container,
+                    "--network",
+                    "none",
+                    "--entrypoint",
+                    "/bin/true",
+                    image_id,
+                ],
+                environment=environment,
+                timeout=30,
+            ),
+        )
+        _run(
+            [docker, "container", "start", "--attach", sentinel_container],
+            environment=environment,
+            timeout=30,
+        )
+        sentinel_container_identity = _container_identity(
+            docker,
+            environment,
+            sentinel_container,
+        )
+        assert sentinel_container_identity[1] == "exited"
+
+        _owned_mutation(
+            cleanup_commands,
+            [docker, "volume", "rm", sentinel_volume],
+            lambda: _run(
+                [docker, "volume", "create", sentinel_volume],
+                environment=environment,
+                timeout=30,
+            ),
+        )
+        sentinel_volume_identity = _volume_identity(
+            docker,
+            environment,
+            sentinel_volume,
+        )
+        network_result = _owned_mutation(
+            cleanup_commands,
+            [docker, "network", "rm", sentinel_network],
+            lambda: _run(
+                [docker, "network", "create", sentinel_network],
+                environment=environment,
+                timeout=30,
+            ),
+        )
+        sentinel_network_id = network_result.stdout.strip()
+        assert re.fullmatch(r"[0-9a-f]{64}", sentinel_network_id)
+
+        adopted_result = _cli(
+            environment,
+            "adopt",
+            "--state-dir",
+            str(state_directory),
+            "--checkout",
+            str(project_directory),
+            "--expected-origin",
+            EXPECTED_ORIGIN,
+            "--compose-project",
+            compose_project,
+        )
+        assert PRIVATE_CANARY not in adopted_result.stdout
+        assert PRIVATE_CANARY not in adopted_result.stderr
+        adopted = json.loads(adopted_result.stdout)
+        assert adopted["status"] == "adopted"
+        state = adopted["current"]["state"]
+        assert state["source_revision"] == revision
+        assert state["image_reference"] == exact_reference
+        assert state["image_id"] == image_id
+        assert state["oci_revision"] == revision
+        assert state["compose_project"] == compose_project
+        assert state["compose_service"] == "agent"
+
+        store = DeploymentStateStore(state_directory)
+        current = store.read_current()
+        assert current is not None
+        snapshot = state_directory / current.state.environment_snapshot
+        assert snapshot.read_bytes() == environment_before
+        assert (
+            current.state.environment_sha256
+            == hashlib.sha256(environment_before).hexdigest()
+        )
+        assert PRIVATE_CANARY.encode() not in store.current_path.read_bytes()
+        assert (
+            PRIVATE_CANARY.encode()
+            not in (store.journal_path / "00000000000000000001.json").read_bytes()
+        )
+        assert stat.S_IMODE(state_directory.stat().st_mode) == 0o700
+        for path in (
+            store.lock_path,
+            store.current_path,
+            store.journal_path / "00000000000000000001.json",
+            snapshot,
+        ):
+            assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+        inspected = _cli(
+            environment,
+            "inspect",
+            "--state-dir",
+            str(state_directory),
+        )
+        assert PRIVATE_CANARY not in inspected.stdout
+        assert PRIVATE_CANARY not in inspected.stderr
+        assert json.loads(inspected.stdout)["status"] == "recorded"
+
+        with store.transaction():
+            busy = _cli(
+                environment,
+                "inspect",
+                "--state-dir",
+                str(state_directory),
+                check=False,
+            )
+            assert busy.returncode == 75
+            assert "another deployment transaction" in busy.stderr
+            assert PRIVATE_CANARY not in busy.stderr
+
+        zero = _cli(
+            environment,
+            "adopt",
+            "--state-dir",
+            str(zero_state_directory),
+            "--checkout",
+            str(project_directory),
+            "--expected-origin",
+            EXPECTED_ORIGIN,
+            "--compose-project",
+            zero_project,
+        )
+        assert PRIVATE_CANARY not in zero.stdout
+        assert PRIVATE_CANARY not in zero.stderr
+        assert json.loads(zero.stdout)["status"] == "fresh"
+        assert DeploymentStateStore(zero_state_directory).read_current() is None
+
+        assert env_file.read_bytes() == environment_before
+        assert (
+            env_file.stat().st_dev,
+            env_file.stat().st_ino,
+            env_file.stat().st_size,
+            env_file.stat().st_mtime_ns,
+            env_file.stat().st_mode,
+            env_file.stat().st_nlink,
+        ) == environment_metadata_before
+        assert (
+            _git(
+                git,
+                environment,
+                "rev-parse",
+                "HEAD",
+                cwd=project_directory,
+            )
+            == revision
+        )
+        assert (
+            _git(
+                git,
+                environment,
+                "diff",
+                "--quiet",
+                "--",
+                cwd=project_directory,
+            )
+            == ""
+        )
+        assert (
+            _git(
+                git,
+                environment,
+                "diff",
+                "--cached",
+                "--quiet",
+                "--",
+                cwd=project_directory,
+            )
+            == ""
+        )
+        assert (
+            _container_identity(
+                docker,
+                environment,
+                deployed_container,
+            )
+            == deployed_container_identity
+        )
+        assert (
+            _image_identity(docker, environment, exact_reference)
+            == deployed_image_identity
+        )
+        assert (
+            _image_identity(docker, environment, sentinel_image)
+            == sentinel_image_identity
+        )
+
+        assert (
+            _container_identity(
+                docker,
+                environment,
+                sentinel_container,
+            )
+            == sentinel_container_identity
+        )
+        assert (
+            _volume_identity(
+                docker,
+                environment,
+                sentinel_volume,
+            )
+            == sentinel_volume_identity
+        )
+        assert (
+            _run(
+                [
+                    docker,
+                    "network",
+                    "inspect",
+                    "--format",
+                    "{{.Id}}",
+                    sentinel_network,
+                ],
+                environment=environment,
+                timeout=30,
+            ).stdout.strip()
+            == sentinel_network_id
+        )
+    except BaseException as error:
+        primary_error = error
+        raise
+    finally:
+        cleanup_failures: list[str] = []
+        if compose_cleanup_required:
+            cleanup_failures.extend(
+                _capture_cleanup_operation(
+                    lambda: _compose(
+                        docker,
+                        environment,
+                        project_directory=project_directory,
+                        project=compose_project,
+                        env_file=env_file,
+                        image_reference=(
+                            source_tag if exact_reference is None else exact_reference
+                        ),
+                        arguments=("down", "--remove-orphans", "--timeout", "30"),
+                        check=False,
+                        timeout=60,
+                    )
+                )
+            )
+        cleanup_failures.extend(_execute_exact_cleanup(cleanup_commands, environment))
+        try:
+            remaining_volumes = _docker_names(docker, environment, "volume")
+        except AssertionError:
+            cleanup_failures.append("Docker volume inventory failed after cleanup")
+        else:
+            if remaining_volumes != baseline_volumes:
+                cleanup_failures.append("Docker volume set changed after cleanup")
+        _report_cleanup_failures(cleanup_failures, primary_error)

--- a/tests/test_deployment_state_workflow.py
+++ b/tests/test_deployment_state_workflow.py
@@ -1,0 +1,192 @@
+"""Hosted Docker workflow contracts for VM deployment-state adoption."""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import yaml  # type: ignore[import-untyped]
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = REPOSITORY_ROOT / ".github" / "workflows" / "test-docker-compose.yml"
+RUNTIME_PATH = REPOSITORY_ROOT / "tests" / "test_deployment_state_runtime.py"
+CHECKOUT_PIN = "3d3c42e5aac5ba805825da76410c181273ba90b1"
+SETUP_UV_PIN = "d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86"
+
+
+def _workflow() -> dict[str, object]:
+    document = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    assert isinstance(document, dict)
+    return document
+
+
+def _job() -> dict[str, object]:
+    jobs = _workflow()["jobs"]
+    assert isinstance(jobs, dict)
+    selected = jobs["deployment-state"]
+    assert isinstance(selected, dict)
+    return selected
+
+
+def _function_source(document: str, name: str) -> str:
+    tree = ast.parse(document)
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == name
+    )
+    return ast.get_source_segment(document, function) or ""
+
+
+def test_deployment_state_job_is_read_only_and_secret_free() -> None:
+    """Run Docker-root-equivalent proof only on an ephemeral least-privilege host."""
+    workflow = _workflow()
+    job = _job()
+    job_source = yaml.safe_dump(job, sort_keys=False)
+
+    assert workflow["permissions"] == {"contents": "read"}
+    assert job["name"] == "Validate VM deployment-state adoption"
+    assert job["runs-on"] == "ubuntu-latest"
+    assert job["timeout-minutes"] == 20
+    assert "permissions" not in job
+    assert ": write" not in job_source
+    assert "secrets." not in job_source
+    assert "github.token" not in job_source
+    assert "GITHUB_TOKEN" not in job_source
+    assert "docker/login-action" not in job_source
+    assert "push: true" not in job_source
+
+
+def test_deployment_state_job_uses_pinned_locked_focused_tools() -> None:
+    """Keep the hosted proof reproducible and limited to one runtime test."""
+    steps = _job()["steps"]
+    assert isinstance(steps, list)
+    rendered = yaml.safe_dump(steps, sort_keys=False)
+
+    assert rendered.count("actions/checkout@") == 1
+    assert f"actions/checkout@{CHECKOUT_PIN}" in rendered
+    assert rendered.count("persist-credentials: false") == 1
+    assert rendered.count("astral-sh/setup-uv@") == 1
+    assert f"astral-sh/setup-uv@{SETUP_UV_PIN}" in rendered
+    assert "run: uv python install 3.13" in rendered
+    assert "run: uv sync --locked" in rendered
+    assert rendered.count("uv run pytest") == 1
+    assert "uv run pytest tests/test_deployment_state_runtime.py -q" in rendered
+
+
+def test_deployment_state_job_enables_unique_opt_in_boundary() -> None:
+    """Require explicit real-Docker execution and a per-run owned namespace."""
+    environment = _job()["env"]
+    assert isinstance(environment, dict)
+    assert environment == {
+        "RUN_DEPLOYMENT_STATE_INTEGRATION": "1",
+        "DEPLOYMENT_STATE_TEST_PREFIX": "adk-state-${{ github.run_id }}",
+    }
+    assert "COMPOSE_PROJECT_NAME" not in environment
+
+
+def test_runtime_uses_candidate_not_production_compose() -> None:
+    """Prove adoption without publishing a production port or touching its project."""
+    source = RUNTIME_PATH.read_text(encoding="utf-8")
+
+    assert (
+        'CANDIDATE_COMPOSE_PATH = REPOSITORY_ROOT / "compose.candidate.yaml"' in source
+    )
+    assert 'REPOSITORY_ROOT / "compose.yaml"' not in source
+    assert '"127.0.0.1::5000"' in source
+    assert '"up",' in source
+    assert '"--no-build",' in source
+    assert '"--pull",' in source
+    assert '"never",' in source
+    assert '"--wait",' in source
+    assert '"deployment-state-runtime"' in source
+
+
+def test_runtime_cleanup_is_exact_and_never_prunes() -> None:
+    """Preserve unrelated VM resources and persistent volumes."""
+    source = RUNTIME_PATH.read_text(encoding="utf-8")
+    compose_source = _function_source(source, "_compose")
+    runtime_source = _function_source(
+        source,
+        "test_real_docker_adopts_exact_healthy_compose_state",
+    )
+    for forbidden in (
+        "docker system prune",
+        "docker image prune",
+        "docker builder prune",
+        '"volume", "prune"',
+        '"network", "prune"',
+        '"container", "prune"',
+    ):
+        assert forbidden not in source
+    assert 'project.startswith("adk-state-")' in compose_source
+    assert '"down", "--remove-orphans", "--timeout", "30"' in runtime_source
+    assert runtime_source.count('"--volumes"') == 1
+    assert re.search(
+        r'"container",\s*"rm",\s*"--force",\s*"--volumes",\s*registry_name',
+        runtime_source,
+    )
+    assert "baseline_volumes" in runtime_source
+    assert "remaining_volumes != baseline_volumes" in runtime_source
+    assert "sentinel_container_identity" in runtime_source
+    assert "sentinel_volume_identity" in runtime_source
+    assert "sentinel_network_id" in runtime_source
+    assert "sentinel_image_identity" in runtime_source
+
+
+def test_runtime_pins_supported_registry_and_prearms_cleanup() -> None:
+    """Use an immutable Registry v3 image and clean partial startup failures."""
+    source = RUNTIME_PATH.read_text(encoding="utf-8")
+    runtime_source = _function_source(
+        source,
+        "test_real_docker_adopts_exact_healthy_compose_state",
+    )
+    owned_source = _function_source(source, "_owned_mutation")
+    registry_source = _function_source(source, "_ensure_registry_image")
+    digest_match = re.search(
+        r"REGISTRY_IMAGE_REFERENCE = \(\n"
+        r'    "registry@sha256:([0-9a-f]{64})"\n'
+        r"\)",
+        source,
+    )
+
+    assert digest_match is not None
+    assert digest_match.group(1) != "0" * 64
+    assert "registry:2" not in source
+    assert "registry:3" not in source
+    assert owned_source.index("cleanup_commands.append") < owned_source.index(
+        "return operation()"
+    )
+    assert runtime_source.count("_owned_mutation(") >= 7
+    assert "lambda: _build_image(" in runtime_source
+    assert "lambda: _create_registry(" in runtime_source
+    assert "_owned_mutation(" in registry_source
+    assert "REGISTRY_IMAGE_REFERENCE" in registry_source
+    assert runtime_source.index(
+        "compose_cleanup_required = True"
+    ) < runtime_source.index("_compose(")
+
+
+def test_runtime_proves_real_cli_lock_and_durable_private_state() -> None:
+    """Keep the opt-in proof tied to the operator-facing state boundary."""
+    source = RUNTIME_PATH.read_text(encoding="utf-8")
+    runtime_source = _function_source(
+        source,
+        "test_real_docker_adopts_exact_healthy_compose_state",
+    )
+
+    assert 'os.environ.get(RUN_ENVIRONMENT_NAME) != "1"' in source
+    assert "_require_docker(environment)" in runtime_source
+    assert '"-m", "agent.deployment_state_cli"' in source
+    assert '"adopt",' in runtime_source
+    assert '"inspect",' in runtime_source
+    assert "with store.transaction():" in runtime_source
+    assert "busy.returncode == 75" in runtime_source
+    assert "snapshot.read_bytes() == environment_before" in runtime_source
+    assert "env_file.read_bytes() == environment_before" in runtime_source
+    assert "environment_sha256" in runtime_source
+    assert "0o700" in runtime_source
+    assert "0o600" in runtime_source
+    assert "PRIVATE_CANARY not in" in runtime_source


### PR DESCRIPTION
## What

Add a durable, locked deployment-state boundary for single-VM Google ADK
deployments, including explicit read-only adoption of an existing healthy
Compose service.

## Why

Workflow concurrency cannot serialize manual operations on a VM, and mutable
runtime inspection is not an authoritative rollback record. The deployment
workflow needs a local transaction lock and crash-safe, secret-free history
before candidate promotion and rollback can be implemented safely.

## How

- Add an owner-private POSIX lock and hash-chained canonical JSON journal.
- Publish environment snapshots and the derived current pointer atomically.
- Recover journal-ahead state while rejecting gaps, tampering, and unsafe files.
- Validate the exact Git checkout, Compose labels, health, digest, image ID,
  OCI revision, and private environment source before adoption.
- Add a secret-free `deployment-state` inspect/adopt CLI.
- Add deterministic race, crash, permission, corruption, and process tests.
- Add an isolated hosted Docker adoption proof that preserves unrelated
  containers, images, volumes, networks, Git state, and environment bytes.

## Tests

- [x] `uv sync --locked`
- [x] `uv run ruff format`
- [x] `uv run ruff format --check`
- [x] `uv run ruff check --no-fix --output-format=github`
- [x] `uv run mypy .`
- [x] `uv run pytest --cov=src --cov-report=xml --cov-report=term-missing`
- [x] 869 tests pass locally with 100% statement and branch coverage
- [x] Hosted real-Docker deployment-state adoption proof

## Related Issues

Closes #117
Part of #111
