### PR TITLE
feat: add transactional VM promotion

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,7 +3,7 @@ name: Docker Publish
 on:
   push:
     branches: [ "main" ]
-    tags: [ 'v*.*.*' ]
+    tags: [ "v*.*.*" ]
   workflow_dispatch:
     inputs:
       deploy:
@@ -16,14 +16,12 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  # 1. Run Code Quality First
   quality:
     permissions:
       contents: read
       id-token: write
     uses: ./.github/workflows/code-quality.yml
 
-  # 2. Build and Push after Quality passes
   build:
     needs: quality
     runs-on: ubuntu-latest
@@ -35,21 +33,20 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Downcase IMAGE_NAME
         run: |
           echo "IMAGE_NAME=${GITHUB_REPOSITORY@L}" >> "${GITHUB_ENV}"
 
-      # Multi-platform support (qemu + buildx)
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -57,7 +54,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -68,18 +65,16 @@ jobs:
 
       - name: Build and push Docker image
         id: build-push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           push: true
-          # Multi-platform builds for Bare Metal (ARM64 for Pis, AMD64 for Cloud)
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: |
             ${{ steps.meta.outputs.labels }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
-          # Borrowed high-perf caching
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -98,17 +93,31 @@ jobs:
       github.ref == 'refs/heads/main' &&
       inputs.deploy
     runs-on: ubuntu-latest
+    timeout-minutes: 50
+    permissions:
+      contents: read
+    env:
+      DEPLOY_SHA: ${{ github.sha }}
+      IMAGE_DIGEST: ${{ needs.build.outputs.digest }}
+      DEPLOY_RUN_ID: "${{ github.run_id }}"
+      DEPLOY_RUN_ATTEMPT: "${{ github.run_attempt }}"
     concurrency:
       group: production-deployment
       cancel-in-progress: false
-      queue: max
+
     steps:
-      - name: Validate deployment provenance
-        env:
-          DEPLOY_SHA: ${{ github.sha }}
-          IMAGE_DIGEST: ${{ needs.build.outputs.digest }}
+      - name: Checkout deployment revision
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Prepare private deployment transport
+        id: transport
         run: |
-          set -eu
+          set -euo pipefail
+          umask 077
 
           if [ "${#DEPLOY_SHA}" -ne 40 ]; then
             echo "ERROR: Invalid deployment commit."
@@ -120,7 +129,6 @@ jobs:
               exit 1
               ;;
           esac
-
           case "$IMAGE_DIGEST" in
             sha256:*) ;;
             *)
@@ -139,174 +147,343 @@ jobs:
               exit 1
               ;;
           esac
+          for RUN_VALUE in "$DEPLOY_RUN_ID" "$DEPLOY_RUN_ATTEMPT"; do
+            case "$RUN_VALUE" in
+              ""|*[!0123456789]*)
+                echo "ERROR: Invalid deployment run identity."
+                exit 1
+                ;;
+            esac
+          done
 
-      - name: Deploy to Server
-        uses: appleboy/ssh-action@v1.0.3
+          CHECKED_OUT_SHA="$(git rev-parse --verify HEAD)"
+          if [ "$CHECKED_OUT_SHA" != "$DEPLOY_SHA" ]; then
+            echo "ERROR: Deployment checkout does not match the requested commit."
+            exit 1
+          fi
+          for SOURCE_PATH in \
+            scripts/deployment_bootstrap.sh \
+            scripts/deployment_cleanup.sh \
+            src/agent/compose_env.py
+          do
+            if [ ! -f "$SOURCE_PATH" ] || [ -L "$SOURCE_PATH" ]; then
+              echo "ERROR: Deployment source file is unavailable."
+              exit 1
+            fi
+            SOURCE_ENTRY="$(git ls-tree "$DEPLOY_SHA" -- "$SOURCE_PATH")"
+            read -r SOURCE_MODE SOURCE_TYPE EXPECTED_BLOB SOURCE_NAME \
+              <<< "$SOURCE_ENTRY"
+            case "$SOURCE_MODE:$SOURCE_TYPE" in
+              100644:blob|100755:blob) ;;
+              *)
+                echo "ERROR: Deployment source file type is unsafe."
+                exit 1
+                ;;
+            esac
+            if [ "$SOURCE_NAME" != "$SOURCE_PATH" ]; then
+              echo "ERROR: Deployment source file identity is invalid."
+              exit 1
+            fi
+            ACTUAL_BLOB="$(git hash-object "$SOURCE_PATH")"
+            if [ "$EXPECTED_BLOB" != "$ACTUAL_BLOB" ]; then
+              echo "ERROR: Deployment source file does not match the commit."
+              exit 1
+            fi
+          done
+
+          TRANSPORT_DIR="$(mktemp -d "$RUNNER_TEMP/adk-deploy.XXXXXXXX")"
+          chmod 700 "$TRANSPORT_DIR"
+          printf 'directory=%s\n' "$TRANSPORT_DIR" >> "$GITHUB_OUTPUT"
+
+      - name: Serialize production environment
         env:
-          DEPLOY_SHA: ${{ github.sha }}
-          IMAGE_DIGEST: ${{ needs.build.outputs.digest }}
-        with:
-          host: ${{ secrets.SERVER_HOST }}
-          username: ${{ secrets.SERVER_USER }}
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          envs: DEPLOY_SHA,IMAGE_DIGEST
-          script: |
-            set -eu
+          TRANSPORT_DIR: ${{ steps.transport.outputs.directory }}
+          AGENT_NAME: production-agent
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          ROOT_AGENT_MODEL: ${{ secrets.ROOT_AGENT_MODEL }}
+          LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+          LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
+          LANGFUSE_BASE_URL: ${{ secrets.LANGFUSE_HOST }}
+          LOG_LEVEL: INFO
+          PORT: "8080"
+          HOST: 0.0.0.0
+        run: >-
+          python3 -I -S -B
+          "$GITHUB_WORKSPACE/src/agent/compose_env.py"
+          "$TRANSPORT_DIR/production.env"
+          AGENT_NAME
+          DATABASE_URL
+          OPENROUTER_API_KEY
+          GOOGLE_API_KEY
+          ROOT_AGENT_MODEL
+          LANGFUSE_PUBLIC_KEY
+          LANGFUSE_SECRET_KEY
+          LANGFUSE_BASE_URL
+          LOG_LEVEL
+          PORT
+          HOST
 
-            if [ "${#DEPLOY_SHA}" -ne 40 ]; then
-              echo "ERROR: Invalid deployment commit."
+      - name: Run locked transactional deployment
+        env:
+          TRANSPORT_DIR: ${{ steps.transport.outputs.directory }}
+          SERVER_HOST: ${{ secrets.SERVER_HOST }}
+          SERVER_USER: ${{ secrets.SERVER_USER }}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          SERVER_HOST_FINGERPRINT: ${{ secrets.SERVER_HOST_FINGERPRINT }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          umask 077
+
+          case "$SERVER_HOST" in
+            ""|-*|*[!ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._:-]*)
+              echo "ERROR: Invalid deployment server host."
               exit 1
-            fi
-            case "$DEPLOY_SHA" in
-              *[!0123456789abcdef]*)
-                echo "ERROR: Invalid deployment commit."
-                exit 1
-                ;;
-            esac
-
-            case "$IMAGE_DIGEST" in
-              sha256:*) ;;
-              *)
-                echo "ERROR: Invalid image digest."
-                exit 1
-                ;;
-            esac
-            DIGEST_HEX=${IMAGE_DIGEST#sha256:}
-            if [ "${#DIGEST_HEX}" -ne 64 ]; then
-              echo "ERROR: Invalid image digest."
+              ;;
+          esac
+          case "$SERVER_USER" in
+            ""|-*|*[!ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.-]*)
+              echo "ERROR: Invalid deployment server user."
               exit 1
-            fi
-            case "$DIGEST_HEX" in
-              *[!0123456789abcdef]*)
-                echo "ERROR: Invalid image digest."
-                exit 1
-                ;;
-            esac
+              ;;
+          esac
+          case "$SERVER_HOST_FINGERPRINT" in
+            SHA256:*) ;;
+            *)
+              echo "ERROR: Invalid server host fingerprint."
+              exit 1
+              ;;
+          esac
+          FINGERPRINT_VALUE=${SERVER_HOST_FINGERPRINT#SHA256:}
+          if [ "${#FINGERPRINT_VALUE}" -ne 43 ]; then
+            echo "ERROR: Invalid server host fingerprint."
+            exit 1
+          fi
+          case "$FINGERPRINT_VALUE" in
+            *[!ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/]*)
+              echo "ERROR: Invalid server host fingerprint."
+              exit 1
+              ;;
+          esac
+          if [ -z "$SSH_PRIVATE_KEY" ]; then
+            echo "ERROR: Deployment SSH key is unavailable."
+            exit 1
+          fi
+          case "$TRANSPORT_DIR" in
+            "$RUNNER_TEMP"/adk-deploy.*) ;;
+            *)
+              echo "ERROR: Invalid private transport directory."
+              exit 1
+              ;;
+          esac
 
-            # 1. Set dynamic project directory based on repository name
-            PROJECT_NAME="${{ github.event.repository.name }}"
-            PROJECT_DIR="$HOME/$PROJECT_NAME"
-            EXPECTED_ORIGIN="https://github.com/${{ github.repository }}"
-            IMAGE_REPOSITORY="$(
-              printf '%s' "ghcr.io/${{ github.repository }}" \
-                | tr '[:upper:]' '[:lower:]'
+          PAYLOAD_FILE="$TRANSPORT_DIR/production.env"
+          IDENTITY_FILE="$TRANSPORT_DIR/identity"
+          SCANNED_KEYS="$TRANSPORT_DIR/scanned-host-keys"
+          CANDIDATE_KEY="$TRANSPORT_DIR/candidate-host-key"
+          KNOWN_HOSTS="$TRANSPORT_DIR/known-hosts"
+          if [ ! -f "$PAYLOAD_FILE" ] \
+            || [ -L "$PAYLOAD_FILE" ] \
+            || [ "$(stat -c '%a:%u:%h' "$PAYLOAD_FILE")" != "600:$(id -u):1" ]
+          then
+            echo "ERROR: Private production payload is unsafe."
+            exit 1
+          fi
+
+          install -m 600 /dev/null "$IDENTITY_FILE"
+          printf '%s\n' "$SSH_PRIVATE_KEY" > "$IDENTITY_FILE"
+          unset SSH_PRIVATE_KEY
+          ssh-keyscan -T 10 "$SERVER_HOST" > "$SCANNED_KEYS"
+          install -m 600 /dev/null "$KNOWN_HOSTS"
+          MATCHING_KEYS=0
+          while IFS= read -r HOST_KEY; do
+            printf '%s\n' "$HOST_KEY" > "$CANDIDATE_KEY"
+            OBSERVED_FINGERPRINT="$(
+              ssh-keygen -E sha256 -lf "$CANDIDATE_KEY" | awk '{print $2}'
             )"
-            IMAGE_NAME="${IMAGE_REPOSITORY}@${IMAGE_DIGEST}"
-            DEPLOY_PROJECT="$(
-              printf 'adk-%s' "$PROJECT_NAME" | tr '[:upper:].' '[:lower:]-'
-            )"
+            if [ "$OBSERVED_FINGERPRINT" = "$SERVER_HOST_FINGERPRINT" ]; then
+              printf '%s\n' "$HOST_KEY" >> "$KNOWN_HOSTS"
+              MATCHING_KEYS=$((MATCHING_KEYS + 1))
+            fi
+          done < "$SCANNED_KEYS"
+          if [ "$MATCHING_KEYS" -ne 1 ]; then
+            echo "ERROR: Server host key did not match exactly once."
+            exit 1
+          fi
+          unset SERVER_HOST_FINGERPRINT
 
-            # 2. Ensure project directory exists
-            if [ -e "$PROJECT_DIR" ] && [ ! -d "$PROJECT_DIR/.git" ]; then
-              echo "ERROR: Project path exists without a Git checkout."
-              exit 1
-            fi
-            if [ ! -d "$PROJECT_DIR/.git" ]; then
-              echo "Project directory not found. Cloning..."
-              git clone https://github.com/${{ github.repository }} "$PROJECT_DIR"
-            fi
+          SSH_OPTIONS=(
+            -F /dev/null
+            -i "$IDENTITY_FILE"
+            -o BatchMode=yes
+            -o PasswordAuthentication=no
+            -o KbdInteractiveAuthentication=no
+            -o PreferredAuthentications=publickey
+            -o IdentitiesOnly=yes
+            -o IdentityAgent=none
+            -o StrictHostKeyChecking=yes
+            -o "UserKnownHostsFile=$KNOWN_HOSTS"
+            -o GlobalKnownHostsFile=/dev/null
+            -o VerifyHostKeyDNS=no
+            -o UpdateHostKeys=no
+            -o ForwardAgent=no
+            -o ForwardX11=no
+            -o ClearAllForwardings=yes
+            -o RequestTTY=no
+            -o ConnectTimeout=30
+            -o ServerAliveInterval=15
+            -o ServerAliveCountMax=2
+            -o LogLevel=ERROR
+          )
+          REMOTE_RELEASE_READY=0
+          REMOTE_CLEANUP_ALLOWED=0
+          BOOTSTRAP_LOG="$TRANSPORT_DIR/bootstrap-status"
 
-            # 3. Navigate to the exact source revision without discarding changes
-            cd "$PROJECT_DIR"
-            ACTUAL_ORIGIN="$(git remote get-url origin)"
-            case "$ACTUAL_ORIGIN" in
-              "$EXPECTED_ORIGIN"|"$EXPECTED_ORIGIN.git") ;;
-              *)
-                echo "ERROR: Existing checkout has an unexpected origin."
-                exit 1
-                ;;
-            esac
-            if ! git diff --quiet --; then
-              echo "ERROR: Tracked worktree changes block deployment."
-              exit 1
+          cleanup_remote_release() {
+            PRIMARY_STATUS=$?
+            trap - EXIT INT TERM
+            if [ "$REMOTE_RELEASE_READY" -eq 1 ] \
+              && [ "$REMOTE_CLEANUP_ALLOWED" -eq 1 ]
+            then
+              set +e
+              timeout --signal=TERM --kill-after=15s 2m \
+                ssh "${SSH_OPTIONS[@]}" "$SERVER_USER@$SERVER_HOST" \
+                sh -s -- \
+                "$DEPLOY_SHA" \
+                "$IMAGE_DIGEST" \
+                "$DEPLOY_RUN_ID" \
+                "$DEPLOY_RUN_ATTEMPT" \
+                "${{ github.event.repository.name }}" \
+                "${{ github.repository }}" \
+                < "$GITHUB_WORKSPACE/scripts/deployment_cleanup.sh"
+              CLEANUP_STATUS=$?
+              set -e
+              if [ "$CLEANUP_STATUS" -ne 0 ]; then
+                echo "ERROR: Exact release worktree cleanup failed."
+                if [ "$PRIMARY_STATUS" -eq 0 ]; then
+                  PRIMARY_STATUS=1
+                fi
+              fi
             fi
-            if ! git diff --cached --quiet --; then
-              echo "ERROR: Staged changes block deployment."
-              exit 1
-            fi
-            git fetch --no-tags origin "$DEPLOY_SHA"
-            git checkout --detach "$DEPLOY_SHA"
-            CHECKED_OUT_SHA="$(git rev-parse --verify HEAD)"
-            if [ "$CHECKED_OUT_SHA" != "$DEPLOY_SHA" ]; then
-              echo "ERROR: Checked-out commit does not match deployment commit."
-              exit 1
-            fi
-            if ! git diff --quiet --; then
-              echo "ERROR: Checkout left tracked worktree changes."
-              exit 1
-            fi
-            if ! git diff --cached --quiet --; then
-              echo "ERROR: Checkout left staged changes."
-              exit 1
-            fi
-            if ! git ls-files --error-unmatch -- compose.yaml >/dev/null 2>&1; then
-              echo "ERROR: Deployment commit does not track compose.yaml."
-              exit 1
-            fi
+            exit "$PRIMARY_STATUS"
+          }
+          trap cleanup_remote_release EXIT
+          trap 'exit 130' INT
+          trap 'exit 143' TERM
 
-            # 4. Inject Secrets into .env (Automated Configuration)
-            echo "Generating .env file from GitHub Secrets..."
-            cat <<'ENV_FILE' > .env
-            AGENT_NAME=production-agent
-            DATABASE_URL=${{ secrets.DATABASE_URL }}
-            OPENROUTER_API_KEY=${{ secrets.OPENROUTER_API_KEY }}
-            GOOGLE_API_KEY=${{ secrets.GOOGLE_API_KEY }}
-            ROOT_AGENT_MODEL=${{ secrets.ROOT_AGENT_MODEL }}
-            LANGFUSE_PUBLIC_KEY=${{ secrets.LANGFUSE_PUBLIC_KEY }}
-            LANGFUSE_SECRET_KEY=${{ secrets.LANGFUSE_SECRET_KEY }}
-            LANGFUSE_BASE_URL=${{ secrets.LANGFUSE_HOST }}
-            LOG_LEVEL=INFO
-            PORT=8080
-            HOST=0.0.0.0
-            ENV_FILE
+          set +e
+          timeout --signal=TERM --kill-after=30s 8m \
+            ssh "${SSH_OPTIONS[@]}" "$SERVER_USER@$SERVER_HOST" \
+            sh -s -- \
+            "$DEPLOY_SHA" \
+            "$IMAGE_DIGEST" \
+            "$DEPLOY_RUN_ID" \
+            "$DEPLOY_RUN_ATTEMPT" \
+            "${{ github.event.repository.name }}" \
+            "${{ github.repository }}" \
+            < "$GITHUB_WORKSPACE/scripts/deployment_bootstrap.sh" \
+            | tee "$BOOTSTRAP_LOG"
+          BOOTSTRAP_STATUS=${PIPESTATUS[0]}
+          set -e
+          if grep -Fqx -- \
+            "BOOTSTRAP_LEASE_READY:$DEPLOY_RUN_ID:$DEPLOY_RUN_ATTEMPT" \
+            "$BOOTSTRAP_LOG"
+          then
+            REMOTE_RELEASE_READY=1
+            REMOTE_CLEANUP_ALLOWED=1
+          fi
+          case "$BOOTSTRAP_STATUS" in
+            0)
+              REMOTE_RELEASE_READY=1
+              REMOTE_CLEANUP_ALLOWED=1
+              ;;
+            124|137|143|255)
+              echo "ERROR: Bootstrap transport ended ambiguously; checking the lease."
+              exit "$BOOTSTRAP_STATUS"
+              ;;
+            *)
+              exit "$BOOTSTRAP_STATUS"
+              ;;
+          esac
 
-            # 5. Deploy with dynamic image
-            export IMAGE="$IMAGE_NAME"
-            CONFIGURED_IMAGE="$(
-              docker compose --project-name "$DEPLOY_PROJECT" \
-                --env-file .env -f compose.yaml config --images
+          PROJECT_NAME="${{ github.event.repository.name }}"
+          PROJECT_SLUG="$(
+            printf '%s' "$PROJECT_NAME" | tr '[:upper:].' '[:lower:]-'
+          )"
+          if [ "${#PROJECT_SLUG}" -gt 45 ]; then
+            PROJECT_HASH="$(
+              printf '%s' "$PROJECT_NAME" | sha256sum | cut -c1-8
             )"
-            if [ "$CONFIGURED_IMAGE" != "$IMAGE_NAME" ]; then
-              echo "ERROR: Compose image does not match the deployment digest."
-              exit 1
-            fi
-            docker compose --project-name "$DEPLOY_PROJECT" \
-              --env-file .env -f compose.yaml pull agent
-            docker compose --project-name "$DEPLOY_PROJECT" \
-              --env-file .env -f compose.yaml \
-              up --no-build --wait --wait-timeout 180 agent
+            PROJECT_SLUG="$(printf '%.45s-%s' "$PROJECT_SLUG" "$PROJECT_HASH")"
+          fi
+          IMAGE_REPOSITORY="$(
+            printf '%s' "ghcr.io/${{ github.repository }}" \
+              | tr '[:upper:]' '[:lower:]'
+          )"
+          CONTROLLER_COMMAND="set -eu
+          PHYSICAL_HOME=\"\$(cd \"\$HOME\" && pwd -P)\"
+          exec env -i \
+          \"HOME=\$PHYSICAL_HOME\" \
+          \"PATH=\$PATH\" \
+          LANG=C \
+          LC_ALL=C \
+          GIT_NO_REPLACE_OBJECTS=1 \
+          \"DOCKER_CONFIG=\${DOCKER_CONFIG-}\" \
+          \"DOCKER_HOST=\${DOCKER_HOST-}\" \
+          \"XDG_RUNTIME_DIR=\${XDG_RUNTIME_DIR-}\" \
+          python3 -I -S -B \
+          -c 'import runpy, sys; source = sys.argv.pop(1); sys.path.insert(0, source); runpy.run_module(\"agent.deployment_promotion\", run_name=\"__main__\", alter_sys=True)' \
+          \"\$PHYSICAL_HOME/$PROJECT_NAME.release-$DEPLOY_RUN_ID-$DEPLOY_RUN_ATTEMPT/src\" \
+          promote \
+          --state-dir \"\$PHYSICAL_HOME/.local/state/$PROJECT_SLUG/deployment\" \
+          --checkout \"\$PHYSICAL_HOME/$PROJECT_NAME\" \
+          --release-checkout \"\$PHYSICAL_HOME/$PROJECT_NAME.release-$DEPLOY_RUN_ID-$DEPLOY_RUN_ATTEMPT\" \
+          --expected-origin \"https://github.com/${{ github.repository }}\" \
+          --compose-project \"adk-$PROJECT_SLUG\" \
+          --compose-service agent \
+          --source-revision \"$DEPLOY_SHA\" \
+          --image-reference \"$IMAGE_REPOSITORY@$IMAGE_DIGEST\" \
+          --adopt-existing \
+          --release-lease \"\$PHYSICAL_HOME/$PROJECT_NAME.release-$DEPLOY_RUN_ID-$DEPLOY_RUN_ATTEMPT.lease/lock\" \
+          --environment-stdin"
+          set +e
+          timeout --signal=TERM --kill-after=30s 30m \
+            ssh "${SSH_OPTIONS[@]}" "$SERVER_USER@$SERVER_HOST" \
+            "$CONTROLLER_COMMAND" < "$PAYLOAD_FILE"
+          CONTROLLER_STATUS=$?
+          set -e
+          case "$CONTROLLER_STATUS" in
+            124|137|143|255)
+              echo "ERROR: Controller transport ended ambiguously; checking the lease."
+              exit "$CONTROLLER_STATUS"
+              ;;
+          esac
+          REMOTE_CLEANUP_ALLOWED=1
+          exit "$CONTROLLER_STATUS"
 
-            CONTAINER_ID="$(
-              docker compose --project-name "$DEPLOY_PROJECT" \
-                --env-file .env -f compose.yaml ps --quiet agent
-            )"
-            if [ -z "$CONTAINER_ID" ]; then
-              echo "ERROR: Compose did not return the agent container."
+      - name: Cleanup private deployment transport
+        if: always()
+        env:
+          TRANSPORT_DIR: ${{ steps.transport.outputs.directory }}
+        run: |
+          set -eu
+          if [ -z "$TRANSPORT_DIR" ]; then
+            exit 0
+          fi
+          case "$TRANSPORT_DIR" in
+            "$RUNNER_TEMP"/adk-deploy.*) ;;
+            *)
+              echo "ERROR: Refusing to clean an unexpected transport directory."
               exit 1
-            fi
-            RUNNING_IMAGE="$(
-              docker inspect --type container \
-                --format '{{.Config.Image}}' "$CONTAINER_ID"
-            )"
-            if [ "$RUNNING_IMAGE" != "$IMAGE_NAME" ]; then
-              echo "ERROR: Running image does not match the deployment digest."
-              exit 1
-            fi
-            CONTAINER_IMAGE_ID="$(
-              docker inspect --type container --format '{{.Image}}' "$CONTAINER_ID"
-            )"
-            if [ -z "$CONTAINER_IMAGE_ID" ]; then
-              echo "ERROR: Running container does not expose an image ID."
-              exit 1
-            fi
-            RUNNING_REVISION="$(
-              docker image inspect \
-                --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' \
-                "$CONTAINER_IMAGE_ID"
-            )"
-            if [ "$RUNNING_REVISION" != "$DEPLOY_SHA" ]; then
-              echo "ERROR: Running image revision does not match the deployment commit."
-              exit 1
-            fi
-
-            docker image prune -f
+              ;;
+          esac
+          rm -f -- \
+            "$TRANSPORT_DIR/production.env" \
+            "$TRANSPORT_DIR/identity" \
+            "$TRANSPORT_DIR/scanned-host-keys" \
+            "$TRANSPORT_DIR/candidate-host-key" \
+            "$TRANSPORT_DIR/known-hosts" \
+            "$TRANSPORT_DIR/bootstrap-status"
+          rmdir "$TRANSPORT_DIR"

--- a/.github/workflows/test-docker-compose.yml
+++ b/.github/workflows/test-docker-compose.yml
@@ -390,6 +390,36 @@ jobs:
       - name: Run real VM deployment-state proof
         run: uv run pytest tests/test_deployment_state_runtime.py -q
 
+  deployment-promotion:
+    name: Validate atomic VM promotion and rollback
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      RUN_DEPLOYMENT_PROMOTION_INTEGRATION: "1"
+      DEPLOYMENT_PROMOTION_TEST_PREFIX: >-
+        adk-promotion-${{ github.run_id }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Install Python
+        run: uv python install 3.13
+
+      - name: Install locked dependencies
+        run: uv sync --locked
+
+      - name: Run atomic promotion and rollback proof
+        run: uv run pytest tests/test_deployment_promotion_runtime.py -q
+
   trace-gateway:
     name: Validate trace-redaction gateway
     runs-on: ubuntu-latest

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -56,6 +56,39 @@ verifies both the running digest-qualified image reference and the image's OCI
 revision label. The immutable image reference is also written to the Docker
 Publish workflow summary.
 
+### Automated VM deployment prerequisites
+
+The manual production job requires `python3` version 3.13, Git, Docker with the
+Compose plugin, and the util-linux `flock` command on the VM. Run SSH under a
+dedicated deployment account whose home owns the checkout and deployment state.
+That account must not have an SSH `ForceCommand`, `~/.ssh/rc`, or shell startup
+customization that reads command standard input: the second SSH connection
+streams the canonical production environment directly to the detached
+controller.
+
+Store the exact SHA256 fingerprint of the VM host key in
+`SERVER_HOST_FINGERPRINT`. The workflow uses a private identity file, ignores
+ambient SSH configuration, and accepts exactly one scanned host key with that
+fingerprint. Production values are serialized in a private runner file and are
+never placed in the remote command, bootstrap script, or command arguments.
+
+An existing checkout's `.env` must be an owner-held, single-link, non-empty
+regular file with mode `0600`. The deployment checks this before cloning,
+fetching, or creating a release worktree. If it reports the actionable
+migration error, run the exact command it prints on the VM, for example:
+
+```bash
+chmod 600 "$HOME/google-adk-on-bare-metal/.env"
+```
+
+The workflow streams the tracked `scripts/deployment_bootstrap.sh` and
+`scripts/deployment_cleanup.sh` bytes from the exact workflow commit. A
+transport timeout or SSH status 255 is ambiguous: the workflow deliberately
+checks the run-scoped lease before cleanup. A held lease preserves the release;
+a free lease permits removal only after the ownership marker, detached commit,
+and exact-clean worktree all match. Inspect the VM process and deployment
+journal before removing any residual release manually.
+
 ### Using GHCR Images
 
 Instead of building locally, you can run the image published by your

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
 [project.scripts]
 server = "agent.server:main"
 deployment-state = "agent.deployment_state_cli:main"
+deployment-promote = "agent.deployment_promotion:main"
 
 [dependency-groups]
 dev = [

--- a/scripts/deployment_bootstrap.sh
+++ b/scripts/deployment_bootstrap.sh
@@ -1,0 +1,443 @@
+#!/bin/sh
+set -eu
+umask 077
+
+if [ "$#" -ne 6 ]; then
+  echo "ERROR: Invalid deployment bootstrap identity."
+  exit 1
+fi
+DEPLOY_SHA=$1
+IMAGE_DIGEST=$2
+DEPLOY_RUN_ID=$3
+DEPLOY_RUN_ATTEMPT=$4
+PROJECT_NAME=$5
+REPOSITORY=$6
+
+case "$PROJECT_NAME" in
+  ""|-*|*[!ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.-]*)
+    echo "ERROR: Invalid deployment project name."
+    exit 1
+    ;;
+esac
+case "$REPOSITORY" in
+  */*) ;;
+  *)
+    echo "ERROR: Invalid deployment repository."
+    exit 1
+    ;;
+esac
+case "$REPOSITORY" in
+  ""|-*|*[!ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_./-]*)
+    echo "ERROR: Invalid deployment repository."
+    exit 1
+    ;;
+esac
+if [ "${#DEPLOY_SHA}" -ne 40 ]; then
+  echo "ERROR: Invalid deployment commit."
+  exit 1
+fi
+case "$DEPLOY_SHA" in
+  *[!0123456789abcdef]*)
+    echo "ERROR: Invalid deployment commit."
+    exit 1
+    ;;
+esac
+case "$IMAGE_DIGEST" in
+  sha256:*) ;;
+  *)
+    echo "ERROR: Invalid image digest."
+    exit 1
+    ;;
+esac
+DIGEST_HEX=${IMAGE_DIGEST#sha256:}
+if [ "${#DIGEST_HEX}" -ne 64 ]; then
+  echo "ERROR: Invalid image digest."
+  exit 1
+fi
+case "$DIGEST_HEX" in
+  *[!0123456789abcdef]*)
+    echo "ERROR: Invalid image digest."
+    exit 1
+    ;;
+esac
+for RUN_VALUE in "$DEPLOY_RUN_ID" "$DEPLOY_RUN_ATTEMPT"; do
+  case "$RUN_VALUE" in
+    ""|*[!0123456789]*)
+      echo "ERROR: Invalid deployment run identity."
+      exit 1
+      ;;
+  esac
+done
+
+PHYSICAL_HOME="$(cd "$HOME" && pwd -P)"
+case "$PHYSICAL_HOME" in
+  /*) ;;
+  *)
+    echo "ERROR: Deployment home is invalid."
+    exit 1
+    ;;
+esac
+case "$PHYSICAL_HOME" in
+  ""|*[!ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_./+-]*)
+    echo "ERROR: Deployment home is invalid."
+    exit 1
+    ;;
+esac
+PROJECT_DIR="$PHYSICAL_HOME/$PROJECT_NAME"
+EXPECTED_ORIGIN="https://github.com/$REPOSITORY"
+IMAGE_REPOSITORY="$(
+  printf '%s' "ghcr.io/$REPOSITORY" | tr '[:upper:]' '[:lower:]'
+)"
+IMAGE_NAME="${IMAGE_REPOSITORY}@${IMAGE_DIGEST}"
+PROJECT_SLUG="$(
+  printf '%s' "$PROJECT_NAME" | tr '[:upper:].' '[:lower:]-'
+)"
+if [ "${#PROJECT_SLUG}" -gt 45 ]; then
+  PROJECT_HASH="$(
+    printf '%s' "$PROJECT_NAME" | sha256sum | cut -c1-8
+  )"
+  PROJECT_SLUG="$(printf '%.45s-%s' "$PROJECT_SLUG" "$PROJECT_HASH")"
+fi
+DEPLOY_PROJECT="adk-$PROJECT_SLUG"
+STATE_DIR="$PHYSICAL_HOME/.local/state/$PROJECT_SLUG/deployment"
+RELEASE_DIR="$PROJECT_DIR.release-$DEPLOY_RUN_ID-$DEPLOY_RUN_ATTEMPT"
+LEASE_DIR="$RELEASE_DIR.lease"
+OWNER_FILE="$LEASE_DIR/owner"
+LOCK_FILE="$LEASE_DIR/lock"
+WORKTREE_CLEANUP_ARMED=0
+LEASE_CREATED=0
+KEEP_RELEASE=0
+
+git_safe() {
+  env -i \
+    "HOME=$PHYSICAL_HOME" \
+    "PATH=$PATH" \
+    LANG=C \
+    LC_ALL=C \
+    GIT_CONFIG_NOSYSTEM=1 \
+    GIT_CONFIG_GLOBAL=/dev/null \
+    GIT_CONFIG_SYSTEM=/dev/null \
+    GIT_TEMPLATE_DIR=/dev/null \
+    GIT_NO_REPLACE_OBJECTS=1 \
+    GIT_TERMINAL_PROMPT=0 \
+    git \
+      -c core.hooksPath=/dev/null \
+      -c core.fsmonitor=false \
+      "$@"
+}
+
+registered_release() {
+  git_safe -C "$PROJECT_DIR" worktree list --porcelain \
+    | grep -Fqx -- "worktree $RELEASE_DIR"
+}
+
+owned_release() {
+  {
+    IFS= read -r OWNER_SHA
+    IFS= read -r OWNER_PROJECT
+    IFS= read -r OWNER_RELEASE
+    IFS= read -r OWNER_ORIGIN
+    IFS= read -r OWNER_IMAGE
+    IFS= read -r OWNER_COMPOSE
+    IFS= read -r OWNER_STATE
+    if IFS= read -r OWNER_EXTRA; then
+      return 1
+    fi
+  } < "$OWNER_FILE"
+  [ "$OWNER_SHA" = "$DEPLOY_SHA" ] \
+    && [ "$OWNER_PROJECT" = "$PROJECT_DIR" ] \
+    && [ "$OWNER_RELEASE" = "$RELEASE_DIR" ] \
+    && [ "$OWNER_ORIGIN" = "$EXPECTED_ORIGIN" ] \
+    && [ "$OWNER_IMAGE" = "$IMAGE_NAME" ] \
+    && [ "$OWNER_COMPOSE" = "$DEPLOY_PROJECT" ] \
+    && [ "$OWNER_STATE" = "$STATE_DIR" ]
+}
+
+remove_owned_partial_release() {
+  env -i \
+    "HOME=$PHYSICAL_HOME" \
+    "PATH=$PATH" \
+    LANG=C \
+    LC_ALL=C \
+    python3 -I -S -B -c '
+import os
+import shutil
+import stat
+import sys
+from pathlib import Path
+
+project = Path(sys.argv[1])
+release = Path(sys.argv[2])
+expected_name = f"{project.name}.release-{sys.argv[3]}-{sys.argv[4]}"
+if (
+    not release.is_absolute()
+    or release != release.resolve(strict=False)
+    or release.parent != project.parent
+    or release.name != expected_name
+    or not shutil.rmtree.avoids_symlink_attacks
+):
+    raise SystemExit("ERROR: Partial release cleanup proof failed.")
+parent_descriptor = os.open(
+    release.parent,
+    os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_CLOEXEC", 0),
+)
+try:
+    metadata = os.stat(
+        release.name,
+        dir_fd=parent_descriptor,
+        follow_symlinks=False,
+    )
+    if not stat.S_ISDIR(metadata.st_mode) or metadata.st_uid != os.geteuid():
+        raise SystemExit("ERROR: Partial release cleanup proof failed.")
+    shutil.rmtree(release.name, dir_fd=parent_descriptor)
+finally:
+    os.close(parent_descriptor)
+' "$PROJECT_DIR" "$RELEASE_DIR" "$DEPLOY_RUN_ID" "$DEPLOY_RUN_ATTEMPT"
+}
+
+cleanup_bootstrap_release() {
+  CLEANUP_STATUS=0
+  if [ "$WORKTREE_CLEANUP_ARMED" -eq 1 ]; then
+    if registered_release; then
+      RELEASE_HEAD="$(git_safe -C "$RELEASE_DIR" rev-parse --verify HEAD)"
+      if owned_release \
+        && [ "$RELEASE_HEAD" = "$DEPLOY_SHA" ] \
+        && ! git_safe -C "$RELEASE_DIR" symbolic-ref -q HEAD >/dev/null
+      then
+        if ! git_safe -C "$PROJECT_DIR" worktree remove \
+          --force "$RELEASE_DIR"
+        then
+          CLEANUP_STATUS=1
+        fi
+      else
+        CLEANUP_STATUS=1
+      fi
+    elif [ -e "$RELEASE_DIR" ]; then
+      if ! owned_release || ! remove_owned_partial_release; then
+        CLEANUP_STATUS=1
+      fi
+    fi
+  fi
+  if [ "$LEASE_CREATED" -eq 1 ] \
+    && ! registered_release \
+    && [ ! -e "$RELEASE_DIR" ]
+  then
+    rm -f -- "$OWNER_FILE" "$LOCK_FILE"
+    if ! rmdir "$LEASE_DIR"; then
+      CLEANUP_STATUS=1
+    fi
+  fi
+  return "$CLEANUP_STATUS"
+}
+
+bootstrap_exit() {
+  PRIMARY_STATUS=$?
+  trap - EXIT INT TERM
+  if [ "$KEEP_RELEASE" -eq 0 ]; then
+    if ! cleanup_bootstrap_release; then
+      echo "ERROR: Incomplete release worktree could not be cleaned."
+      if [ "$PRIMARY_STATUS" -eq 0 ]; then
+        PRIMARY_STATUS=1
+      fi
+    fi
+  fi
+  exit "$PRIMARY_STATUS"
+}
+trap bootstrap_exit EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+if [ -e "$PROJECT_DIR" ] && [ ! -d "$PROJECT_DIR/.git" ]; then
+  echo "ERROR: Project path exists without a Git checkout."
+  exit 1
+fi
+if [ -d "$PROJECT_DIR/.git" ]; then
+  set +e
+  env -i \
+    "HOME=$PHYSICAL_HOME" \
+    "PATH=$PATH" \
+    LANG=C \
+    LC_ALL=C \
+    GIT_NO_REPLACE_OBJECTS=1 \
+    python3 -I -S -B -c '
+import os
+import stat
+import sys
+
+path = sys.argv[1]
+try:
+    metadata = os.lstat(path)
+except FileNotFoundError:
+    raise SystemExit(0)
+if (
+    not stat.S_ISREG(metadata.st_mode)
+    or metadata.st_uid != os.geteuid()
+    or metadata.st_nlink != 1
+    or metadata.st_size <= 0
+):
+    raise SystemExit(65)
+if stat.S_IMODE(metadata.st_mode) != 0o600:
+    raise SystemExit(64)
+' "$PROJECT_DIR/.env"
+  ENVIRONMENT_STATUS=$?
+  set -e
+  if [ "$ENVIRONMENT_STATUS" -eq 64 ]; then
+    echo "ERROR: Legacy .env permissions block deployment."
+    echo "Run on the VM: chmod 600 \"$PROJECT_DIR/.env\""
+    exit 1
+  fi
+  if [ "$ENVIRONMENT_STATUS" -ne 0 ]; then
+    echo "ERROR: Legacy .env ownership or file type is unsafe."
+    exit 1
+  fi
+fi
+
+env -i \
+  "HOME=$PHYSICAL_HOME" \
+  "PATH=$PATH" \
+  LANG=C \
+  LC_ALL=C \
+  GIT_NO_REPLACE_OBJECTS=1 \
+  python3 -I -S -B -c '
+import sys
+
+if sys.version_info[:2] != (3, 13):
+    raise SystemExit("ERROR: Python 3.13 is required for deployment.")
+'
+command -v flock >/dev/null
+if [ ! -d "$PROJECT_DIR/.git" ]; then
+  echo "Project directory not found. Cloning..."
+  git_safe clone "$EXPECTED_ORIGIN" "$PROJECT_DIR"
+fi
+
+ACTUAL_ORIGIN="$(git_safe -C "$PROJECT_DIR" remote get-url origin)"
+case "$ACTUAL_ORIGIN" in
+  "$EXPECTED_ORIGIN"|"$EXPECTED_ORIGIN.git") ;;
+  *)
+    echo "ERROR: Existing checkout has an unexpected origin."
+    exit 1
+    ;;
+esac
+if ! git_safe -C "$PROJECT_DIR" diff \
+  --no-ext-diff --no-textconv --quiet --
+then
+  echo "ERROR: Tracked worktree changes block deployment."
+  exit 1
+fi
+if ! git_safe -C "$PROJECT_DIR" diff \
+  --cached --no-ext-diff --no-textconv --quiet --
+then
+  echo "ERROR: Staged changes block deployment."
+  exit 1
+fi
+
+git_safe -C "$PROJECT_DIR" fetch --no-tags origin "$DEPLOY_SHA"
+if ! git_safe -C "$PROJECT_DIR" cat-file -e "${DEPLOY_SHA}^{commit}"; then
+  echo "ERROR: Deployment commit is unavailable."
+  exit 1
+fi
+for TARGET_PATH in \
+  compose.yaml \
+  compose.candidate.yaml \
+  src/agent/__init__.py \
+  src/agent/compose_env.py \
+  src/agent/deployment_adoption.py \
+  src/agent/deployment_promotion.py \
+  src/agent/deployment_state.py
+do
+  TARGET_ENTRY="$(git_safe -C "$PROJECT_DIR" ls-tree "$DEPLOY_SHA" -- "$TARGET_PATH")"
+  SAVED_IFS=$IFS
+  IFS='	 '
+  set -- $TARGET_ENTRY
+  IFS=$SAVED_IFS
+  if [ "$#" -ne 4 ] \
+    || [ "$4" != "$TARGET_PATH" ] \
+    || [ "$2" != blob ]
+  then
+    echo "ERROR: Deployment commit is missing required files."
+    exit 1
+  fi
+  case "$1" in
+    100644|100755) ;;
+    *)
+      echo "ERROR: Deployment commit has an unsafe required file type."
+      exit 1
+      ;;
+  esac
+done
+
+if [ -e "$RELEASE_DIR" ] || [ -e "$LEASE_DIR" ]; then
+  echo "ERROR: Release worktree or lease path already exists."
+  exit 1
+fi
+mkdir -m 700 "$LEASE_DIR"
+LEASE_CREATED=1
+install -m 600 /dev/null "$LOCK_FILE"
+exec 8> "$LOCK_FILE"
+if ! flock -n 8; then
+  echo "ERROR: Release bootstrap lease is already held."
+  exit 1
+fi
+{
+  printf '%s\n' "$DEPLOY_SHA"
+  printf '%s\n' "$PROJECT_DIR"
+  printf '%s\n' "$RELEASE_DIR"
+  printf '%s\n' "$EXPECTED_ORIGIN"
+  printf '%s\n' "$IMAGE_NAME"
+  printf '%s\n' "$DEPLOY_PROJECT"
+  printf '%s\n' "$STATE_DIR"
+} > "$OWNER_FILE"
+chmod 600 "$OWNER_FILE"
+printf 'BOOTSTRAP_LEASE_READY:%s:%s\n' \
+  "$DEPLOY_RUN_ID" "$DEPLOY_RUN_ATTEMPT"
+
+WORKTREE_CLEANUP_ARMED=1
+git_safe -C "$PROJECT_DIR" worktree add \
+  --no-checkout --detach "$RELEASE_DIR" "$DEPLOY_SHA"
+git_safe -C "$RELEASE_DIR" checkout --detach "$DEPLOY_SHA"
+RELEASE_SHA="$(git_safe -C "$RELEASE_DIR" rev-parse --verify HEAD)"
+if [ "$RELEASE_SHA" != "$DEPLOY_SHA" ] \
+  || git_safe -C "$RELEASE_DIR" symbolic-ref -q HEAD >/dev/null
+then
+  echo "ERROR: Release worktree does not match deployment commit."
+  exit 1
+fi
+if ! git_safe -C "$RELEASE_DIR" diff \
+  --no-ext-diff --no-textconv --quiet --
+then
+  echo "ERROR: Release worktree has tracked changes."
+  exit 1
+fi
+if ! git_safe -C "$RELEASE_DIR" diff \
+  --cached --no-ext-diff --no-textconv --quiet --
+then
+  echo "ERROR: Release worktree has staged changes."
+  exit 1
+fi
+RELEASE_STATUS="$(
+  git_safe -C "$RELEASE_DIR" status \
+    --porcelain=v1 \
+    --untracked-files=all \
+    --ignored=matching
+)"
+if [ -n "$RELEASE_STATUS" ]; then
+  echo "ERROR: Release worktree is not exact-clean."
+  exit 1
+fi
+for TARGET_PATH in \
+  compose.yaml \
+  compose.candidate.yaml \
+  src/agent/__init__.py \
+  src/agent/compose_env.py \
+  src/agent/deployment_adoption.py \
+  src/agent/deployment_promotion.py \
+  src/agent/deployment_state.py
+do
+  if [ ! -f "$RELEASE_DIR/$TARGET_PATH" ] \
+    || [ -L "$RELEASE_DIR/$TARGET_PATH" ]
+  then
+    echo "ERROR: Release worktree has an unsafe required file type."
+    exit 1
+  fi
+done
+KEEP_RELEASE=1

--- a/scripts/deployment_cleanup.sh
+++ b/scripts/deployment_cleanup.sh
@@ -1,0 +1,219 @@
+#!/bin/sh
+set -eu
+umask 077
+
+if [ "$#" -ne 6 ]; then
+  echo "ERROR: Invalid release cleanup identity."
+  exit 1
+fi
+DEPLOY_SHA=$1
+IMAGE_DIGEST=$2
+DEPLOY_RUN_ID=$3
+DEPLOY_RUN_ATTEMPT=$4
+PROJECT_NAME=$5
+REPOSITORY=$6
+
+case "$PROJECT_NAME" in
+  ""|-*|*[!ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.-]*)
+    echo "ERROR: Invalid deployment project name."
+    exit 1
+    ;;
+esac
+case "$REPOSITORY" in
+  */*) ;;
+  *)
+    echo "ERROR: Invalid deployment repository."
+    exit 1
+    ;;
+esac
+case "$REPOSITORY" in
+  ""|-*|*[!ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_./-]*)
+    echo "ERROR: Invalid deployment repository."
+    exit 1
+    ;;
+esac
+if [ "${#DEPLOY_SHA}" -ne 40 ]; then
+  echo "ERROR: Invalid deployment commit."
+  exit 1
+fi
+case "$DEPLOY_SHA" in
+  *[!0123456789abcdef]*)
+    echo "ERROR: Invalid deployment commit."
+    exit 1
+    ;;
+esac
+case "$IMAGE_DIGEST" in
+  sha256:*) ;;
+  *)
+    echo "ERROR: Invalid image digest."
+    exit 1
+    ;;
+esac
+DIGEST_HEX=${IMAGE_DIGEST#sha256:}
+if [ "${#DIGEST_HEX}" -ne 64 ]; then
+  echo "ERROR: Invalid image digest."
+  exit 1
+fi
+case "$DIGEST_HEX" in
+  *[!0123456789abcdef]*)
+    echo "ERROR: Invalid image digest."
+    exit 1
+    ;;
+esac
+for RUN_VALUE in "$DEPLOY_RUN_ID" "$DEPLOY_RUN_ATTEMPT"; do
+  case "$RUN_VALUE" in
+    ""|*[!0123456789]*)
+      echo "ERROR: Invalid deployment run identity."
+      exit 1
+      ;;
+  esac
+done
+
+PHYSICAL_HOME="$(cd "$HOME" && pwd -P)"
+PROJECT_DIR="$PHYSICAL_HOME/$PROJECT_NAME"
+EXPECTED_ORIGIN="https://github.com/$REPOSITORY"
+IMAGE_REPOSITORY="$(
+  printf '%s' "ghcr.io/$REPOSITORY" | tr '[:upper:]' '[:lower:]'
+)"
+IMAGE_NAME="${IMAGE_REPOSITORY}@${IMAGE_DIGEST}"
+PROJECT_SLUG="$(
+  printf '%s' "$PROJECT_NAME" | tr '[:upper:].' '[:lower:]-'
+)"
+if [ "${#PROJECT_SLUG}" -gt 45 ]; then
+  PROJECT_HASH="$(
+    printf '%s' "$PROJECT_NAME" | sha256sum | cut -c1-8
+  )"
+  PROJECT_SLUG="$(printf '%.45s-%s' "$PROJECT_SLUG" "$PROJECT_HASH")"
+fi
+DEPLOY_PROJECT="adk-$PROJECT_SLUG"
+STATE_DIR="$PHYSICAL_HOME/.local/state/$PROJECT_SLUG/deployment"
+RELEASE_DIR="$PROJECT_DIR.release-$DEPLOY_RUN_ID-$DEPLOY_RUN_ATTEMPT"
+LEASE_DIR="$RELEASE_DIR.lease"
+OWNER_FILE="$LEASE_DIR/owner"
+LOCK_FILE="$LEASE_DIR/lock"
+
+git_safe() {
+  env -i \
+    "HOME=$PHYSICAL_HOME" \
+    "PATH=$PATH" \
+    LANG=C \
+    LC_ALL=C \
+    GIT_CONFIG_NOSYSTEM=1 \
+    GIT_CONFIG_GLOBAL=/dev/null \
+    GIT_CONFIG_SYSTEM=/dev/null \
+    GIT_TEMPLATE_DIR=/dev/null \
+    GIT_NO_REPLACE_OBJECTS=1 \
+    GIT_TERMINAL_PROMPT=0 \
+    git \
+      -c core.hooksPath=/dev/null \
+      -c core.fsmonitor=false \
+      "$@"
+}
+
+if [ ! -e "$LEASE_DIR" ] \
+  && [ ! -L "$LEASE_DIR" ] \
+  && [ ! -e "$RELEASE_DIR" ] \
+  && [ ! -L "$RELEASE_DIR" ]
+then
+  exit 0
+fi
+if [ ! -d "$LEASE_DIR" ] || [ -L "$LEASE_DIR" ]; then
+  echo "ERROR: Release lease is unavailable."
+  exit 1
+fi
+env -i \
+  "HOME=$PHYSICAL_HOME" \
+  "PATH=$PATH" \
+  LANG=C \
+  LC_ALL=C \
+  python3 -I -S -B -c '
+import os
+import stat
+import sys
+
+lease, owner, lock = sys.argv[1:]
+for path, mode, directory in (
+    (lease, 0o700, True),
+    (owner, 0o600, False),
+    (lock, 0o600, False),
+):
+    metadata = os.lstat(path)
+    expected_type = stat.S_ISDIR if directory else stat.S_ISREG
+    if (
+        not expected_type(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or stat.S_IMODE(metadata.st_mode) != mode
+        or (not directory and metadata.st_nlink != 1)
+    ):
+        raise SystemExit("ERROR: Release lease metadata is unsafe.")
+' "$LEASE_DIR" "$OWNER_FILE" "$LOCK_FILE"
+exec 9< "$LOCK_FILE"
+if ! flock -n 9; then
+  echo "ERROR: Release controller still holds the lease."
+  exit 1
+fi
+{
+  IFS= read -r OWNER_SHA
+  IFS= read -r OWNER_PROJECT
+  IFS= read -r OWNER_RELEASE
+  IFS= read -r OWNER_ORIGIN
+  IFS= read -r OWNER_IMAGE
+  IFS= read -r OWNER_COMPOSE
+  IFS= read -r OWNER_STATE
+  if IFS= read -r OWNER_EXTRA; then
+    exit 1
+  fi
+} < "$OWNER_FILE"
+if [ "$OWNER_SHA" != "$DEPLOY_SHA" ] \
+  || [ "$OWNER_PROJECT" != "$PROJECT_DIR" ] \
+  || [ "$OWNER_RELEASE" != "$RELEASE_DIR" ] \
+  || [ "$OWNER_ORIGIN" != "$EXPECTED_ORIGIN" ] \
+  || [ "$OWNER_IMAGE" != "$IMAGE_NAME" ] \
+  || [ "$OWNER_COMPOSE" != "$DEPLOY_PROJECT" ] \
+  || [ "$OWNER_STATE" != "$STATE_DIR" ]
+then
+  echo "ERROR: Release ownership marker does not match."
+  exit 1
+fi
+if ! git_safe -C "$PROJECT_DIR" worktree list --porcelain \
+  | grep -Fqx -- "worktree $RELEASE_DIR"
+then
+  if [ ! -e "$RELEASE_DIR" ] && [ ! -L "$RELEASE_DIR" ]; then
+    rm -f -- "$OWNER_FILE" "$LOCK_FILE"
+    rmdir "$LEASE_DIR"
+    exit 0
+  fi
+  echo "ERROR: Exact release worktree is not registered."
+  exit 1
+fi
+if [ "$(git_safe -C "$RELEASE_DIR" rev-parse --verify HEAD)" != "$DEPLOY_SHA" ] \
+  || git_safe -C "$RELEASE_DIR" symbolic-ref -q HEAD >/dev/null
+then
+  echo "ERROR: Exact detached release identity does not match."
+  exit 1
+fi
+if ! git_safe -C "$RELEASE_DIR" diff \
+  --no-ext-diff --no-textconv --quiet --
+then
+  echo "ERROR: Exact release worktree has tracked changes."
+  exit 1
+fi
+if ! git_safe -C "$RELEASE_DIR" diff \
+  --cached --no-ext-diff --no-textconv --quiet --
+then
+  echo "ERROR: Exact release worktree has staged changes."
+  exit 1
+fi
+RELEASE_STATUS="$(
+  git_safe -C "$RELEASE_DIR" status \
+    --porcelain=v1 \
+    --untracked-files=all \
+    --ignored=matching
+)"
+if [ -n "$RELEASE_STATUS" ]; then
+  echo "ERROR: Exact release worktree is not exact-clean."
+  exit 1
+fi
+git_safe -C "$PROJECT_DIR" worktree remove "$RELEASE_DIR"
+rm -f -- "$OWNER_FILE" "$LOCK_FILE"
+rmdir "$LEASE_DIR"

--- a/src/agent/compose_env.py
+++ b/src/agent/compose_env.py
@@ -51,6 +51,61 @@ def serialize_compose_environment(
     return "\n".join(lines) + "\n"
 
 
+def parse_compose_environment(
+    payload: str,
+    names: Sequence[str],
+) -> dict[str, str]:
+    """Invert the canonical serializer for one exact ordered allowlist."""
+    if not names:
+        raise ComposeEnvironmentError("at least one environment key is required")
+
+    seen_names: set[str] = set()
+    for name in names:
+        if _ENVIRONMENT_KEY.fullmatch(name) is None:
+            raise ComposeEnvironmentError("environment key is invalid")
+        if name in seen_names:
+            raise ComposeEnvironmentError(f"environment key is duplicated: {name}")
+        seen_names.add(name)
+
+    if not payload.endswith("\n") or "\0" in payload or "\r" in payload:
+        raise ComposeEnvironmentError("serialized environment is invalid")
+    lines = payload.split("\n")
+    if len(lines) != len(names) + 1:
+        raise ComposeEnvironmentError("serialized environment is invalid")
+
+    environment: dict[str, str] = {}
+    for name, line in zip(names, lines[:-1], strict=True):
+        prefix = f'{name}="'
+        if not line.startswith(prefix) or not line.endswith('"'):
+            raise ComposeEnvironmentError("serialized environment is invalid")
+
+        encoded = line[len(prefix) : -1]
+        decoded: list[str] = []
+        index = 0
+        while index < len(encoded):
+            character = encoded[index]
+            if character == "\\":
+                index += 1
+                if index >= len(encoded):
+                    raise ComposeEnvironmentError("serialized environment is invalid")
+                decoded.append(encoded[index])
+            elif character == "$":
+                index += 1
+                if index >= len(encoded) or encoded[index] != "$":
+                    raise ComposeEnvironmentError("serialized environment is invalid")
+                decoded.append("$")
+            elif character == '"':
+                raise ComposeEnvironmentError("serialized environment is invalid")
+            else:
+                decoded.append(character)
+            index += 1
+        environment[name] = "".join(decoded)
+
+    if serialize_compose_environment(names, environment) != payload:
+        raise ComposeEnvironmentError("serialized environment is invalid")
+    return environment
+
+
 def write_compose_environment(
     path: Path,
     names: Sequence[str],

--- a/src/agent/deployment_adoption.py
+++ b/src/agent/deployment_adoption.py
@@ -25,6 +25,13 @@ _IMAGE_REFERENCE = re.compile(
 )
 _GITHUB_ORIGIN = re.compile(r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\Z")
 _MAX_OUTPUT_BYTES = 256 * 1024
+_HOST_ENVIRONMENT_NAMES = (
+    "HOME",
+    "PATH",
+    "DOCKER_CONFIG",
+    "DOCKER_HOST",
+    "XDG_RUNTIME_DIR",
+)
 
 
 class DeploymentAdoptionError(RuntimeError):
@@ -74,12 +81,19 @@ def _command_environment(
 ) -> dict[str, str]:
     source = os.environ if environment is None else environment
     selected = {
-        key: value
-        for key, value in source.items()
-        if not key.startswith("GIT_") and key not in {"LC_ALL", "LANG"}
+        name: source[name] for name in _HOST_ENVIRONMENT_NAMES if name in source
     }
     selected.update(
         {
+            "GIT_CONFIG_COUNT": "2",
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+            "GIT_CONFIG_KEY_0": "core.hooksPath",
+            "GIT_CONFIG_KEY_1": "core.fsmonitor",
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_NO_REPLACE_OBJECTS": "1",
+            "GIT_CONFIG_VALUE_0": "/dev/null",
+            "GIT_CONFIG_VALUE_1": "false",
             "GIT_OPTIONAL_LOCKS": "0",
             "GIT_TERMINAL_PROMPT": "0",
             "LC_ALL": "C",
@@ -231,8 +245,25 @@ def _git_facts(
         raise DeploymentAdoptionError("legacy checkout origin does not match")
 
     for arguments in (
-        ["-C", str(checkout), "diff", "--quiet", "--"],
-        ["-C", str(checkout), "diff", "--cached", "--quiet", "--"],
+        [
+            "-C",
+            str(checkout),
+            "diff",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--quiet",
+            "--",
+        ],
+        [
+            "-C",
+            str(checkout),
+            "diff",
+            "--cached",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--quiet",
+            "--",
+        ],
     ):
         result = _run(
             git,

--- a/src/agent/deployment_promotion.py
+++ b/src/agent/deployment_promotion.py
@@ -1,0 +1,1895 @@
+"""Lock-held promotion of one exact image with verified rollback."""
+
+from __future__ import annotations
+
+import argparse
+import errno
+import fcntl
+import hashlib
+import json
+import os
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import uuid
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path, PurePosixPath
+from typing import BinaryIO, Final
+
+from agent.compose_env import (
+    ComposeEnvironmentError,
+    parse_compose_environment,
+    write_compose_environment,
+)
+from agent.deployment_adoption import (
+    DeploymentAdoptionError,
+    DeploymentObservation,
+    observe_legacy_deployment,
+)
+from agent.deployment_state import (
+    CandidateReceipt,
+    CurrentDeployment,
+    DeploymentLockBusyError,
+    DeploymentState,
+    DeploymentStateError,
+    DeploymentStateStore,
+    DeploymentStateTransaction,
+    DeploymentTerminalCommittedError,
+    DeploymentTerminalIndeterminateError,
+    PendingPromotion,
+    PersistentVolumeIdentity,
+)
+
+PRODUCTION_ENVIRONMENT_NAMES: Final = (
+    "AGENT_NAME",
+    "DATABASE_URL",
+    "OPENROUTER_API_KEY",
+    "GOOGLE_API_KEY",
+    "ROOT_AGENT_MODEL",
+    "LANGFUSE_PUBLIC_KEY",
+    "LANGFUSE_SECRET_KEY",
+    "LANGFUSE_BASE_URL",
+    "LOG_LEVEL",
+    "PORT",
+    "HOST",
+)
+
+_CANDIDATE_ENVIRONMENT_NAMES: Final = (
+    "AGENT_NAME",
+    "ROOT_AGENT_MODEL",
+    "LOG_LEVEL",
+    "TELEMETRY_NAMESPACE",
+    "K_REVISION",
+    "CANDIDATE_ENV_CANARY",
+)
+_HOST_ENVIRONMENT_NAMES: Final = (
+    "HOME",
+    "PATH",
+    "DOCKER_CONFIG",
+    "DOCKER_HOST",
+    "XDG_RUNTIME_DIR",
+)
+_MAX_SERIALIZED_ENVIRONMENT_BYTES: Final = 64 * 1024
+_COMPOSE_NAME = re.compile(r"[a-z0-9][a-z0-9_-]{0,62}\Z")
+_REVISION = re.compile(r"[0-9a-f]{40}\Z")
+_IMAGE_ID = re.compile(r"sha256:[0-9a-f]{64}\Z")
+_CONTAINER_ID = re.compile(r"[0-9a-f]{64}\Z")
+_CONTROLLER_TRANSACTION_ID = re.compile(
+    r"[0-9a-f]{23}-(?P<baseline_revision>[0-9a-f]{40})\Z"
+)
+_REPOSITORY_COMPONENT = r"[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*"
+_REGISTRY_LABEL = r"[a-z0-9](?:[a-z0-9-]*[a-z0-9])?"
+_IMAGE_REFERENCE = re.compile(
+    rf"(?=.{{1,255}}@sha256:)"
+    rf"(?:{_REGISTRY_LABEL}(?:\.{_REGISTRY_LABEL})*(?::[0-9]{{1,5}})?/)?"
+    rf"{_REPOSITORY_COMPONENT}(?:/{_REPOSITORY_COMPONENT})*"
+    r"@sha256:[0-9a-f]{64}\Z"
+)
+_EXPECTED_ORIGIN = re.compile(r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\Z")
+_VOLUME_CREATED_AT = re.compile(
+    r"[0-9]{4}-[0-9]{2}-[0-9]{2}T"
+    r"[0-9]{2}:[0-9]{2}:[0-9]{2}"
+    r"(?:\.[0-9]{1,9})?(?:Z|[+-][0-9]{2}:[0-9]{2})\Z"
+)
+_MAX_COMMAND_OUTPUT_BYTES: Final = 256 * 1024
+_MAX_VOLUME_FIELD_BYTES: Final = 4096
+_COMMAND_TIMEOUT_SECONDS: Final = 240
+
+
+class PromotionError(RuntimeError):
+    """Report a deterministic, secret-free promotion failure."""
+
+
+class PromotionRolledBackError(PromotionError):
+    """Report a failed promotion whose exact baseline was restored."""
+
+
+class PromotionRecoveryRequiredError(PromotionError):
+    """Report completed recovery that deliberately requires a fresh invocation."""
+
+
+class PromotionRecoveryFailedError(PromotionError):
+    """Report recovery that could not prove the recorded baseline."""
+
+
+@dataclass(frozen=True, slots=True)
+class PromotionConfig:
+    """Validated host paths and immutable promotion identity."""
+
+    state_dir: Path
+    checkout: Path
+    release_checkout: Path
+    expected_origin: str
+    compose_project: str
+    compose_service: str
+    source_revision: str
+    image_reference: str
+    adopt_existing: bool
+
+
+@dataclass(frozen=True, slots=True)
+class Executables:
+    """Resolved external command boundaries."""
+
+    git: Path
+    docker: Path
+
+
+@dataclass(frozen=True, slots=True)
+class ImageProof:
+    """Locally observed immutable image identity."""
+
+    image_reference: str
+    image_id: str
+    oci_revision: str
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class VolumeProof:
+    """Runtime and daemon fields that detect replacement of a named volume."""
+
+    name: str
+    driver: str
+    destination: str
+    mountpoint: str
+    created_at: str
+
+    def recorded_identity(self) -> PersistentVolumeIdentity:
+        """Return the complete durable daemon and mount identity."""
+        return PersistentVolumeIdentity(
+            name=self.name,
+            driver=self.driver,
+            mountpoint=self.mountpoint,
+            destination=self.destination,
+            created_at=self.created_at,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeProof:
+    """One independently observed healthy Compose service."""
+
+    observation: DeploymentObservation
+    container_id: str
+    volumes: tuple[VolumeProof, ...]
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def _validated_config(config: PromotionConfig) -> PromotionConfig:
+    for path, field in (
+        (config.state_dir, "state directory"),
+        (config.checkout, "production checkout"),
+        (config.release_checkout, "release checkout"),
+    ):
+        if not path.is_absolute() or path != path.resolve(strict=False):
+            raise PromotionError(f"{field} must be an absolute normalized path")
+    if config.checkout == config.release_checkout:
+        raise PromotionError("production and release checkouts must be distinct")
+    for path, field in (
+        (config.checkout, "production checkout"),
+        (config.release_checkout, "release checkout"),
+    ):
+        try:
+            metadata = path.stat()
+        except OSError:
+            raise PromotionError(f"{field} is unavailable") from None
+        if not stat.S_ISDIR(metadata.st_mode):
+            raise PromotionError(f"{field} is not a directory")
+    if _EXPECTED_ORIGIN.fullmatch(
+        config.expected_origin
+    ) is None or config.expected_origin.endswith(".git"):
+        raise PromotionError("expected origin is invalid")
+    for value, field in (
+        (config.compose_project, "Compose project"),
+        (config.compose_service, "Compose service"),
+    ):
+        if _COMPOSE_NAME.fullmatch(value) is None:
+            raise PromotionError(f"{field} is invalid")
+    if _REVISION.fullmatch(config.source_revision) is None:
+        raise PromotionError("source revision is invalid")
+    if _IMAGE_REFERENCE.fullmatch(config.image_reference) is None:
+        raise PromotionError("image reference is not an immutable digest")
+    return config
+
+
+def _command_environment(source: Mapping[str, str]) -> dict[str, str]:
+    selected = {
+        name: source[name] for name in _HOST_ENVIRONMENT_NAMES if name in source
+    }
+    selected.update(
+        {
+            "COMPOSE_DISABLE_ENV_FILE": "1",
+            "GIT_CONFIG_COUNT": "2",
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+            "GIT_CONFIG_KEY_0": "core.hooksPath",
+            "GIT_CONFIG_KEY_1": "core.fsmonitor",
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_NO_REPLACE_OBJECTS": "1",
+            "GIT_CONFIG_VALUE_0": "/dev/null",
+            "GIT_CONFIG_VALUE_1": "false",
+            "GIT_OPTIONAL_LOCKS": "0",
+            "GIT_TERMINAL_PROMPT": "0",
+            "LANG": "C",
+            "LC_ALL": "C",
+        }
+    )
+    return selected
+
+
+def _resolve_executable(name: str, environment: Mapping[str, str]) -> Path:
+    resolved = shutil.which(name, path=environment.get("PATH"))
+    if resolved is None:
+        raise PromotionError(f"required executable is unavailable: {name}")
+    path = Path(resolved)
+    try:
+        canonical = path.resolve(strict=True)
+        metadata = canonical.stat()
+    except OSError:
+        raise PromotionError(f"required executable is unavailable: {name}") from None
+    if not canonical.is_absolute() or not stat.S_ISREG(metadata.st_mode):
+        raise PromotionError(f"required executable is invalid: {name}")
+    return canonical
+
+
+def _run(
+    executable: Path,
+    arguments: Sequence[str],
+    *,
+    environment: Mapping[str, str],
+    cwd: Path | None = None,
+    accepted_returncodes: frozenset[int] = frozenset({0}),
+    timeout: int = _COMMAND_TIMEOUT_SECONDS,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        result = subprocess.run(  # noqa: S603 - resolved executable, bounded args
+            [str(executable), *arguments],
+            cwd=cwd,
+            env=environment,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        raise PromotionError("deployment command failed") from None
+    if result.returncode not in accepted_returncodes:
+        raise PromotionError("deployment command failed")
+    if (
+        len(result.stdout.encode()) > _MAX_COMMAND_OUTPUT_BYTES
+        or len(result.stderr.encode()) > _MAX_COMMAND_OUTPUT_BYTES
+    ):
+        raise PromotionError("deployment command output is too large")
+    return result
+
+
+def _one_line(value: str, field: str) -> str:
+    selected = value[:-1] if value.endswith("\n") else value
+    if not selected or any(character in selected for character in "\0\r\n"):
+        raise PromotionError(f"deployment command output is invalid: {field}")
+    return selected
+
+
+def _json_object(value: str, field: str) -> dict[str, object]:
+    try:
+        decoded = json.loads(value)
+    except json.JSONDecodeError:
+        raise PromotionError(f"deployment command output is invalid: {field}") from None
+    if not isinstance(decoded, list) or len(decoded) != 1:
+        raise PromotionError(f"deployment command output is invalid: {field}")
+    selected = decoded[0]
+    if not isinstance(selected, dict):
+        raise PromotionError(f"deployment command output is invalid: {field}")
+    return selected
+
+
+def _mapping(
+    document: Mapping[str, object],
+    key: str,
+    field: str,
+) -> Mapping[str, object]:
+    value = document.get(key)
+    if not isinstance(value, dict):
+        raise PromotionError(f"deployment command output is invalid: {field}")
+    return value
+
+
+def _string(
+    document: Mapping[str, object],
+    key: str,
+    field: str,
+) -> str:
+    value = document.get(key)
+    if not isinstance(value, str):
+        raise PromotionError(f"deployment command output is invalid: {field}")
+    return value
+
+
+def _git_line(
+    executables: Executables,
+    checkout: Path,
+    arguments: Sequence[str],
+    environment: Mapping[str, str],
+    field: str,
+) -> str:
+    return _one_line(
+        _run(
+            executables.git,
+            ["-C", str(checkout), *arguments],
+            environment=environment,
+        ).stdout,
+        field,
+    )
+
+
+def _validate_release_checkout(
+    config: PromotionConfig,
+    executables: Executables,
+    environment: Mapping[str, str],
+) -> None:
+    root_value = _git_line(
+        executables,
+        config.release_checkout,
+        ["rev-parse", "--show-toplevel"],
+        environment,
+        "release root",
+    )
+    try:
+        root = Path(root_value).resolve(strict=True)
+    except OSError:
+        raise PromotionError("release checkout root is unavailable") from None
+    if root != config.release_checkout:
+        raise PromotionError("release checkout root does not match")
+    origin = _git_line(
+        executables,
+        config.release_checkout,
+        ["remote", "get-url", "origin"],
+        environment,
+        "release origin",
+    )
+    if origin not in {config.expected_origin, f"{config.expected_origin}.git"}:
+        raise PromotionError("release checkout origin does not match")
+    revision = _git_line(
+        executables,
+        config.release_checkout,
+        ["rev-parse", "--verify", "HEAD"],
+        environment,
+        "release revision",
+    )
+    if revision != config.source_revision:
+        raise PromotionError("release checkout revision does not match")
+    for arguments in (
+        ["diff", "--no-ext-diff", "--no-textconv", "--quiet", "--"],
+        [
+            "diff",
+            "--cached",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--quiet",
+            "--",
+        ],
+    ):
+        result = _run(
+            executables.git,
+            ["-C", str(config.release_checkout), *arguments],
+            environment=environment,
+            accepted_returncodes=frozenset({0, 1}),
+        )
+        if result.returncode == 1:
+            raise PromotionError("release checkout has tracked changes")
+    status = _run(
+        executables.git,
+        [
+            "-C",
+            str(config.release_checkout),
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+            "--ignored=matching",
+        ],
+        environment=environment,
+    )
+    if status.stdout:
+        raise PromotionError("release checkout contains untracked or ignored files")
+    _run(
+        executables.git,
+        [
+            "-C",
+            str(config.release_checkout),
+            "ls-files",
+            "--error-unmatch",
+            "--",
+            "compose.yaml",
+            "compose.candidate.yaml",
+            "src/agent/deployment_promotion.py",
+        ],
+        environment=environment,
+    )
+
+
+def _validate_production_checkout(
+    config: PromotionConfig,
+    executables: Executables,
+    environment: Mapping[str, str],
+) -> None:
+    root_value = _git_line(
+        executables,
+        config.checkout,
+        ["rev-parse", "--show-toplevel"],
+        environment,
+        "production root",
+    )
+    try:
+        root = Path(root_value).resolve(strict=True)
+    except OSError:
+        raise PromotionError("production checkout root is unavailable") from None
+    if root != config.checkout:
+        raise PromotionError("production checkout root does not match")
+    origin = _git_line(
+        executables,
+        config.checkout,
+        ["remote", "get-url", "origin"],
+        environment,
+        "production origin",
+    )
+    if origin not in {config.expected_origin, f"{config.expected_origin}.git"}:
+        raise PromotionError("production checkout origin does not match")
+    for arguments in (
+        ["diff", "--no-ext-diff", "--no-textconv", "--quiet", "--"],
+        [
+            "diff",
+            "--cached",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--quiet",
+            "--",
+        ],
+    ):
+        result = _run(
+            executables.git,
+            ["-C", str(config.checkout), *arguments],
+            environment=environment,
+            accepted_returncodes=frozenset({0, 1}),
+        )
+        if result.returncode == 1:
+            raise PromotionError("production checkout has tracked changes")
+
+
+def _validate_pending_ownership(
+    *,
+    pending: PendingPromotion,
+    current: CurrentDeployment | None,
+    config: PromotionConfig,
+    executables: Executables,
+    environment: Mapping[str, str],
+) -> None:
+    target = pending.intent.target
+    if (
+        target.compose_project != config.compose_project
+        or target.compose_service != config.compose_service
+    ):
+        raise PromotionError("pending promotion Compose identity does not match")
+    checkout_revision = _git_line(
+        executables,
+        config.checkout,
+        ["rev-parse", "--verify", "HEAD"],
+        environment,
+        "pending production revision",
+    )
+    if _REVISION.fullmatch(checkout_revision) is None:
+        raise PromotionError("pending production checkout revision is invalid")
+    allowed_revisions = {target.source_revision}
+    if current is not None:
+        if (
+            current.state.compose_project != config.compose_project
+            or current.state.compose_service != config.compose_service
+        ):
+            raise PromotionError("pending baseline Compose identity does not match")
+        allowed_revisions.add(current.state.source_revision)
+    else:
+        allowed_revisions.add(_transaction_baseline_revision(pending))
+    if checkout_revision not in allowed_revisions:
+        raise PromotionError("pending production checkout ownership does not match")
+    ids = _container_ids(
+        project=config.compose_project,
+        service=config.compose_service,
+        executables=executables,
+        environment=environment,
+    )
+    if len(ids) > 1:
+        raise PromotionError("pending production deployment is ambiguous")
+    if not ids:
+        return
+    document = _json_object(
+        _run(
+            executables.docker,
+            ["container", "inspect", ids[0]],
+            environment=environment,
+        ).stdout,
+        "pending production container",
+    )
+    full_id = _string(document, "Id", "pending production container ID")
+    config_document = _mapping(
+        document,
+        "Config",
+        "pending production container configuration",
+    )
+    labels = _mapping(
+        config_document,
+        "Labels",
+        "pending production container labels",
+    )
+    allowed_images = {
+        (target.image_reference, target.image_id),
+    }
+    if current is not None:
+        allowed_images.add(
+            (current.state.image_reference, current.state.image_id),
+        )
+    if (
+        _CONTAINER_ID.fullmatch(full_id) is None
+        or not full_id.startswith(ids[0])
+        or labels.get("com.docker.compose.project") != config.compose_project
+        or labels.get("com.docker.compose.service") != config.compose_service
+        or labels.get("com.docker.compose.project.working_dir") != str(config.checkout)
+        or (config_document.get("Image"), document.get("Image")) not in allowed_images
+    ):
+        raise PromotionError("pending production container ownership does not match")
+
+
+def _inspect_image(
+    *,
+    proof_reference: str,
+    expected_revision: str,
+    executables: Executables,
+    environment: Mapping[str, str],
+) -> ImageProof:
+    document = _json_object(
+        _run(
+            executables.docker,
+            ["image", "inspect", proof_reference],
+            environment=environment,
+        ).stdout,
+        "image",
+    )
+    image_id = _string(document, "Id", "image ID")
+    if _IMAGE_ID.fullmatch(image_id) is None:
+        raise PromotionError("local image ID is invalid")
+    repo_digests = document.get("RepoDigests")
+    if (
+        not isinstance(repo_digests, list)
+        or not all(isinstance(value, str) for value in repo_digests)
+        or proof_reference not in repo_digests
+    ):
+        raise PromotionError("local image digest does not match")
+    config = _mapping(document, "Config", "image configuration")
+    labels = _mapping(config, "Labels", "image labels")
+    oci_revision = labels.get("org.opencontainers.image.revision")
+    if oci_revision != expected_revision:
+        raise PromotionError("image OCI revision does not match")
+    return ImageProof(
+        image_reference=proof_reference,
+        image_id=image_id,
+        oci_revision=expected_revision,
+    )
+
+
+def _pull_and_prove_image(
+    config: PromotionConfig,
+    executables: Executables,
+    environment: Mapping[str, str],
+) -> ImageProof:
+    _run(
+        executables.docker,
+        ["image", "pull", config.image_reference],
+        environment=environment,
+    )
+    return _inspect_image(
+        proof_reference=config.image_reference,
+        expected_revision=config.source_revision,
+        executables=executables,
+        environment=environment,
+    )
+
+
+def _container_ids(
+    *,
+    project: str,
+    service: str,
+    executables: Executables,
+    environment: Mapping[str, str],
+) -> tuple[str, ...]:
+    result = _run(
+        executables.docker,
+        [
+            "container",
+            "ls",
+            "--all",
+            "--filter",
+            f"label=com.docker.compose.project={project}",
+            "--filter",
+            f"label=com.docker.compose.service={service}",
+            "--format",
+            "{{.ID}}",
+        ],
+        environment=environment,
+    )
+    values = tuple(line for line in result.stdout.splitlines() if line)
+    if any(
+        not (12 <= len(value) <= 64) or re.fullmatch(r"[0-9a-f]+", value) is None
+        for value in values
+    ):
+        raise PromotionError("Compose container list is invalid")
+    return values
+
+
+def _volume_proofs(
+    *,
+    mounts: object,
+    executables: Executables,
+    environment: Mapping[str, str],
+) -> tuple[VolumeProof, ...]:
+    if not isinstance(mounts, list):
+        raise PromotionError("container mount observation is invalid")
+    selected: list[VolumeProof] = []
+    for raw_mount in mounts:
+        if not isinstance(raw_mount, dict):
+            raise PromotionError("container mount observation is invalid")
+        if raw_mount.get("Type") != "volume":
+            continue
+        name = _string(raw_mount, "Name", "volume name")
+        destination = _string(raw_mount, "Destination", "volume destination")
+        driver = _string(raw_mount, "Driver", "volume driver")
+        if (
+            not name
+            or not driver
+            or not destination.startswith("/")
+            or destination == "/"
+            or str(PurePosixPath(destination)) != destination
+        ):
+            raise PromotionError("named volume mount identity is invalid")
+        document = _json_object(
+            _run(
+                executables.docker,
+                ["volume", "inspect", name],
+                environment=environment,
+            ).stdout,
+            "volume",
+        )
+        if (
+            _string(document, "Name", "volume name") != name
+            or _string(document, "Driver", "volume driver") != driver
+        ):
+            raise PromotionError("named volume daemon identity does not match")
+        mountpoint = _string(document, "Mountpoint", "volume mountpoint")
+        raw_created_at = _string(document, "CreatedAt", "volume creation time")
+        if (
+            not mountpoint.startswith("/")
+            or mountpoint == "/"
+            or str(PurePosixPath(mountpoint)) != mountpoint
+            or len(mountpoint.encode()) > _MAX_VOLUME_FIELD_BYTES
+            or not raw_created_at
+            or len(raw_created_at.encode()) > _MAX_VOLUME_FIELD_BYTES
+        ):
+            raise PromotionError("named volume daemon identity is invalid")
+        try:
+            parsed_created_at = datetime.fromisoformat(
+                raw_created_at.replace("Z", "+00:00")
+            )
+        except ValueError:
+            raise PromotionError("named volume creation time is invalid") from None
+        if (
+            _VOLUME_CREATED_AT.fullmatch(raw_created_at) is None
+            or parsed_created_at.tzinfo is None
+        ):
+            raise PromotionError("named volume creation time is invalid")
+        selected.append(
+            VolumeProof(
+                name=name,
+                driver=driver,
+                destination=destination,
+                mountpoint=mountpoint,
+                created_at=raw_created_at,
+            )
+        )
+    result = tuple(sorted(selected))
+    if len({value.name for value in result}) != len(result) or len(
+        {value.destination for value in result}
+    ) != len(result):
+        raise PromotionError("named volume mount identities are ambiguous")
+    return result
+
+
+def _inspect_container(
+    *,
+    container_id: str,
+    expected_checkout: Path,
+    expected_project: str,
+    expected_service: str,
+    image: ImageProof,
+    executables: Executables,
+    environment: Mapping[str, str],
+    require_no_mounts: bool = False,
+) -> tuple[str, tuple[VolumeProof, ...]]:
+    document = _json_object(
+        _run(
+            executables.docker,
+            ["container", "inspect", container_id],
+            environment=environment,
+        ).stdout,
+        "container",
+    )
+    full_id = _string(document, "Id", "container ID")
+    if _CONTAINER_ID.fullmatch(full_id) is None or not full_id.startswith(container_id):
+        raise PromotionError("container identity is invalid")
+    state = _mapping(document, "State", "container state")
+    health = _mapping(state, "Health", "container health")
+    if state.get("Status") != "running" or health.get("Status") != "healthy":
+        raise PromotionError("container is not running and healthy")
+    config = _mapping(document, "Config", "container configuration")
+    if (
+        config.get("Image") != image.image_reference
+        or document.get("Image") != image.image_id
+    ):
+        raise PromotionError("container image identity does not match")
+    labels = _mapping(config, "Labels", "container labels")
+    expected_labels = {
+        "com.docker.compose.project": expected_project,
+        "com.docker.compose.service": expected_service,
+        "com.docker.compose.project.working_dir": str(expected_checkout),
+    }
+    if any(labels.get(name) != value for name, value in expected_labels.items()):
+        raise PromotionError("container Compose labels do not match")
+    mounts = document.get("Mounts")
+    if require_no_mounts:
+        host_config = _mapping(document, "HostConfig", "candidate host configuration")
+        restart_policy = _mapping(
+            host_config,
+            "RestartPolicy",
+            "candidate restart policy",
+        )
+        if (
+            mounts != []
+            or config.get("User") != "1000:1000"
+            or host_config.get("NetworkMode") != "none"
+            or host_config.get("PortBindings") not in (None, {})
+            or restart_policy.get("Name") != "no"
+            or host_config.get("CapDrop") != ["ALL"]
+            or host_config.get("SecurityOpt") != ["no-new-privileges:true"]
+        ):
+            raise PromotionError("candidate isolation boundary does not match")
+    return full_id, _volume_proofs(
+        mounts=mounts,
+        executables=executables,
+        environment=environment,
+    )
+
+
+def _observe_runtime(
+    *,
+    config: PromotionConfig,
+    image: ImageProof,
+    executables: Executables,
+    environment: Mapping[str, str],
+) -> RuntimeProof | None:
+    try:
+        observation = observe_legacy_deployment(
+            checkout_path=config.checkout,
+            expected_origin=config.expected_origin,
+            compose_project=config.compose_project,
+            compose_service=config.compose_service,
+            environment_path=config.checkout / ".env",
+            git_executable=executables.git,
+            docker_executable=executables.docker,
+            environment=environment,
+        )
+    except DeploymentAdoptionError:
+        raise PromotionError("production deployment observation failed") from None
+    if observation is None:
+        return None
+    ids = _container_ids(
+        project=config.compose_project,
+        service=config.compose_service,
+        executables=executables,
+        environment=environment,
+    )
+    if len(ids) != 1:
+        raise PromotionError("production deployment is ambiguous")
+    container_id, volumes = _inspect_container(
+        container_id=ids[0],
+        expected_checkout=config.checkout,
+        expected_project=config.compose_project,
+        expected_service=config.compose_service,
+        image=image,
+        executables=executables,
+        environment=environment,
+    )
+    if (
+        observation.image_reference != image.image_reference
+        or observation.image_id != image.image_id
+        or observation.oci_revision != image.oci_revision
+    ):
+        raise PromotionError("production observation image does not match")
+    return RuntimeProof(
+        observation=observation,
+        container_id=container_id,
+        volumes=volumes,
+    )
+
+
+def _proof_from_observation(observation: DeploymentObservation) -> ImageProof:
+    return ImageProof(
+        image_reference=observation.image_reference,
+        image_id=observation.image_id,
+        oci_revision=observation.oci_revision,
+    )
+
+
+def _environment_sha256(path: Path) -> str:
+    try:
+        payload = path.read_bytes()
+    except OSError:
+        raise PromotionError("production environment could not be verified") from None
+    if not payload:
+        raise PromotionError("production environment could not be verified")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _matches_state(runtime: RuntimeProof, current: CurrentDeployment) -> bool:
+    state = current.state
+    observation = runtime.observation
+    return (
+        observation.compose_project == state.compose_project
+        and observation.compose_service == state.compose_service
+        and observation.revision == state.source_revision
+        and observation.image_reference == state.image_reference
+        and observation.image_id == state.image_id
+        and observation.oci_revision == state.oci_revision
+        and _environment_sha256(observation.environment_path)
+        == state.environment_sha256
+    )
+
+
+def _baseline(
+    *,
+    transaction: DeploymentStateTransaction,
+    config: PromotionConfig,
+    executables: Executables,
+    environment: Mapping[str, str],
+) -> tuple[CurrentDeployment | None, RuntimeProof | None, str]:
+    checkout_revision = _git_line(
+        executables,
+        config.checkout,
+        ["rev-parse", "--verify", "HEAD"],
+        environment,
+        "production revision",
+    )
+    if _REVISION.fullmatch(checkout_revision) is None:
+        raise PromotionError("production checkout revision is invalid")
+    current = transaction.current()
+    try:
+        initial = observe_legacy_deployment(
+            checkout_path=config.checkout,
+            expected_origin=config.expected_origin,
+            compose_project=config.compose_project,
+            compose_service=config.compose_service,
+            environment_path=config.checkout / ".env",
+            git_executable=executables.git,
+            docker_executable=executables.docker,
+            environment=environment,
+        )
+    except DeploymentAdoptionError:
+        raise PromotionError("production deployment observation failed") from None
+    if initial is None:
+        if current is not None:
+            raise PromotionError("recorded production deployment is unavailable")
+        if (config.checkout / ".env").exists():
+            raise PromotionError("unrecorded production environment blocks install")
+        return None, None, checkout_revision
+
+    image = _proof_from_observation(initial)
+    runtime = _observe_runtime(
+        config=config,
+        image=image,
+        executables=executables,
+        environment=environment,
+    )
+    if runtime is None:
+        raise PromotionError("production deployment disappeared during observation")
+    if current is None:
+        if not config.adopt_existing:
+            raise PromotionError("running production deployment is not recorded")
+        current = transaction.adopt(
+            compose_project=initial.compose_project,
+            compose_service=initial.compose_service,
+            source_revision=initial.revision,
+            image_reference=initial.image_reference,
+            image_id=initial.image_id,
+            oci_revision=initial.oci_revision,
+            environment_source=initial.environment_path,
+        )
+    if not _matches_state(runtime, current):
+        raise PromotionError("recorded and running production deployments disagree")
+    establishing_entry = transaction.journal()[current.journal_sequence - 1]
+    if (
+        establishing_entry.event == "promoted"
+        and tuple(volume.recorded_identity() for volume in runtime.volumes)
+        != establishing_entry.persistent_volumes
+    ):
+        raise PromotionError("recorded persistent volume identity changed")
+    return current, runtime, checkout_revision
+
+
+def _candidate_environment(
+    source: Mapping[str, str],
+    source_revision: str,
+) -> dict[str, str]:
+    return {
+        "AGENT_NAME": source["AGENT_NAME"],
+        "ROOT_AGENT_MODEL": source["ROOT_AGENT_MODEL"],
+        "LOG_LEVEL": source["LOG_LEVEL"],
+        "TELEMETRY_NAMESPACE": "candidate",
+        "K_REVISION": source_revision,
+        "CANDIDATE_ENV_CANARY": uuid.uuid4().hex,
+    }
+
+
+def _new_transaction_id(baseline_revision: str) -> str:
+    """Bind the pre-cutover Git baseline into the durable transaction identity."""
+    if _REVISION.fullmatch(baseline_revision) is None:
+        raise PromotionError("promotion baseline revision is invalid")
+    return f"{uuid.uuid4().hex[:23]}-{baseline_revision}"
+
+
+def _transaction_baseline_revision(pending: PendingPromotion) -> str:
+    """Recover the exact pre-cutover Git baseline from a controller-owned intent."""
+    match = _CONTROLLER_TRANSACTION_ID.fullmatch(pending.transaction_id)
+    if match is None:
+        raise PromotionRecoveryFailedError(
+            "fresh-install pending baseline revision is unavailable"
+        )
+    return match.group("baseline_revision")
+
+
+def _compose_prefix(
+    *,
+    docker: Path,
+    project: str,
+    env_file: Path,
+    compose_file: Path,
+) -> tuple[str, ...]:
+    return (
+        str(docker),
+        "compose",
+        "--project-name",
+        project,
+        "--env-file",
+        str(env_file),
+        "-f",
+        str(compose_file),
+    )
+
+
+def _run_candidate(
+    *,
+    transaction: DeploymentStateTransaction,
+    config: PromotionConfig,
+    image: ImageProof,
+    transaction_id: str,
+    executables: Executables,
+    environment: Mapping[str, str],
+    production_environment: Mapping[str, str],
+) -> CandidateReceipt:
+    candidate_project = f"candidate-{transaction_id[:24]}"
+    candidate_compose = config.release_checkout / "compose.candidate.yaml"
+    baseline_journal = transaction.journal()
+    baseline_sequence = baseline_journal[-1].sequence if baseline_journal else None
+    baseline_sha256 = baseline_journal[-1].sha256 if baseline_journal else None
+    with tempfile.TemporaryDirectory(
+        prefix=".promotion-candidate-",
+        dir=config.state_dir,
+    ) as temporary_name:
+        temporary = Path(temporary_name)
+        candidate_env = temporary / "candidate.env"
+        write_compose_environment(
+            candidate_env,
+            _CANDIDATE_ENVIRONMENT_NAMES,
+            _candidate_environment(production_environment, config.source_revision),
+        )
+        candidate_environment = dict(environment)
+        candidate_environment.update(
+            {"ENV_FILE": str(candidate_env), "IMAGE": image.image_reference}
+        )
+        prefix = _compose_prefix(
+            docker=executables.docker,
+            project=candidate_project,
+            env_file=candidate_env,
+            compose_file=candidate_compose,
+        )
+        started = False
+        failure: Exception | None = None
+        receipt: CandidateReceipt
+        try:
+            _run(
+                executables.docker,
+                [*prefix[1:], "config", "--quiet"],
+                environment=candidate_environment,
+            )
+            started = True
+            _run(
+                executables.docker,
+                [
+                    *prefix[1:],
+                    "up",
+                    "--detach",
+                    "--no-build",
+                    "--pull",
+                    "never",
+                    "--wait",
+                    "--wait-timeout",
+                    "60",
+                    config.compose_service,
+                ],
+                environment=candidate_environment,
+            )
+            ids = _container_ids(
+                project=candidate_project,
+                service=config.compose_service,
+                executables=executables,
+                environment=environment,
+            )
+            if len(ids) != 1:
+                raise PromotionError("candidate deployment is ambiguous")
+            container_id, _volumes = _inspect_container(
+                container_id=ids[0],
+                expected_checkout=config.release_checkout,
+                expected_project=candidate_project,
+                expected_service=config.compose_service,
+                image=image,
+                executables=executables,
+                environment=environment,
+                require_no_mounts=True,
+            )
+            receipt = CandidateReceipt(
+                observed_at=_now(),
+                compose_project=candidate_project,
+                compose_service=config.compose_service,
+                container_id=container_id,
+                image_reference=image.image_reference,
+                image_id=image.image_id,
+                oci_revision=image.oci_revision,
+                baseline_journal_sequence=baseline_sequence,
+                baseline_journal_sha256=baseline_sha256,
+            )
+        except Exception as error:
+            failure = error
+        finally:
+            if started:
+                try:
+                    _run(
+                        executables.docker,
+                        [*prefix[1:], "down", "--remove-orphans"],
+                        environment=candidate_environment,
+                    )
+                    if _container_ids(
+                        project=candidate_project,
+                        service=config.compose_service,
+                        executables=executables,
+                        environment=environment,
+                    ):
+                        raise PromotionError(
+                            "candidate cleanup left a service container"
+                        )
+                except Exception as cleanup_error:
+                    failure = cleanup_error
+        if failure is not None:
+            raise failure
+        return receipt
+
+
+def _checkout_revision(
+    *,
+    checkout: Path,
+    revision: str,
+    executables: Executables,
+    environment: Mapping[str, str],
+) -> None:
+    _run(
+        executables.git,
+        [
+            "-C",
+            str(checkout),
+            "-c",
+            "advice.detachedHead=false",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            "core.fsmonitor=false",
+            "checkout",
+            "--detach",
+            revision,
+        ],
+        environment=environment,
+    )
+    actual = _git_line(
+        executables,
+        checkout,
+        ["rev-parse", "--verify", "HEAD"],
+        environment,
+        "production revision",
+    )
+    if actual != revision:
+        raise PromotionError("production checkout revision does not match")
+    for arguments in (
+        ["diff", "--no-ext-diff", "--no-textconv", "--quiet", "--"],
+        [
+            "diff",
+            "--cached",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--quiet",
+            "--",
+        ],
+    ):
+        result = _run(
+            executables.git,
+            ["-C", str(checkout), *arguments],
+            environment=environment,
+            accepted_returncodes=frozenset({0, 1}),
+        )
+        if result.returncode == 1:
+            raise PromotionError("production checkout has tracked changes")
+
+
+def _compose_up(
+    *,
+    config: PromotionConfig,
+    image_reference: str,
+    executables: Executables,
+    environment: Mapping[str, str],
+    before_up: Callable[[], None] | None = None,
+) -> None:
+    env_file = config.checkout / ".env"
+    compose_file = config.checkout / "compose.yaml"
+    compose_environment = dict(environment)
+    compose_environment.update({"ENV_FILE": str(env_file), "IMAGE": image_reference})
+    prefix = _compose_prefix(
+        docker=executables.docker,
+        project=config.compose_project,
+        env_file=env_file,
+        compose_file=compose_file,
+    )
+    configured = _run(
+        executables.docker,
+        [*prefix[1:], "config", "--images"],
+        environment=compose_environment,
+    ).stdout.splitlines()
+    if configured != [image_reference]:
+        raise PromotionError("production Compose image does not match")
+    if before_up is not None:
+        before_up()
+    _run(
+        executables.docker,
+        [
+            *prefix[1:],
+            "up",
+            "--detach",
+            "--no-build",
+            "--force-recreate",
+            "--no-deps",
+            "--pull",
+            "never",
+            "--wait",
+            "--wait-timeout",
+            "180",
+            config.compose_service,
+        ],
+        environment=compose_environment,
+    )
+
+
+def _remove_owned_service_container(
+    *,
+    target: DeploymentState,
+    config: PromotionConfig,
+    executables: Executables,
+    environment: Mapping[str, str],
+    target_environment_proven: bool,
+    verify_target_environment: Callable[[], bool],
+) -> None:
+    ids = _container_ids(
+        project=config.compose_project,
+        service=config.compose_service,
+        executables=executables,
+        environment=environment,
+    )
+    if len(ids) > 1:
+        raise PromotionRecoveryFailedError(
+            "fresh-install recovery found ambiguous service containers"
+        )
+    if not ids:
+        return
+    document = _json_object(
+        _run(
+            executables.docker,
+            ["container", "inspect", ids[0]],
+            environment=environment,
+        ).stdout,
+        "fresh-install container",
+    )
+    full_id = _string(document, "Id", "fresh-install container ID")
+    config_document = _mapping(
+        document,
+        "Config",
+        "fresh-install container configuration",
+    )
+    labels = _mapping(
+        config_document,
+        "Labels",
+        "fresh-install container labels",
+    )
+    expected_labels = {
+        "com.docker.compose.project": config.compose_project,
+        "com.docker.compose.service": config.compose_service,
+        "com.docker.compose.project.working_dir": str(config.checkout),
+    }
+    if (
+        _CONTAINER_ID.fullmatch(full_id) is None
+        or not full_id.startswith(ids[0])
+        or any(labels.get(name) != value for name, value in expected_labels.items())
+        or config_document.get("Image") != target.image_reference
+        or document.get("Image") != target.image_id
+    ):
+        raise PromotionRecoveryFailedError(
+            "fresh-install service container ownership is invalid"
+        )
+    if not target_environment_proven or not verify_target_environment():
+        raise PromotionRecoveryFailedError(
+            "fresh-install target environment is unavailable"
+        )
+    _run(
+        executables.docker,
+        ["container", "rm", "--force", full_id],
+        environment=environment,
+    )
+
+
+def _abort_fresh_install(
+    *,
+    transaction: DeploymentStateTransaction,
+    pending: PendingPromotion,
+    config: PromotionConfig,
+    executables: Executables,
+    environment: Mapping[str, str],
+    baseline_revision: str,
+) -> None:
+    environment_path = config.checkout / ".env"
+    target_environment_proven = transaction.verify_installed_environment(
+        pending.intent.target,
+        environment_path,
+        allow_missing=True,
+    )
+    _remove_owned_service_container(
+        target=pending.intent.target,
+        config=config,
+        executables=executables,
+        environment=environment,
+        target_environment_proven=target_environment_proven,
+        verify_target_environment=lambda: transaction.verify_installed_environment(
+            pending.intent.target,
+            environment_path,
+            allow_missing=True,
+        ),
+    )
+    transaction.remove_environment(pending.intent.target, environment_path)
+    actual_revision = _git_line(
+        executables,
+        config.checkout,
+        ["rev-parse", "--verify", "HEAD"],
+        environment,
+        "fresh-install recovery revision",
+    )
+    if actual_revision != baseline_revision:
+        _checkout_revision(
+            checkout=config.checkout,
+            revision=baseline_revision,
+            executables=executables,
+            environment=environment,
+        )
+    environment_still_installed = transaction.verify_installed_environment(
+        pending.intent.target,
+        environment_path,
+        allow_missing=True,
+    )
+    if environment_still_installed or _container_ids(
+        project=config.compose_project,
+        service=config.compose_service,
+        executables=executables,
+        environment=environment,
+    ):
+        raise PromotionRecoveryFailedError(
+            "fresh-install baseline could not be verified"
+        )
+    transaction.record_abort(
+        pending.transaction_id,
+        persistent_volumes=(),
+    )
+
+
+def _verify_target(
+    *,
+    transaction: DeploymentStateTransaction,
+    pending: PendingPromotion,
+    baseline_runtime: RuntimeProof | None,
+    config: PromotionConfig,
+    executables: Executables,
+    environment: Mapping[str, str],
+) -> RuntimeProof:
+    image = ImageProof(
+        image_reference=pending.intent.target.image_reference,
+        image_id=pending.intent.target.image_id,
+        oci_revision=pending.intent.target.oci_revision,
+    )
+    runtime = _observe_runtime(
+        config=config,
+        image=image,
+        executables=executables,
+        environment=environment,
+    )
+    if runtime is None:
+        raise PromotionError("promoted production deployment is unavailable")
+    target = pending.intent.target
+    if (
+        runtime.observation.revision != target.source_revision
+        or _environment_sha256(runtime.observation.environment_path)
+        != target.environment_sha256
+    ):
+        raise PromotionError("promoted production deployment does not match intent")
+    if baseline_runtime is not None and runtime.volumes != baseline_runtime.volumes:
+        raise PromotionError("persistent volume identity changed during promotion")
+    if baseline_runtime is None and not runtime.volumes:
+        raise PromotionError("first production install has no persistent volume")
+    recorded = tuple(volume.recorded_identity() for volume in runtime.volumes)
+    if baseline_runtime is not None and recorded != pending.intent.persistent_volumes:
+        raise PromotionError("persistent volume intent does not match runtime")
+    transaction.read_environment(target)
+    return runtime
+
+
+def _restore_baseline(
+    *,
+    transaction: DeploymentStateTransaction,
+    pending: PendingPromotion,
+    current: CurrentDeployment | None,
+    baseline_runtime: RuntimeProof | None,
+    config: PromotionConfig,
+    executables: Executables,
+    environment: Mapping[str, str],
+) -> RuntimeProof:
+    if current is None:
+        raise PromotionRecoveryFailedError(
+            "automatic recovery has no recorded production baseline"
+        )
+    state = current.state
+    image = _inspect_image(
+        proof_reference=state.image_reference,
+        expected_revision=state.oci_revision,
+        executables=executables,
+        environment=environment,
+    )
+    if image.image_id != state.image_id:
+        raise PromotionRecoveryFailedError(
+            "automatic recovery baseline image identity does not match"
+        )
+    _checkout_revision(
+        checkout=config.checkout,
+        revision=state.source_revision,
+        executables=executables,
+        environment=environment,
+    )
+    transaction.install_environment(state, config.checkout / ".env")
+    _compose_up(
+        config=config,
+        image_reference=state.image_reference,
+        executables=executables,
+        environment=environment,
+    )
+    restored = _observe_runtime(
+        config=config,
+        image=image,
+        executables=executables,
+        environment=environment,
+    )
+    if restored is None or not _matches_state(restored, current):
+        raise PromotionRecoveryFailedError(
+            "automatic recovery did not restore the recorded baseline"
+        )
+    recorded = tuple(volume.recorded_identity() for volume in restored.volumes)
+    if recorded != pending.intent.persistent_volumes:
+        raise PromotionRecoveryFailedError(
+            "automatic recovery changed persistent volume identity"
+        )
+    if baseline_runtime is not None and restored.volumes != baseline_runtime.volumes:
+        raise PromotionRecoveryFailedError(
+            "automatic recovery changed persistent volume identity"
+        )
+    return restored
+
+
+def _recover_pending(
+    *,
+    transaction: DeploymentStateTransaction,
+    pending: PendingPromotion,
+    config: PromotionConfig,
+    executables: Executables,
+    environment: Mapping[str, str],
+) -> None:
+    current = transaction.current()
+    if current is None:
+        _abort_fresh_install(
+            transaction=transaction,
+            pending=pending,
+            config=config,
+            executables=executables,
+            environment=environment,
+            baseline_revision=_transaction_baseline_revision(pending),
+        )
+        raise PromotionRecoveryRequiredError(
+            "aborted an interrupted fresh install; rerun promotion"
+        )
+    current_revision = _git_line(
+        executables,
+        config.checkout,
+        ["rev-parse", "--verify", "HEAD"],
+        environment,
+        "pending production revision",
+    )
+    if current_revision == current.state.source_revision:
+        image = _inspect_image(
+            proof_reference=current.state.image_reference,
+            expected_revision=current.state.oci_revision,
+            executables=executables,
+            environment=environment,
+        )
+        if image.image_id != current.state.image_id:
+            raise PromotionRecoveryFailedError(
+                "pending baseline image identity does not match"
+            )
+        try:
+            unchanged = _observe_runtime(
+                config=config,
+                image=image,
+                executables=executables,
+                environment=environment,
+            )
+        except PromotionError:
+            unchanged = None
+        if unchanged is not None and _matches_state(unchanged, current):
+            unchanged_volumes = tuple(
+                volume.recorded_identity() for volume in unchanged.volumes
+            )
+            if unchanged_volumes != pending.intent.persistent_volumes:
+                raise PromotionRecoveryFailedError(
+                    "pending baseline persistent volume identity changed"
+                )
+            transaction.record_abort(
+                pending.transaction_id,
+                persistent_volumes=unchanged_volumes,
+            )
+            raise PromotionRecoveryRequiredError(
+                "confirmed an interrupted pre-cutover deployment; rerun promotion"
+            )
+    restored = _restore_baseline(
+        transaction=transaction,
+        pending=pending,
+        current=current,
+        baseline_runtime=None,
+        config=config,
+        executables=executables,
+        environment=environment,
+    )
+    transaction.record_rollback(
+        pending.transaction_id,
+        persistent_volumes=tuple(
+            volume.recorded_identity() for volume in restored.volumes
+        ),
+    )
+    raise PromotionRecoveryRequiredError(
+        "recovered an interrupted deployment; rerun promotion"
+    )
+
+
+def _promote_locked(
+    *,
+    transaction: DeploymentStateTransaction,
+    config: PromotionConfig,
+    executables: Executables,
+    command_environment: Mapping[str, str],
+    source_environment: Mapping[str, str],
+) -> CurrentDeployment:
+    recovered_terminal = transaction.recovered_terminal()
+    if recovered_terminal is not None:
+        raise PromotionRecoveryRequiredError(
+            "reconciled a committed deployment outcome; rerun promotion"
+        )
+    _validate_production_checkout(config, executables, command_environment)
+    pending_on_entry = transaction.pending()
+    if pending_on_entry is not None:
+        _validate_pending_ownership(
+            pending=pending_on_entry,
+            current=transaction.current(),
+            config=config,
+            executables=executables,
+            environment=command_environment,
+        )
+        _recover_pending(
+            transaction=transaction,
+            pending=pending_on_entry,
+            config=config,
+            executables=executables,
+            environment=command_environment,
+        )
+
+    _validate_release_checkout(
+        config,
+        executables,
+        command_environment,
+    )
+    try:
+        production_environment = {
+            name: source_environment[name] for name in PRODUCTION_ENVIRONMENT_NAMES
+        }
+    except KeyError:
+        raise PromotionError("required production environment is incomplete") from None
+    for value in production_environment.values():
+        if any(character in value for character in "\0\r\n"):
+            raise PromotionError("production environment contains an unsafe value")
+
+    current, baseline_runtime, original_revision = _baseline(
+        transaction=transaction,
+        config=config,
+        executables=executables,
+        environment=command_environment,
+    )
+    image = _pull_and_prove_image(
+        config,
+        executables,
+        command_environment,
+    )
+    transaction_id = _new_transaction_id(original_revision)
+    receipt = _run_candidate(
+        transaction=transaction,
+        config=config,
+        image=image,
+        transaction_id=transaction_id,
+        executables=executables,
+        environment=command_environment,
+        production_environment=production_environment,
+    )
+    with tempfile.TemporaryDirectory(
+        prefix=".promotion-target-",
+        dir=config.state_dir,
+    ) as temporary_name:
+        environment_source = Path(temporary_name) / "target.env"
+        write_compose_environment(
+            environment_source,
+            PRODUCTION_ENVIRONMENT_NAMES,
+            production_environment,
+        )
+        volumes = (
+            ()
+            if baseline_runtime is None
+            else tuple(
+                volume.recorded_identity() for volume in baseline_runtime.volumes
+            )
+        )
+        pending = transaction.begin_promotion(
+            compose_project=config.compose_project,
+            compose_service=config.compose_service,
+            source_revision=config.source_revision,
+            image_reference=image.image_reference,
+            image_id=image.image_id,
+            oci_revision=image.oci_revision,
+            environment_source=environment_source,
+            candidate=receipt,
+            persistent_volumes=volumes,
+            transaction_id=transaction_id,
+        )
+
+    production_start_attempted = False
+
+    def mark_production_start() -> None:
+        nonlocal production_start_attempted
+        production_start_attempted = True
+
+    try:
+        _checkout_revision(
+            checkout=config.checkout,
+            revision=config.source_revision,
+            executables=executables,
+            environment=command_environment,
+        )
+        transaction.install_environment(
+            pending.intent.target,
+            config.checkout / ".env",
+        )
+        _compose_up(
+            config=config,
+            image_reference=image.image_reference,
+            executables=executables,
+            environment=command_environment,
+            before_up=mark_production_start,
+        )
+        verified_target = _verify_target(
+            transaction=transaction,
+            pending=pending,
+            baseline_runtime=baseline_runtime,
+            config=config,
+            executables=executables,
+            environment=command_environment,
+        )
+        return transaction.commit_promotion(
+            transaction_id,
+            persistent_volumes=tuple(
+                volume.recorded_identity() for volume in verified_target.volumes
+            ),
+        )
+    except (
+        DeploymentTerminalCommittedError,
+        DeploymentTerminalIndeterminateError,
+    ):
+        raise
+    except Exception as primary:
+        try:
+            if current is None:
+                _abort_fresh_install(
+                    transaction=transaction,
+                    pending=pending,
+                    config=config,
+                    executables=executables,
+                    environment=command_environment,
+                    baseline_revision=original_revision,
+                )
+            else:
+                restored_runtime = _restore_baseline(
+                    transaction=transaction,
+                    pending=pending,
+                    current=current,
+                    baseline_runtime=baseline_runtime,
+                    config=config,
+                    executables=executables,
+                    environment=command_environment,
+                )
+                transaction.record_rollback(
+                    transaction_id,
+                    persistent_volumes=tuple(
+                        volume.recorded_identity()
+                        for volume in restored_runtime.volumes
+                    ),
+                )
+        except (
+            DeploymentTerminalCommittedError,
+            DeploymentTerminalIndeterminateError,
+        ):
+            raise
+        except Exception:
+            raise PromotionRecoveryFailedError(
+                "promotion failed and automatic recovery could not be verified"
+            ) from None
+        outcome = (
+            "fresh install was safely aborted"
+            if current is None
+            else "the recorded baseline was restored"
+        )
+        if current is None and production_start_attempted:
+            outcome += " and its exact service container was removed"
+        raise PromotionRolledBackError(f"promotion failed; {outcome}") from primary
+
+
+def promote(
+    config: PromotionConfig,
+    *,
+    environment: Mapping[str, str] | None = None,
+) -> CurrentDeployment:
+    """Execute one complete promotion while holding one state transaction."""
+    selected_config = _validated_config(config)
+    source = os.environ if environment is None else environment
+    command_environment = _command_environment(source)
+    executables = Executables(
+        git=_resolve_executable("git", command_environment),
+        docker=_resolve_executable("docker", command_environment),
+    )
+    store = DeploymentStateStore(selected_config.state_dir)
+    with store.transaction() as transaction:
+        return _promote_locked(
+            transaction=transaction,
+            config=selected_config,
+            executables=executables,
+            command_environment=command_environment,
+            source_environment=source,
+        )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m agent.deployment_promotion",
+        description="Promote and verify one exact VM deployment.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    promote_parser = subparsers.add_parser("promote")
+    promote_parser.add_argument("--state-dir", required=True, type=Path)
+    promote_parser.add_argument("--checkout", required=True, type=Path)
+    promote_parser.add_argument("--release-checkout", required=True, type=Path)
+    promote_parser.add_argument("--expected-origin", required=True)
+    promote_parser.add_argument("--compose-project", required=True)
+    promote_parser.add_argument("--compose-service", required=True)
+    promote_parser.add_argument("--source-revision", required=True)
+    promote_parser.add_argument("--image-reference", required=True)
+    promote_parser.add_argument("--adopt-existing", action="store_true")
+    promote_parser.add_argument("--environment-stdin", action="store_true")
+    promote_parser.add_argument("--release-lease", type=Path)
+    return parser
+
+
+def _stdin_environment(stream: BinaryIO) -> dict[str, str]:
+    """Read one bounded UTF-8 canonical production environment payload."""
+    try:
+        payload = stream.read(_MAX_SERIALIZED_ENVIRONMENT_BYTES + 1)
+    except OSError:
+        raise ComposeEnvironmentError(
+            "serialized environment could not be read"
+        ) from None
+    if len(payload) > _MAX_SERIALIZED_ENVIRONMENT_BYTES:
+        raise ComposeEnvironmentError("serialized environment is too large")
+    try:
+        decoded = payload.decode("utf-8", errors="strict")
+    except UnicodeDecodeError:
+        raise ComposeEnvironmentError("serialized environment is not UTF-8") from None
+    return parse_compose_environment(decoded, PRODUCTION_ENVIRONMENT_NAMES)
+
+
+@contextmanager
+def _release_lease(path: Path) -> Iterator[None]:
+    """Hold one pre-created private release lease across the whole controller."""
+    if not path.is_absolute() or path != path.resolve(strict=False):
+        raise PromotionError("release lease must be an absolute normalized path")
+    parent = path.parent
+    try:
+        parent_metadata = parent.stat()
+    except OSError:
+        raise PromotionError("release lease directory is unavailable") from None
+    if (
+        not stat.S_ISDIR(parent_metadata.st_mode)
+        or parent_metadata.st_uid != os.geteuid()
+        or stat.S_IMODE(parent_metadata.st_mode) != 0o700
+    ):
+        raise PromotionError("release lease directory is unsafe")
+    flags = os.O_RDWR | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError:
+        raise PromotionError("release lease is unavailable") from None
+    try:
+        metadata = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_uid != os.geteuid()
+            or metadata.st_nlink != 1
+            or stat.S_IMODE(metadata.st_mode) != 0o600
+        ):
+            raise PromotionError("release lease is unsafe")
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as error:
+            if error.errno in {errno.EACCES, errno.EAGAIN}:
+                raise DeploymentLockBusyError(
+                    "another release controller holds the lease"
+                ) from None
+            raise PromotionError("release lease could not be acquired") from None
+        try:
+            yield
+        finally:
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+    finally:
+        os.close(descriptor)
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    environment: Mapping[str, str] | None = None,
+    input_stream: BinaryIO | None = None,
+) -> int:
+    """Run the promotion CLI and return a stable process status."""
+    arguments = _parser().parse_args(sys.argv[1:] if argv is None else argv)
+    config = PromotionConfig(
+        state_dir=arguments.state_dir,
+        checkout=arguments.checkout,
+        release_checkout=arguments.release_checkout,
+        expected_origin=arguments.expected_origin,
+        compose_project=arguments.compose_project,
+        compose_service=arguments.compose_service,
+        source_revision=arguments.source_revision,
+        image_reference=arguments.image_reference,
+        adopt_existing=arguments.adopt_existing,
+    )
+    try:
+        if (arguments.release_lease is None) != (not arguments.environment_stdin):
+            raise PromotionError(
+                "release lease and serialized environment must be used together"
+            )
+        if arguments.release_lease is None:
+            selected_environment = os.environ if environment is None else environment
+            current = promote(config, environment=selected_environment)
+        else:
+            with _release_lease(arguments.release_lease):
+                source = os.environ if environment is None else environment
+                stream = sys.stdin.buffer if input_stream is None else input_stream
+                production_environment = _stdin_environment(stream)
+                selected_environment = {
+                    name: source[name]
+                    for name in _HOST_ENVIRONMENT_NAMES
+                    if name in source
+                }
+                selected_environment.update(production_environment)
+                current = promote(config, environment=selected_environment)
+    except PromotionRecoveryRequiredError as error:
+        print(f"RECOVERED: {error}", file=sys.stderr)
+        return 3
+    except (
+        DeploymentTerminalCommittedError,
+        DeploymentTerminalIndeterminateError,
+    ) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 4
+    except (
+        ComposeEnvironmentError,
+        DeploymentLockBusyError,
+        DeploymentStateError,
+        PromotionError,
+        OSError,
+    ) as error:
+        if isinstance(error, OSError):
+            message = "deployment host operation failed"
+        else:
+            message = str(error)
+        print(f"ERROR: {message}", file=sys.stderr)
+        return 1
+    print(
+        f"PROMOTED: revision={current.state.source_revision} "
+        f"transaction={current.state.deployment_id}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent/deployment_promotion.py
+++ b/src/agent/deployment_promotion.py
@@ -19,6 +19,7 @@ from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from enum import StrEnum
 from pathlib import Path, PurePosixPath
 from typing import BinaryIO, Final
 
@@ -116,6 +117,27 @@ class PromotionRecoveryRequiredError(PromotionError):
 
 class PromotionRecoveryFailedError(PromotionError):
     """Report recovery that could not prove the recorded baseline."""
+
+
+class CommandOperation(StrEnum):
+    """Fixed, secret-free labels for external promotion boundaries."""
+
+    GIT_METADATA = "Git metadata read"
+    GIT_DIFF = "Git checkout diff"
+    GIT_STATUS = "Git release status"
+    GIT_MANIFEST = "Git release manifest"
+    GIT_CHECKOUT = "Git production checkout"
+    IMAGE_PULL = "Docker image pull"
+    IMAGE_INSPECT = "Docker image inspect"
+    CONTAINER_LIST = "Docker container list"
+    CONTAINER_INSPECT = "Docker container inspect"
+    CONTAINER_REMOVE = "Docker container removal"
+    VOLUME_INSPECT = "Docker volume inspect"
+    CANDIDATE_CONFIG = "candidate Compose validation"
+    CANDIDATE_START = "candidate Compose start"
+    CANDIDATE_CLEANUP = "candidate Compose cleanup"
+    PRODUCTION_CONFIG = "production Compose validation"
+    PRODUCTION_START = "production Compose start"
 
 
 @dataclass(frozen=True, slots=True)
@@ -265,6 +287,7 @@ def _run(
     executable: Path,
     arguments: Sequence[str],
     *,
+    operation: CommandOperation,
     environment: Mapping[str, str],
     cwd: Path | None = None,
     accepted_returncodes: frozenset[int] = frozenset({0}),
@@ -280,15 +303,26 @@ def _run(
             check=False,
             timeout=timeout,
         )
-    except (OSError, subprocess.TimeoutExpired):
-        raise PromotionError("deployment command failed") from None
+    except subprocess.TimeoutExpired:
+        raise PromotionError(
+            f"deployment command timed out during {operation.value}"
+        ) from None
+    except OSError:
+        raise PromotionError(
+            f"deployment command could not start during {operation.value}"
+        ) from None
     if result.returncode not in accepted_returncodes:
-        raise PromotionError("deployment command failed")
+        raise PromotionError(
+            "deployment command failed during "
+            f"{operation.value} (exit {result.returncode})"
+        )
     if (
         len(result.stdout.encode()) > _MAX_COMMAND_OUTPUT_BYTES
         or len(result.stderr.encode()) > _MAX_COMMAND_OUTPUT_BYTES
     ):
-        raise PromotionError("deployment command output is too large")
+        raise PromotionError(
+            f"deployment command output is too large during {operation.value}"
+        )
     return result
 
 
@@ -345,6 +379,7 @@ def _git_line(
         _run(
             executables.git,
             ["-C", str(checkout), *arguments],
+            operation=CommandOperation.GIT_METADATA,
             environment=environment,
         ).stdout,
         field,
@@ -401,6 +436,7 @@ def _validate_release_checkout(
         result = _run(
             executables.git,
             ["-C", str(config.release_checkout), *arguments],
+            operation=CommandOperation.GIT_DIFF,
             environment=environment,
             accepted_returncodes=frozenset({0, 1}),
         )
@@ -416,6 +452,7 @@ def _validate_release_checkout(
             "--untracked-files=all",
             "--ignored=matching",
         ],
+        operation=CommandOperation.GIT_STATUS,
         environment=environment,
     )
     if status.stdout:
@@ -432,6 +469,7 @@ def _validate_release_checkout(
             "compose.candidate.yaml",
             "src/agent/deployment_promotion.py",
         ],
+        operation=CommandOperation.GIT_MANIFEST,
         environment=environment,
     )
 
@@ -477,6 +515,7 @@ def _validate_production_checkout(
         result = _run(
             executables.git,
             ["-C", str(config.checkout), *arguments],
+            operation=CommandOperation.GIT_DIFF,
             environment=environment,
             accepted_returncodes=frozenset({0, 1}),
         )
@@ -533,6 +572,7 @@ def _validate_pending_ownership(
         _run(
             executables.docker,
             ["container", "inspect", ids[0]],
+            operation=CommandOperation.CONTAINER_INSPECT,
             environment=environment,
         ).stdout,
         "pending production container",
@@ -577,6 +617,7 @@ def _inspect_image(
         _run(
             executables.docker,
             ["image", "inspect", proof_reference],
+            operation=CommandOperation.IMAGE_INSPECT,
             environment=environment,
         ).stdout,
         "image",
@@ -611,6 +652,7 @@ def _pull_and_prove_image(
     _run(
         executables.docker,
         ["image", "pull", config.image_reference],
+        operation=CommandOperation.IMAGE_PULL,
         environment=environment,
     )
     return _inspect_image(
@@ -641,6 +683,7 @@ def _container_ids(
             "--format",
             "{{.ID}}",
         ],
+        operation=CommandOperation.CONTAINER_LIST,
         environment=environment,
     )
     values = tuple(line for line in result.stdout.splitlines() if line)
@@ -681,6 +724,7 @@ def _volume_proofs(
             _run(
                 executables.docker,
                 ["volume", "inspect", name],
+                operation=CommandOperation.VOLUME_INSPECT,
                 environment=environment,
             ).stdout,
             "volume",
@@ -744,6 +788,7 @@ def _inspect_container(
         _run(
             executables.docker,
             ["container", "inspect", container_id],
+            operation=CommandOperation.CONTAINER_INSPECT,
             environment=environment,
         ).stdout,
         "container",
@@ -1042,6 +1087,7 @@ def _run_candidate(
             _run(
                 executables.docker,
                 [*prefix[1:], "config", "--quiet"],
+                operation=CommandOperation.CANDIDATE_CONFIG,
                 environment=candidate_environment,
             )
             started = True
@@ -1059,6 +1105,7 @@ def _run_candidate(
                     "60",
                     config.compose_service,
                 ],
+                operation=CommandOperation.CANDIDATE_START,
                 environment=candidate_environment,
             )
             ids = _container_ids(
@@ -1098,6 +1145,7 @@ def _run_candidate(
                     _run(
                         executables.docker,
                         [*prefix[1:], "down", "--remove-orphans"],
+                        operation=CommandOperation.CANDIDATE_CLEANUP,
                         environment=candidate_environment,
                     )
                     if _container_ids(
@@ -1138,6 +1186,7 @@ def _checkout_revision(
             "--detach",
             revision,
         ],
+        operation=CommandOperation.GIT_CHECKOUT,
         environment=environment,
     )
     actual = _git_line(
@@ -1163,6 +1212,7 @@ def _checkout_revision(
         result = _run(
             executables.git,
             ["-C", str(checkout), *arguments],
+            operation=CommandOperation.GIT_DIFF,
             environment=environment,
             accepted_returncodes=frozenset({0, 1}),
         )
@@ -1191,6 +1241,7 @@ def _compose_up(
     configured = _run(
         executables.docker,
         [*prefix[1:], "config", "--images"],
+        operation=CommandOperation.PRODUCTION_CONFIG,
         environment=compose_environment,
     ).stdout.splitlines()
     if configured != [image_reference]:
@@ -1213,6 +1264,7 @@ def _compose_up(
             "180",
             config.compose_service,
         ],
+        operation=CommandOperation.PRODUCTION_START,
         environment=compose_environment,
     )
 
@@ -1242,6 +1294,7 @@ def _remove_owned_service_container(
         _run(
             executables.docker,
             ["container", "inspect", ids[0]],
+            operation=CommandOperation.CONTAINER_INSPECT,
             environment=environment,
         ).stdout,
         "fresh-install container",
@@ -1279,6 +1332,7 @@ def _remove_owned_service_container(
     _run(
         executables.docker,
         ["container", "rm", "--force", full_id],
+        operation=CommandOperation.CONTAINER_REMOVE,
         environment=environment,
     )
 

--- a/src/agent/deployment_state.py
+++ b/src/agent/deployment_state.py
@@ -15,18 +15,24 @@ from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from pathlib import Path
-from typing import Final
+from pathlib import Path, PurePosixPath
+from typing import Final, cast
 
 SCHEMA_VERSION: Final = 1
+PROMOTION_SCHEMA_VERSION: Final = 2
 MAX_ENVIRONMENT_BYTES: Final = 1024 * 1024
 MAX_JSON_BYTES: Final = 64 * 1024
+MAX_PERSISTENT_VOLUMES: Final = 64
+MAX_VOLUME_PATH_BYTES: Final = 4096
 
 _COMPOSE_NAME = re.compile(r"[a-z0-9][a-z0-9_-]{0,62}\Z")
 _DEPLOYMENT_ID = re.compile(r"[a-z0-9][a-z0-9-]{0,63}\Z")
 _REVISION = re.compile(r"[0-9a-f]{40}\Z")
 _SHA256_HEX = re.compile(r"[0-9a-f]{64}\Z")
 _IMAGE_ID = re.compile(r"sha256:[0-9a-f]{64}\Z")
+_CONTAINER_ID = re.compile(r"[0-9a-f]{64}\Z")
+_VOLUME_NAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,254}\Z")
+_VOLUME_DRIVER = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}\Z")
 _REPOSITORY_COMPONENT = r"[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*"
 _REGISTRY_LABEL = r"[a-z0-9](?:[a-z0-9-]*[a-z0-9])?"
 _IMAGE_REFERENCE = re.compile(
@@ -39,6 +45,11 @@ _RECORDED_AT = re.compile(
     r"[0-9]{4}-[0-9]{2}-[0-9]{2}T"
     r"[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}Z\Z"
 )
+_VOLUME_CREATED_AT = re.compile(
+    r"[0-9]{4}-[0-9]{2}-[0-9]{2}T"
+    r"[0-9]{2}:[0-9]{2}:[0-9]{2}"
+    r"(?:\.[0-9]{1,9})?(?:Z|[+-][0-9]{2}:[0-9]{2})\Z"
+)
 _JOURNAL_NAME = re.compile(r"([0-9]{20})\.json\Z")
 _ENVIRONMENT_NAME = re.compile(r"[a-z0-9][a-z0-9-]{0,63}\.env\Z")
 _CURRENT_TEMPORARY_NAME = re.compile(r"\.deployment-current-[a-z0-9._-]+\.tmp\Z")
@@ -46,6 +57,11 @@ _JOURNAL_TEMPORARY_NAME = re.compile(r"\.deployment-journal-[a-z0-9._-]+\.tmp\Z"
 _ENVIRONMENT_TEMPORARY_NAME = re.compile(
     r"\.deployment-environment-[a-z0-9._-]+\.tmp\Z"
 )
+_INTENT_NAME = re.compile(r"([a-z0-9][a-z0-9-]{0,63})\.json\Z")
+_INTENT_TEMPORARY_NAME = re.compile(r"\.deployment-intent-[a-z0-9._-]+\.tmp\Z")
+_PENDING_TEMPORARY_NAME = re.compile(r"\.deployment-pending-[a-z0-9._-]+\.tmp\Z")
+_PENDING_NAME = re.compile(r"pending\.json\Z")
+_TERMINAL_EVENTS = frozenset({"promoted", "rolled_back", "aborted"})
 
 
 class DeploymentStateError(RuntimeError):
@@ -54,6 +70,26 @@ class DeploymentStateError(RuntimeError):
 
 class DeploymentLockBusyError(DeploymentStateError):
     """Report that another process owns the VM deployment transaction."""
+
+
+class DeploymentTerminalCommittedError(DeploymentStateError):
+    """Report a durable terminal outcome whose derived state needs repair."""
+
+    def __init__(self, event: str, transaction_id: str) -> None:
+        self.event = event
+        self.transaction_id = transaction_id
+        super().__init__(
+            f"deployment outcome is committed but reconciliation failed: {event}"
+        )
+
+
+class DeploymentTerminalIndeterminateError(DeploymentStateError):
+    """Report a visible terminal record whose directory sync was indeterminate."""
+
+    def __init__(self, event: str, transaction_id: str) -> None:
+        self.event = event
+        self.transaction_id = transaction_id
+        super().__init__(f"deployment outcome publication is indeterminate: {event}")
 
 
 @dataclass(frozen=True, slots=True)
@@ -75,7 +111,9 @@ class DeploymentState:
     def as_document(self) -> dict[str, object]:
         """Return the exact persisted state schema."""
         return {
-            "schema_version": SCHEMA_VERSION,
+            "schema_version": (
+                SCHEMA_VERSION if self.adopted else PROMOTION_SCHEMA_VERSION
+            ),
             "deployment_id": self.deployment_id,
             "recorded_at": self.recorded_at,
             "compose_project": self.compose_project,
@@ -98,16 +136,32 @@ class JournalEntry:
     sha256: str
     previous_sha256: str | None
     event: str
-    state: DeploymentState
+    state: DeploymentState | None
+    transaction_id: str | None = None
+    intent_sha256: str | None = None
+    persistent_volumes: tuple[PersistentVolumeIdentity, ...] = ()
 
     def as_document(self) -> dict[str, object]:
         """Return the exact persisted journal schema, excluding its outer hash."""
+        if self.event != "adopted":
+            return {
+                "schema_version": PROMOTION_SCHEMA_VERSION,
+                "sequence": self.sequence,
+                "previous_sha256": self.previous_sha256,
+                "event": self.event,
+                "transaction_id": self.transaction_id,
+                "intent_sha256": self.intent_sha256,
+                "state": None if self.state is None else self.state.as_document(),
+                "persistent_volumes": [
+                    volume.as_document() for volume in self.persistent_volumes
+                ],
+            }
         return {
             "schema_version": SCHEMA_VERSION,
             "sequence": self.sequence,
             "previous_sha256": self.previous_sha256,
             "event": self.event,
-            "state": self.state.as_document(),
+            "state": cast(DeploymentState, self.state).as_document(),
         }
 
 
@@ -122,10 +176,114 @@ class CurrentDeployment:
     def as_document(self) -> dict[str, object]:
         """Return the exact persisted current-pointer schema."""
         return {
-            "schema_version": SCHEMA_VERSION,
+            "schema_version": (
+                SCHEMA_VERSION if self.state.adopted else PROMOTION_SCHEMA_VERSION
+            ),
             "journal_sequence": self.journal_sequence,
             "journal_sha256": self.journal_sha256,
             "state": self.state.as_document(),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateReceipt:
+    """Secret-free exact observation of one isolated candidate container."""
+
+    observed_at: str
+    compose_project: str
+    compose_service: str
+    container_id: str
+    image_reference: str
+    image_id: str
+    oci_revision: str
+    baseline_journal_sequence: int | None
+    baseline_journal_sha256: str | None
+
+    def as_document(self) -> dict[str, object]:
+        """Return the exact persisted candidate receipt schema."""
+        return {
+            "schema_version": PROMOTION_SCHEMA_VERSION,
+            "observed_at": self.observed_at,
+            "compose_project": self.compose_project,
+            "compose_service": self.compose_service,
+            "container_id": self.container_id,
+            "image_reference": self.image_reference,
+            "image_id": self.image_id,
+            "oci_revision": self.oci_revision,
+            "baseline_journal_sequence": self.baseline_journal_sequence,
+            "baseline_journal_sha256": self.baseline_journal_sha256,
+        }
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class PersistentVolumeIdentity:
+    """Stable Docker volume identity and its production mount destination."""
+
+    name: str
+    driver: str
+    mountpoint: str
+    destination: str
+    created_at: str
+
+    def as_document(self) -> dict[str, object]:
+        """Return the exact persisted volume identity schema."""
+        return {
+            "name": self.name,
+            "driver": self.driver,
+            "mountpoint": self.mountpoint,
+            "destination": self.destination,
+            "created_at": self.created_at,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class PromotionIntent:
+    """Immutable recovery contract published before production mutation."""
+
+    transaction_id: str
+    recorded_at: str
+    baseline_journal_sequence: int | None
+    baseline_journal_sha256: str | None
+    baseline_current_sequence: int | None
+    baseline_current_sha256: str | None
+    target: DeploymentState
+    candidate: CandidateReceipt
+    persistent_volumes: tuple[PersistentVolumeIdentity, ...]
+
+    def as_document(self) -> dict[str, object]:
+        """Return the exact persisted promotion intent schema."""
+        return {
+            "schema_version": PROMOTION_SCHEMA_VERSION,
+            "transaction_id": self.transaction_id,
+            "recorded_at": self.recorded_at,
+            "baseline_journal_sequence": self.baseline_journal_sequence,
+            "baseline_journal_sha256": self.baseline_journal_sha256,
+            "baseline_current_sequence": self.baseline_current_sequence,
+            "baseline_current_sha256": self.baseline_current_sha256,
+            "target": self.target.as_document(),
+            "candidate": self.candidate.as_document(),
+            "persistent_volumes": [
+                volume.as_document() for volume in self.persistent_volumes
+            ],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class PendingPromotion:
+    """Validated pointer to one immutable unresolved promotion intent."""
+
+    transaction_id: str
+    intent_path: str
+    intent_sha256: str
+    intent: PromotionIntent
+
+    def as_document(self) -> dict[str, object]:
+        """Return the exact persisted pending-pointer schema."""
+        return {
+            "schema_version": PROMOTION_SCHEMA_VERSION,
+            "transaction_id": self.transaction_id,
+            "intent_path": self.intent_path,
+            "intent_sha256": self.intent_sha256,
         }
 
 
@@ -140,14 +298,14 @@ def _validated_string(
     return value
 
 
-def _validate_timestamp(value: str) -> str:
+def _validate_timestamp(value: str, *, field: str = "recorded_at") -> str:
     if _RECORDED_AT.fullmatch(value) is None:
-        raise DeploymentStateError("deployment state field is invalid: recorded_at")
+        raise DeploymentStateError(f"deployment state field is invalid: {field}")
     try:
         datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=UTC)
     except ValueError:
         raise DeploymentStateError(
-            "deployment state field is invalid: recorded_at"
+            f"deployment state field is invalid: {field}"
         ) from None
     return value
 
@@ -161,7 +319,27 @@ def _validate_snapshot_path(value: object, deployment_id: str) -> str:
     return value
 
 
-def _state_from_document(document: object) -> DeploymentState:
+def _validate_volume_created_at(value: object) -> str:
+    if (
+        not isinstance(value, str)
+        or len(value.encode()) > 35
+        or _VOLUME_CREATED_AT.fullmatch(value) is None
+    ):
+        raise DeploymentStateError("deployment state field is invalid: created_at")
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        raise DeploymentStateError(
+            "deployment state field is invalid: created_at"
+        ) from None
+    return value
+
+
+def _state_from_document_with_adoption(
+    document: object,
+    *,
+    expected_adopted: bool | None,
+) -> DeploymentState:
     if not isinstance(document, dict):
         raise DeploymentStateError("deployment state document must be an object")
     expected_keys = {
@@ -178,16 +356,18 @@ def _state_from_document(document: object) -> DeploymentState:
         "environment_sha256",
         "adopted",
     }
-    if (
-        set(document) != expected_keys
-        or document.get("schema_version") != SCHEMA_VERSION
-    ):
+    if set(document) != expected_keys:
         raise DeploymentStateError("deployment state schema is invalid")
 
     deployment_id = _validated_string(document, "deployment_id", _DEPLOYMENT_ID)
     adopted = document.get("adopted")
-    if adopted is not True:
+    if type(adopted) is not bool or (
+        expected_adopted is not None and adopted is not expected_adopted
+    ):
         raise DeploymentStateError("deployment state field is invalid: adopted")
+    expected_schema_version = SCHEMA_VERSION if adopted else PROMOTION_SCHEMA_VERSION
+    if document.get("schema_version") != expected_schema_version:
+        raise DeploymentStateError("deployment state schema is invalid")
     return DeploymentState(
         deployment_id=deployment_id,
         recorded_at=_validate_timestamp(
@@ -224,7 +404,243 @@ def _state_from_document(document: object) -> DeploymentState:
             "environment_sha256",
             _SHA256_HEX,
         ),
-        adopted=True,
+        adopted=adopted,
+    )
+
+
+def _state_from_document(document: object) -> DeploymentState:
+    """Parse the original schema-v1 adopted-state contract."""
+    return _state_from_document_with_adoption(document, expected_adopted=True)
+
+
+def _target_state_from_document(document: object) -> DeploymentState:
+    return _state_from_document_with_adoption(document, expected_adopted=False)
+
+
+def _any_state_from_document(document: object) -> DeploymentState:
+    return _state_from_document_with_adoption(document, expected_adopted=None)
+
+
+def _validated_optional_identity(
+    document: Mapping[str, object],
+    sequence_key: str,
+    sha256_key: str,
+) -> tuple[int | None, str | None]:
+    sequence = document.get(sequence_key)
+    sha256 = document.get(sha256_key)
+    if sequence is None and sha256 is None:
+        return None, None
+    if (
+        type(sequence) is not int
+        or sequence <= 0
+        or not isinstance(sha256, str)
+        or _SHA256_HEX.fullmatch(sha256) is None
+    ):
+        raise DeploymentStateError(
+            f"deployment state identity is invalid: {sequence_key}"
+        )
+    return sequence, sha256
+
+
+def _candidate_from_document(document: object) -> CandidateReceipt:
+    if not isinstance(document, dict):
+        raise DeploymentStateError("candidate receipt must be an object")
+    expected_keys = {
+        "schema_version",
+        "observed_at",
+        "compose_project",
+        "compose_service",
+        "container_id",
+        "image_reference",
+        "image_id",
+        "oci_revision",
+        "baseline_journal_sequence",
+        "baseline_journal_sha256",
+    }
+    if (
+        set(document) != expected_keys
+        or document.get("schema_version") != PROMOTION_SCHEMA_VERSION
+    ):
+        raise DeploymentStateError("candidate receipt schema is invalid")
+    baseline_sequence, baseline_sha256 = _validated_optional_identity(
+        document,
+        "baseline_journal_sequence",
+        "baseline_journal_sha256",
+    )
+    return CandidateReceipt(
+        observed_at=_validate_timestamp(
+            _validated_string(document, "observed_at", _RECORDED_AT),
+            field="observed_at",
+        ),
+        compose_project=_validated_string(
+            document,
+            "compose_project",
+            _COMPOSE_NAME,
+        ),
+        compose_service=_validated_string(
+            document,
+            "compose_service",
+            _COMPOSE_NAME,
+        ),
+        container_id=_validated_string(document, "container_id", _CONTAINER_ID),
+        image_reference=_validated_string(
+            document,
+            "image_reference",
+            _IMAGE_REFERENCE,
+        ),
+        image_id=_validated_string(document, "image_id", _IMAGE_ID),
+        oci_revision=_validated_string(document, "oci_revision", _REVISION),
+        baseline_journal_sequence=baseline_sequence,
+        baseline_journal_sha256=baseline_sha256,
+    )
+
+
+def _volume_from_document(document: object) -> PersistentVolumeIdentity:
+    if not isinstance(document, dict) or set(document) != {
+        "name",
+        "driver",
+        "mountpoint",
+        "destination",
+        "created_at",
+    }:
+        raise DeploymentStateError("persistent volume identity schema is invalid")
+    name = _validated_string(document, "name", _VOLUME_NAME)
+    driver = _validated_string(document, "driver", _VOLUME_DRIVER)
+    mountpoint = document.get("mountpoint")
+    destination = document.get("destination")
+    for field, value in (
+        ("mountpoint", mountpoint),
+        ("destination", destination),
+    ):
+        if (
+            not isinstance(value, str)
+            or len(value.encode()) > MAX_VOLUME_PATH_BYTES
+            or not value.startswith("/")
+            or value.startswith("//")
+            or value == "/"
+            or str(PurePosixPath(value)) != value
+            or ".." in PurePosixPath(value).parts
+            or "\\" in value
+            or any(ord(character) < 32 or ord(character) == 127 for character in value)
+        ):
+            raise DeploymentStateError(f"persistent volume {field} is invalid")
+    return PersistentVolumeIdentity(
+        name=name,
+        driver=driver,
+        mountpoint=cast(str, mountpoint),
+        destination=cast(str, destination),
+        created_at=_validate_volume_created_at(document.get("created_at")),
+    )
+
+
+def _validated_volume_identities(
+    values: Sequence[PersistentVolumeIdentity],
+) -> tuple[PersistentVolumeIdentity, ...]:
+    if len(values) > MAX_PERSISTENT_VOLUMES or any(
+        not isinstance(value, PersistentVolumeIdentity) for value in values
+    ):
+        raise DeploymentStateError("persistent volume identities are invalid")
+    volumes = tuple(
+        sorted(_volume_from_document(value.as_document()) for value in values)
+    )
+    if (
+        len({volume.name for volume in volumes}) != len(volumes)
+        or len({volume.destination for volume in volumes}) != len(volumes)
+        or len({volume.mountpoint for volume in volumes}) != len(volumes)
+    ):
+        raise DeploymentStateError("persistent volume identities are invalid")
+    return volumes
+
+
+def _volume_identities_from_document(
+    document: object,
+) -> tuple[PersistentVolumeIdentity, ...]:
+    if not isinstance(document, list) or len(document) > MAX_PERSISTENT_VOLUMES:
+        raise DeploymentStateError("persistent volume identities are invalid")
+    volumes = tuple(_volume_from_document(value) for value in document)
+    if (
+        tuple(sorted(volumes)) != volumes
+        or len({volume.name for volume in volumes}) != len(volumes)
+        or len({volume.destination for volume in volumes}) != len(volumes)
+        or len({volume.mountpoint for volume in volumes}) != len(volumes)
+    ):
+        raise DeploymentStateError("persistent volume identities are invalid")
+    return volumes
+
+
+def _intent_from_document(document: object) -> PromotionIntent:
+    if not isinstance(document, dict):
+        raise DeploymentStateError("promotion intent must be an object")
+    expected_keys = {
+        "schema_version",
+        "transaction_id",
+        "recorded_at",
+        "baseline_journal_sequence",
+        "baseline_journal_sha256",
+        "baseline_current_sequence",
+        "baseline_current_sha256",
+        "target",
+        "candidate",
+        "persistent_volumes",
+    }
+    if (
+        set(document) != expected_keys
+        or document.get("schema_version") != PROMOTION_SCHEMA_VERSION
+    ):
+        raise DeploymentStateError("promotion intent schema is invalid")
+    baseline_sequence, baseline_sha256 = _validated_optional_identity(
+        document,
+        "baseline_journal_sequence",
+        "baseline_journal_sha256",
+    )
+    current_sequence, current_sha256 = _validated_optional_identity(
+        document,
+        "baseline_current_sequence",
+        "baseline_current_sha256",
+    )
+    recorded_at = _validate_timestamp(
+        _validated_string(document, "recorded_at", _RECORDED_AT)
+    )
+    target = _target_state_from_document(document.get("target"))
+    candidate = _candidate_from_document(document.get("candidate"))
+    volumes = _volume_identities_from_document(document.get("persistent_volumes"))
+    transaction_id = _validated_string(
+        document,
+        "transaction_id",
+        _DEPLOYMENT_ID,
+    )
+    if target.deployment_id != transaction_id:
+        raise DeploymentStateError("promotion target identity does not match")
+    if target.recorded_at != recorded_at or candidate.observed_at > recorded_at:
+        raise DeploymentStateError("promotion intent timestamps do not match")
+    if current_sequence is not None and (
+        baseline_sequence is None or current_sequence > baseline_sequence
+    ):
+        raise DeploymentStateError("promotion current baseline is invalid")
+    if (
+        candidate.baseline_journal_sequence != baseline_sequence
+        or candidate.baseline_journal_sha256 != baseline_sha256
+    ):
+        raise DeploymentStateError("candidate receipt baseline does not match")
+    if (
+        candidate.compose_project == target.compose_project
+        or candidate.compose_service != target.compose_service
+        or candidate.image_reference != target.image_reference
+        or candidate.image_id != target.image_id
+        or candidate.oci_revision != target.oci_revision
+        or target.source_revision != target.oci_revision
+    ):
+        raise DeploymentStateError("candidate receipt target does not match")
+    return PromotionIntent(
+        transaction_id=transaction_id,
+        recorded_at=recorded_at,
+        baseline_journal_sequence=baseline_sequence,
+        baseline_journal_sha256=baseline_sha256,
+        baseline_current_sequence=current_sequence,
+        baseline_current_sha256=current_sha256,
+        target=target,
+        candidate=candidate,
+        persistent_volumes=volumes,
     )
 
 
@@ -409,11 +825,17 @@ def _metadata_identity(metadata: os.stat_result) -> tuple[int, ...]:
     )
 
 
-def _read_private_file(path: Path, *, maximum_bytes: int) -> bytes:
+def _read_private_file(
+    path: Path,
+    *,
+    maximum_bytes: int,
+    require_one_link: bool = True,
+) -> bytes:
     before = _validate_secure_path(
         path,
         expected_mode=0o600,
         directory=False,
+        require_one_link=require_one_link,
     )
     if before.st_size <= 0 or before.st_size > maximum_bytes:
         raise DeploymentStateError("private deployment file size is invalid")
@@ -427,7 +849,7 @@ def _read_private_file(path: Path, *, maximum_bytes: int) -> bytes:
             opened,
             expected_mode=0o600,
             directory=False,
-            require_one_link=True,
+            require_one_link=require_one_link,
         )
         identity = _metadata_identity(opened)
         if _metadata_identity(before) != identity:
@@ -447,7 +869,7 @@ def _read_private_file(path: Path, *, maximum_bytes: int) -> bytes:
             after,
             expected_mode=0o600,
             directory=False,
-            require_one_link=True,
+            require_one_link=require_one_link,
         )
         if _metadata_identity(after) != identity:
             raise DeploymentStateError("private deployment file changed while read")
@@ -455,6 +877,7 @@ def _read_private_file(path: Path, *, maximum_bytes: int) -> bytes:
             path,
             expected_mode=0o600,
             directory=False,
+            require_one_link=require_one_link,
         )
         if _metadata_identity(pathname_after) != identity:
             raise DeploymentStateError("private deployment file changed while read")
@@ -472,17 +895,50 @@ def _journal_from_document(
     *,
     payload_sha256: str,
 ) -> JournalEntry:
-    expected_keys = {
+    schema_version = document.get("schema_version")
+    persistent_volumes: tuple[PersistentVolumeIdentity, ...] = ()
+    v1_keys = {
         "schema_version",
         "sequence",
         "previous_sha256",
         "event",
         "state",
     }
-    if (
-        set(document) != expected_keys
-        or document.get("schema_version") != SCHEMA_VERSION
+    v2_keys = v1_keys | {
+        "transaction_id",
+        "intent_sha256",
+        "persistent_volumes",
+    }
+    if schema_version == SCHEMA_VERSION and set(document) == v1_keys:
+        if document.get("event") != "adopted":
+            raise DeploymentStateError("deployment journal event is invalid")
+        event = "adopted"
+        transaction_id = None
+        intent_sha256 = None
+        state: DeploymentState | None = _state_from_document(document.get("state"))
+    elif (
+        schema_version == PROMOTION_SCHEMA_VERSION
+        and set(document) == v2_keys
+        and document.get("event") in _TERMINAL_EVENTS
     ):
+        raw_event = document.get("event")
+        event = cast(str, raw_event)
+        transaction_id = _validated_string(
+            document,
+            "transaction_id",
+            _DEPLOYMENT_ID,
+        )
+        intent_sha256 = _validated_string(
+            document,
+            "intent_sha256",
+            _SHA256_HEX,
+        )
+        raw_state = document.get("state")
+        state = None if raw_state is None else _any_state_from_document(raw_state)
+        persistent_volumes = _volume_identities_from_document(
+            document.get("persistent_volumes")
+        )
+    else:
         raise DeploymentStateError("deployment journal schema is invalid")
     sequence = document.get("sequence")
     if type(sequence) is not int or sequence <= 0:
@@ -492,15 +948,15 @@ def _journal_from_document(
         not isinstance(previous, str) or _SHA256_HEX.fullmatch(previous) is None
     ):
         raise DeploymentStateError("deployment journal predecessor is invalid")
-    event = document.get("event")
-    if event != "adopted":
-        raise DeploymentStateError("deployment journal event is invalid")
     return JournalEntry(
         sequence=sequence,
         sha256=payload_sha256,
         previous_sha256=previous,
-        event="adopted",
-        state=_state_from_document(document.get("state")),
+        event=event,
+        state=state,
+        transaction_id=transaction_id,
+        intent_sha256=intent_sha256,
+        persistent_volumes=persistent_volumes,
     )
 
 
@@ -511,10 +967,13 @@ def _current_from_document(document: Mapping[str, object]) -> CurrentDeployment:
         "journal_sha256",
         "state",
     }
-    if (
-        set(document) != expected_keys
-        or document.get("schema_version") != SCHEMA_VERSION
-    ):
+    if set(document) != expected_keys:
+        raise DeploymentStateError("current deployment schema is invalid")
+    state = _any_state_from_document(document.get("state"))
+    expected_schema_version = (
+        SCHEMA_VERSION if state.adopted else PROMOTION_SCHEMA_VERSION
+    )
+    if document.get("schema_version") != expected_schema_version:
         raise DeploymentStateError("current deployment schema is invalid")
     sequence = document.get("journal_sequence")
     if type(sequence) is not int or sequence <= 0:
@@ -528,7 +987,53 @@ def _current_from_document(document: Mapping[str, object]) -> CurrentDeployment:
     return CurrentDeployment(
         journal_sequence=sequence,
         journal_sha256=journal_sha256,
-        state=_state_from_document(document.get("state")),
+        state=state,
+    )
+
+
+def _pending_from_document(
+    document: object,
+    *,
+    intents: Mapping[str, tuple[str, PromotionIntent]],
+) -> PendingPromotion:
+    if not isinstance(document, dict):
+        raise DeploymentStateError("pending promotion must be an object")
+    expected_keys = {
+        "schema_version",
+        "transaction_id",
+        "intent_path",
+        "intent_sha256",
+    }
+    if (
+        set(document) != expected_keys
+        or document.get("schema_version") != PROMOTION_SCHEMA_VERSION
+    ):
+        raise DeploymentStateError("pending promotion schema is invalid")
+    transaction_id = _validated_string(
+        document,
+        "transaction_id",
+        _DEPLOYMENT_ID,
+    )
+    expected_path = f"transactions/{transaction_id}.json"
+    intent_path = document.get("intent_path")
+    if intent_path != expected_path:
+        raise DeploymentStateError("pending promotion intent path is invalid")
+    intent_sha256 = _validated_string(
+        document,
+        "intent_sha256",
+        _SHA256_HEX,
+    )
+    selected = intents.get(transaction_id)
+    if selected is None:
+        raise DeploymentStateError("pending promotion intent is missing")
+    actual_sha256, intent = selected
+    if actual_sha256 != intent_sha256:
+        raise DeploymentStateError("pending promotion intent hash is invalid")
+    return PendingPromotion(
+        transaction_id=transaction_id,
+        intent_path=expected_path,
+        intent_sha256=intent_sha256,
+        intent=intent,
     )
 
 
@@ -543,8 +1048,10 @@ class DeploymentStateStore:
         self.path = path
         self.journal_path = path / "journal"
         self.environments_path = path / "environments"
+        self.transactions_path = path / "transactions"
         self.lock_path = path / "deploy.lock"
         self.current_path = path / "current.json"
+        self.pending_path = path / "pending.json"
 
     def _prepare_layout(self) -> None:
         _ensure_secure_directory(self.path)
@@ -610,6 +1117,10 @@ class DeploymentStateTransaction:
         self._closed = False
         self._journal: tuple[JournalEntry, ...] = ()
         self._current: CurrentDeployment | None = None
+        self._intents: dict[str, tuple[str, PromotionIntent]] = {}
+        self._pending: PendingPromotion | None = None
+        self._indeterminate_terminal: tuple[str, str] | None = None
+        self._recovered_terminal: JournalEntry | None = None
 
     def _require_open(self) -> None:
         if self._closed:
@@ -625,12 +1136,37 @@ class DeploymentStateTransaction:
             raise DeploymentStateError("deployment journal contains an unknown path")
         return sorted(files)
 
+    def _intent_files(self) -> list[tuple[str, Path]]:
+        try:
+            _validate_secure_path(
+                self._store.transactions_path,
+                expected_mode=0o700,
+                directory=True,
+                require_one_link=False,
+            )
+        except DeploymentStateError:
+            try:
+                self._store.transactions_path.lstat()
+            except FileNotFoundError:
+                return []
+            raise
+        files: list[tuple[str, Path]] = []
+        for path in self._store.transactions_path.iterdir():
+            match = _INTENT_NAME.fullmatch(path.name)
+            if match is None:
+                raise DeploymentStateError(
+                    "deployment transactions contain an unknown path"
+                )
+            files.append((match.group(1), path))
+        return sorted(files)
+
     def _recover_temporary_files(
         self,
         directory: Path,
         *,
         temporary_pattern: re.Pattern[str],
         final_pattern: re.Pattern[str] | None = None,
+        classify_terminal: bool = False,
     ) -> None:
         for temporary_path in sorted(directory.iterdir()):
             if temporary_pattern.fullmatch(temporary_path.name) is None:
@@ -641,6 +1177,7 @@ class DeploymentStateTransaction:
                 directory=False,
                 require_one_link=False,
             )
+            terminal_entry: JournalEntry | None = None
             if temporary_metadata.st_nlink == 2 and final_pattern is not None:
                 matching_finals: list[Path] = []
                 for candidate in directory.iterdir():
@@ -668,6 +1205,18 @@ class DeploymentStateTransaction:
                     raise DeploymentStateError(
                         "deployment state temporary hard link is ambiguous"
                     )
+                if classify_terminal:
+                    payload = _read_private_file(
+                        matching_finals[0],
+                        maximum_bytes=MAX_JSON_BYTES,
+                        require_one_link=False,
+                    )
+                    candidate_entry = _journal_from_document(
+                        _decode_json(payload),
+                        payload_sha256=hashlib.sha256(payload).hexdigest(),
+                    )
+                    if candidate_entry.event in _TERMINAL_EVENTS:
+                        terminal_entry = candidate_entry
             elif temporary_metadata.st_nlink != 1:
                 raise DeploymentStateError(
                     "deployment state temporary file has unsafe links"
@@ -684,12 +1233,49 @@ class DeploymentStateTransaction:
                 raise DeploymentStateError(
                     "deployment state temporary file changed during recovery"
                 )
-            temporary_path.unlink()
-            _sync_directory(directory)
+            try:
+                temporary_path.unlink()
+                _sync_directory(directory)
+            except OSError as error:
+                if terminal_entry is None:
+                    raise
+                raise DeploymentTerminalIndeterminateError(
+                    terminal_entry.event,
+                    cast(str, terminal_entry.transaction_id),
+                ) from error
 
-    def _load_journal(self) -> tuple[JournalEntry, ...]:
+    def _load_intents(self) -> dict[str, tuple[str, PromotionIntent]]:
+        intents: dict[str, tuple[str, PromotionIntent]] = {}
+        for transaction_id, path in self._intent_files():
+            payload = _read_private_file(path, maximum_bytes=MAX_JSON_BYTES)
+            payload_sha256 = hashlib.sha256(payload).hexdigest()
+            intent = _intent_from_document(_decode_json(payload))
+            if intent.transaction_id != transaction_id:
+                raise DeploymentStateError(
+                    "promotion intent filename and identity disagree"
+                )
+            environment_payload = _read_private_file(
+                self._store.path / intent.target.environment_snapshot,
+                maximum_bytes=MAX_ENVIRONMENT_BYTES,
+            )
+            if (
+                hashlib.sha256(environment_payload).hexdigest()
+                != intent.target.environment_sha256
+            ):
+                raise DeploymentStateError(
+                    "promotion target environment snapshot hash is invalid"
+                )
+            intents[transaction_id] = (payload_sha256, intent)
+        return intents
+
+    def _load_journal(
+        self,
+        intents: Mapping[str, tuple[str, PromotionIntent]],
+    ) -> tuple[JournalEntry, ...]:
         entries: list[JournalEntry] = []
         previous_sha256: str | None = None
+        established: CurrentDeployment | None = None
+        completed_transactions: set[str] = set()
         for expected_sequence, (sequence, path) in enumerate(
             self._journal_files(),
             start=1,
@@ -708,30 +1294,102 @@ class DeploymentStateTransaction:
                 )
             if entry.previous_sha256 != previous_sha256:
                 raise DeploymentStateError("deployment journal hash chain is invalid")
-            environment_payload = _read_private_file(
-                self._store.path / entry.state.environment_snapshot,
-                maximum_bytes=MAX_ENVIRONMENT_BYTES,
-            )
-            if (
-                hashlib.sha256(environment_payload).hexdigest()
-                != entry.state.environment_sha256
-            ):
-                raise DeploymentStateError(
-                    "deployment environment snapshot hash is invalid"
+            if entry.event != "adopted":
+                transaction_id = cast(str, entry.transaction_id)
+                intent_sha256 = cast(str, entry.intent_sha256)
+                if transaction_id in completed_transactions:
+                    raise DeploymentStateError(
+                        "deployment transaction has duplicate outcomes"
+                    )
+                selected = intents.get(transaction_id)
+                if selected is None:
+                    raise DeploymentStateError("deployment journal intent is missing")
+                actual_intent_sha256, intent = selected
+                if actual_intent_sha256 != intent_sha256:
+                    raise DeploymentStateError(
+                        "deployment journal intent hash is invalid"
+                    )
+                preceding_sequence = entries[-1].sequence if entries else None
+                if (
+                    intent.baseline_journal_sequence != preceding_sequence
+                    or intent.baseline_journal_sha256 != previous_sha256
+                ):
+                    raise DeploymentStateError(
+                        "promotion intent journal baseline is invalid"
+                    )
+                current_sequence = (
+                    None if established is None else established.journal_sequence
                 )
+                current_sha256 = (
+                    None if established is None else established.journal_sha256
+                )
+                if (
+                    intent.baseline_current_sequence != current_sequence
+                    or intent.baseline_current_sha256 != current_sha256
+                ):
+                    raise DeploymentStateError(
+                        "promotion intent current baseline is invalid"
+                    )
+                if established is not None and (
+                    intent.target.compose_project != established.state.compose_project
+                    or intent.target.compose_service
+                    != established.state.compose_service
+                ):
+                    raise DeploymentStateError(
+                        "promotion target Compose identity changed"
+                    )
+                expected_state = (
+                    intent.target
+                    if entry.event == "promoted"
+                    else None
+                    if established is None
+                    else established.state
+                )
+                if entry.state != expected_state:
+                    raise DeploymentStateError(
+                        "deployment journal outcome state is invalid"
+                    )
+                if (
+                    entry.event != "promoted" or established is not None
+                ) and entry.persistent_volumes != intent.persistent_volumes:
+                    raise DeploymentStateError(
+                        "deployment journal volume identity is invalid"
+                    )
+                completed_transactions.add(transaction_id)
+            if entry.state is not None:
+                environment_payload = _read_private_file(
+                    self._store.path / entry.state.environment_snapshot,
+                    maximum_bytes=MAX_ENVIRONMENT_BYTES,
+                )
+                if (
+                    hashlib.sha256(environment_payload).hexdigest()
+                    != entry.state.environment_sha256
+                ):
+                    raise DeploymentStateError(
+                        "deployment environment snapshot hash is invalid"
+                    )
             entries.append(entry)
+            if entry.event in {"adopted", "promoted"}:
+                established_state = cast(DeploymentState, entry.state)
+                established = CurrentDeployment(
+                    journal_sequence=entry.sequence,
+                    journal_sha256=entry.sha256,
+                    state=established_state,
+                )
             previous_sha256 = payload_sha256
         return tuple(entries)
 
     def _desired_current(self) -> CurrentDeployment | None:
-        if not self._journal:
-            return None
-        latest = self._journal[-1]
-        return CurrentDeployment(
-            journal_sequence=latest.sequence,
-            journal_sha256=latest.sha256,
-            state=latest.state,
-        )
+        current: CurrentDeployment | None = None
+        for entry in self._journal:
+            if entry.event in {"adopted", "promoted"}:
+                established_state = cast(DeploymentState, entry.state)
+                current = CurrentDeployment(
+                    journal_sequence=entry.sequence,
+                    journal_sha256=entry.sha256,
+                    state=established_state,
+                )
+        return current
 
     def _read_current_file(self) -> CurrentDeployment | None:
         try:
@@ -770,6 +1428,8 @@ class DeploymentStateTransaction:
         if current.journal_sequence > desired.journal_sequence:
             raise DeploymentStateError("current deployment is ahead of the journal")
         indexed = self._journal[current.journal_sequence - 1]
+        if indexed.event not in {"adopted", "promoted"} or indexed.state is None:
+            raise DeploymentStateError("current deployment does not establish state")
         expected_existing = CurrentDeployment(
             journal_sequence=indexed.sequence,
             journal_sha256=indexed.sha256,
@@ -782,23 +1442,157 @@ class DeploymentStateTransaction:
             return desired
         return current
 
-    def _load_and_reconcile(self) -> None:
-        self._recover_temporary_files(
-            self._store.path,
-            temporary_pattern=_CURRENT_TEMPORARY_NAME,
+    def _read_pending_file(self) -> PendingPromotion | None:
+        try:
+            payload = _read_private_file(
+                self._store.pending_path,
+                maximum_bytes=MAX_JSON_BYTES,
+            )
+        except DeploymentStateError:
+            try:
+                self._store.pending_path.lstat()
+            except FileNotFoundError:
+                return None
+            raise
+        return _pending_from_document(
+            _decode_json(payload),
+            intents=self._intents,
         )
+
+    def _terminal_for_pending(
+        self,
+        pending: PendingPromotion,
+    ) -> JournalEntry | None:
+        matches = [
+            entry
+            for entry in self._journal
+            if entry.transaction_id == pending.transaction_id
+            and entry.intent_sha256 == pending.intent_sha256
+        ]
+        if len(matches) > 1:
+            raise DeploymentStateError(
+                "pending promotion has duplicate terminal outcomes"
+            )
+        return None if not matches else matches[0]
+
+    def _validate_unresolved_pending(self, pending: PendingPromotion) -> None:
+        tail_sequence = self._journal[-1].sequence if self._journal else None
+        tail_sha256 = self._journal[-1].sha256 if self._journal else None
+        if (
+            pending.intent.baseline_journal_sequence != tail_sequence
+            or pending.intent.baseline_journal_sha256 != tail_sha256
+        ):
+            raise DeploymentStateError("pending promotion journal baseline is stale")
+        current_sequence = (
+            None if self._current is None else self._current.journal_sequence
+        )
+        current_sha256 = None if self._current is None else self._current.journal_sha256
+        if (
+            pending.intent.baseline_current_sequence != current_sequence
+            or pending.intent.baseline_current_sha256 != current_sha256
+        ):
+            raise DeploymentStateError("pending promotion current baseline is stale")
+        if self._current is not None and (
+            pending.intent.target.compose_project != self._current.state.compose_project
+            or pending.intent.target.compose_service
+            != self._current.state.compose_service
+        ):
+            raise DeploymentStateError("promotion target Compose identity changed")
+
+    def _clear_pending_after_terminal(self, entry: JournalEntry) -> None:
+        transaction_id = cast(str, entry.transaction_id)
+        try:
+            self._store.pending_path.unlink()
+            _sync_directory(self._store.path)
+        except OSError as error:
+            raise DeploymentTerminalCommittedError(
+                entry.event,
+                transaction_id,
+            ) from error
+        self._pending = None
+
+    def _load_and_reconcile(self) -> None:
         self._recover_temporary_files(
             self._store.environments_path,
             temporary_pattern=_ENVIRONMENT_TEMPORARY_NAME,
             final_pattern=_ENVIRONMENT_NAME,
         )
+        if self._store.transactions_path.exists():
+            _validate_secure_path(
+                self._store.transactions_path,
+                expected_mode=0o700,
+                directory=True,
+                require_one_link=False,
+            )
+            self._recover_temporary_files(
+                self._store.transactions_path,
+                temporary_pattern=_INTENT_TEMPORARY_NAME,
+                final_pattern=_INTENT_NAME,
+            )
         self._recover_temporary_files(
             self._store.journal_path,
             temporary_pattern=_JOURNAL_TEMPORARY_NAME,
             final_pattern=_JOURNAL_NAME,
+            classify_terminal=True,
         )
-        self._journal = self._load_journal()
-        self._current = self._reconcile_current()
+        self._intents = self._load_intents()
+        self._journal = self._load_journal(self._intents)
+
+        try:
+            self._store.pending_path.lstat()
+        except FileNotFoundError:
+            pending_marker = False
+        else:
+            pending_marker = True
+        tail = None if not self._journal else self._journal[-1]
+        committed_recovery = (
+            tail
+            if pending_marker and tail is not None and tail.event in _TERMINAL_EVENTS
+            else None
+        )
+        try:
+            self._recover_temporary_files(
+                self._store.path,
+                temporary_pattern=_CURRENT_TEMPORARY_NAME,
+            )
+            self._recover_temporary_files(
+                self._store.path,
+                temporary_pattern=_PENDING_TEMPORARY_NAME,
+                final_pattern=_PENDING_NAME,
+            )
+            self._pending = self._read_pending_file()
+        except (OSError, DeploymentStateError) as error:
+            if committed_recovery is None:
+                raise
+            transaction_id = cast(str, committed_recovery.transaction_id)
+            raise DeploymentTerminalCommittedError(
+                committed_recovery.event,
+                transaction_id,
+            ) from error
+        terminal = (
+            None if self._pending is None else self._terminal_for_pending(self._pending)
+        )
+        if terminal is not None and terminal != tail:
+            raise DeploymentStateError(
+                "pending promotion terminal is not the journal tail"
+            )
+        try:
+            self._current = self._reconcile_current()
+        except (OSError, DeploymentStateError) as error:
+            if terminal is None:
+                raise
+            transaction_id = cast(str, terminal.transaction_id)
+            raise DeploymentTerminalCommittedError(
+                terminal.event,
+                transaction_id,
+            ) from error
+        if self._pending is None:
+            return
+        if terminal is not None:
+            self._clear_pending_after_terminal(terminal)
+            self._recovered_terminal = terminal
+            return
+        self._validate_unresolved_pending(self._pending)
 
     def current(self) -> CurrentDeployment | None:
         """Return the lock-scoped current deployment."""
@@ -809,6 +1603,479 @@ class DeploymentStateTransaction:
         """Return the verified lock-scoped journal."""
         self._require_open()
         return self._journal
+
+    def pending(self) -> PendingPromotion | None:
+        """Return the unresolved lock-scoped promotion intent, if any."""
+        self._require_open()
+        return self._pending
+
+    def recovered_terminal(self) -> JournalEntry | None:
+        """Return a terminal outcome reconciled while opening this transaction."""
+        self._require_open()
+        return self._recovered_terminal
+
+    def _require_no_recovered_terminal(self) -> None:
+        if self._recovered_terminal is None:
+            return
+        raise DeploymentTerminalCommittedError(
+            self._recovered_terminal.event,
+            cast(str, self._recovered_terminal.transaction_id),
+        )
+
+    def _tail_identity(self) -> tuple[int | None, str | None]:
+        if not self._journal:
+            return None, None
+        tail = self._journal[-1]
+        return tail.sequence, tail.sha256
+
+    def _current_identity(self) -> tuple[int | None, str | None]:
+        if self._current is None:
+            return None, None
+        return self._current.journal_sequence, self._current.journal_sha256
+
+    def _recorded_state(self, state: DeploymentState) -> bool:
+        if any(entry.state == state for entry in self._journal):
+            return True
+        return any(intent.target == state for _, intent in self._intents.values())
+
+    def read_environment(self, state: DeploymentState) -> bytes:
+        """Read exact private bytes belonging to one recorded deployment state."""
+        self._require_open()
+        if not self._recorded_state(state):
+            raise DeploymentStateError("deployment environment state is not recorded")
+        payload = _read_private_file(
+            self._store.path / state.environment_snapshot,
+            maximum_bytes=MAX_ENVIRONMENT_BYTES,
+        )
+        if hashlib.sha256(payload).hexdigest() != state.environment_sha256:
+            raise DeploymentStateError(
+                "deployment environment snapshot hash is invalid"
+            )
+        return payload
+
+    def _environment_destination_parent(self, destination: Path) -> Path:
+        if not destination.is_absolute() or destination != destination.resolve(
+            strict=False
+        ):
+            raise DeploymentStateError(
+                "deployment environment destination must be absolute and normalized"
+            )
+        try:
+            parent = destination.parent.resolve(strict=True)
+            parent_metadata = parent.stat()
+        except OSError:
+            raise DeploymentStateError(
+                "deployment environment destination parent is unavailable"
+            ) from None
+        if (
+            parent != destination.parent
+            or not stat.S_ISDIR(parent_metadata.st_mode)
+            or parent_metadata.st_uid != os.geteuid()
+            or stat.S_IMODE(parent_metadata.st_mode) & 0o022
+        ):
+            raise DeploymentStateError(
+                "deployment environment destination parent is unsafe"
+            )
+        return parent
+
+    def install_environment(
+        self,
+        state: DeploymentState,
+        destination: Path,
+    ) -> None:
+        """Atomically install exact recorded environment bytes at a private path."""
+        self._require_open()
+        self._require_no_recovered_terminal()
+        self._environment_destination_parent(destination)
+        try:
+            destination.lstat()
+        except FileNotFoundError:
+            pass
+        else:
+            _validate_secure_path(
+                destination,
+                expected_mode=0o600,
+                directory=False,
+            )
+        payload = self.read_environment(state)
+        _publish_private_file(
+            destination,
+            payload,
+            replace=True,
+            prefix=".deployment-install-",
+        )
+        installed = _read_private_file(
+            destination,
+            maximum_bytes=MAX_ENVIRONMENT_BYTES,
+        )
+        if installed != payload:
+            raise DeploymentStateError(
+                "installed deployment environment does not match"
+            )
+
+    def verify_installed_environment(
+        self,
+        state: DeploymentState,
+        destination: Path,
+        *,
+        allow_missing: bool = False,
+    ) -> bool:
+        """Prove exact installed private bytes without mutating the destination."""
+        self._require_open()
+        self._environment_destination_parent(destination)
+        expected_payload = self.read_environment(state)
+        try:
+            destination.lstat()
+        except FileNotFoundError:
+            if allow_missing:
+                return False
+            raise DeploymentStateError(
+                "installed deployment environment is missing"
+            ) from None
+        installed_payload = _read_private_file(
+            destination,
+            maximum_bytes=MAX_ENVIRONMENT_BYTES,
+        )
+        if (
+            installed_payload != expected_payload
+            or hashlib.sha256(installed_payload).hexdigest() != state.environment_sha256
+        ):
+            raise DeploymentStateError(
+                "installed deployment environment does not match recorded state"
+            )
+        return True
+
+    def remove_environment(
+        self,
+        state: DeploymentState,
+        destination: Path,
+    ) -> None:
+        """Idempotently remove an exact recorded environment and sync its parent."""
+        self._require_open()
+        self._require_no_recovered_terminal()
+        parent = self._environment_destination_parent(destination)
+        expected_payload = self.read_environment(state)
+        try:
+            before = _validate_secure_path(
+                destination,
+                expected_mode=0o600,
+                directory=False,
+            )
+        except DeploymentStateError:
+            try:
+                destination.lstat()
+            except FileNotFoundError:
+                return
+            raise
+        installed_payload = _read_private_file(
+            destination,
+            maximum_bytes=MAX_ENVIRONMENT_BYTES,
+        )
+        if (
+            installed_payload != expected_payload
+            or hashlib.sha256(installed_payload).hexdigest() != state.environment_sha256
+        ):
+            raise DeploymentStateError(
+                "installed deployment environment does not match recorded state"
+            )
+        confirmed = _validate_secure_path(
+            destination,
+            expected_mode=0o600,
+            directory=False,
+        )
+        if _metadata_identity(confirmed) != _metadata_identity(before):
+            raise DeploymentStateError(
+                "installed deployment environment changed before removal"
+            )
+        destination.unlink()
+        _sync_directory(parent)
+
+    def begin_promotion(
+        self,
+        *,
+        compose_project: str,
+        compose_service: str,
+        source_revision: str,
+        image_reference: str,
+        image_id: str,
+        oci_revision: str,
+        environment_source: Path,
+        candidate: CandidateReceipt,
+        persistent_volumes: Sequence[PersistentVolumeIdentity],
+        transaction_id: str | None = None,
+        recorded_at: str | None = None,
+    ) -> PendingPromotion:
+        """Durably publish one immutable promotion intent before cutover."""
+        self._require_open()
+        self._require_no_recovered_terminal()
+        if self._pending is not None:
+            raise DeploymentStateError("a promotion transaction is already pending")
+
+        selected_id = uuid.uuid4().hex if transaction_id is None else transaction_id
+        selected_time = _now() if recorded_at is None else recorded_at
+        snapshot_relative = f"environments/{selected_id}.env"
+        provisional = {
+            "schema_version": PROMOTION_SCHEMA_VERSION,
+            "deployment_id": selected_id,
+            "recorded_at": selected_time,
+            "compose_project": compose_project,
+            "compose_service": compose_service,
+            "source_revision": source_revision,
+            "image_reference": image_reference,
+            "image_id": image_id,
+            "oci_revision": oci_revision,
+            "environment_snapshot": snapshot_relative,
+            "environment_sha256": "0" * 64,
+            "adopted": False,
+        }
+        validated_target = _target_state_from_document(provisional)
+        validated_candidate = _candidate_from_document(candidate.as_document())
+        volumes = _validated_volume_identities(persistent_volumes)
+
+        baseline_sequence, baseline_sha256 = self._tail_identity()
+        current_sequence, current_sha256 = self._current_identity()
+        if (
+            validated_candidate.baseline_journal_sequence != baseline_sequence
+            or validated_candidate.baseline_journal_sha256 != baseline_sha256
+        ):
+            raise DeploymentStateError("candidate receipt baseline does not match")
+        if (
+            validated_candidate.compose_service != validated_target.compose_service
+            or validated_candidate.compose_project == validated_target.compose_project
+            or validated_candidate.image_reference != validated_target.image_reference
+            or validated_candidate.image_id != validated_target.image_id
+            or validated_candidate.oci_revision != validated_target.oci_revision
+            or validated_target.source_revision != validated_target.oci_revision
+        ):
+            raise DeploymentStateError("candidate receipt target does not match")
+        if self._current is not None and (
+            self._current.state.compose_project != validated_target.compose_project
+            or self._current.state.compose_service != validated_target.compose_service
+        ):
+            raise DeploymentStateError("promotion target Compose identity changed")
+
+        environment_payload = _read_private_file(
+            environment_source,
+            maximum_bytes=MAX_ENVIRONMENT_BYTES,
+        )
+        environment_sha256 = hashlib.sha256(environment_payload).hexdigest()
+        target = DeploymentState(
+            deployment_id=validated_target.deployment_id,
+            recorded_at=validated_target.recorded_at,
+            compose_project=validated_target.compose_project,
+            compose_service=validated_target.compose_service,
+            source_revision=validated_target.source_revision,
+            image_reference=validated_target.image_reference,
+            image_id=validated_target.image_id,
+            oci_revision=validated_target.oci_revision,
+            environment_snapshot=validated_target.environment_snapshot,
+            environment_sha256=environment_sha256,
+            adopted=False,
+        )
+        intent = PromotionIntent(
+            transaction_id=selected_id,
+            recorded_at=selected_time,
+            baseline_journal_sequence=baseline_sequence,
+            baseline_journal_sha256=baseline_sha256,
+            baseline_current_sequence=current_sequence,
+            baseline_current_sha256=current_sha256,
+            target=target,
+            candidate=validated_candidate,
+            persistent_volumes=volumes,
+        )
+        validated_intent = _intent_from_document(intent.as_document())
+        intent_payload = _canonical_json(validated_intent.as_document())
+        if len(intent_payload) > MAX_JSON_BYTES:
+            raise DeploymentStateError("promotion intent exceeds the size limit")
+
+        _ensure_secure_directory(self._store.transactions_path)
+        snapshot_path = self._store.path / target.environment_snapshot
+        intent_path = self._store.transactions_path / f"{selected_id}.json"
+        if snapshot_path.exists() or intent_path.exists():
+            raise DeploymentStateError("promotion transaction identity already exists")
+        _publish_private_file(
+            snapshot_path,
+            environment_payload,
+            replace=False,
+            prefix=".deployment-environment-",
+        )
+        intent_sha256 = hashlib.sha256(intent_payload).hexdigest()
+        _publish_private_file(
+            intent_path,
+            intent_payload,
+            replace=False,
+            prefix=".deployment-intent-",
+        )
+        pending = PendingPromotion(
+            transaction_id=selected_id,
+            intent_path=f"transactions/{selected_id}.json",
+            intent_sha256=intent_sha256,
+            intent=validated_intent,
+        )
+        _publish_private_file(
+            self._store.pending_path,
+            _canonical_json(pending.as_document()),
+            replace=False,
+            prefix=".deployment-pending-",
+        )
+        self._intents[selected_id] = (intent_sha256, validated_intent)
+        self._pending = pending
+        return pending
+
+    def _selected_pending(
+        self,
+        transaction_id: str,
+    ) -> PendingPromotion:
+        self._require_no_recovered_terminal()
+        if self._indeterminate_terminal is not None:
+            event, indeterminate_id = self._indeterminate_terminal
+            raise DeploymentTerminalIndeterminateError(
+                event,
+                indeterminate_id,
+            )
+        if _DEPLOYMENT_ID.fullmatch(transaction_id) is None:
+            raise DeploymentStateError("promotion transaction identity is invalid")
+        if self._pending is None:
+            raise DeploymentStateError("no promotion transaction is pending")
+        if self._pending.transaction_id != transaction_id:
+            raise DeploymentStateError("pending promotion identity does not match")
+        terminal = self._terminal_for_pending(self._pending)
+        if terminal is not None:
+            raise DeploymentTerminalCommittedError(
+                terminal.event,
+                transaction_id,
+            )
+        return self._pending
+
+    def _publish_terminal(
+        self,
+        *,
+        event: str,
+        transaction_id: str,
+        persistent_volumes: Sequence[PersistentVolumeIdentity],
+    ) -> CurrentDeployment | None:
+        if event not in _TERMINAL_EVENTS:
+            raise DeploymentStateError("deployment journal event is invalid")
+        pending = self._selected_pending(transaction_id)
+        observed_volumes = _validated_volume_identities(persistent_volumes)
+        if (
+            event != "promoted" or self._current is not None
+        ) and observed_volumes != pending.intent.persistent_volumes:
+            raise DeploymentStateError(
+                "persistent volume identity changed during promotion"
+            )
+        state = (
+            pending.intent.target
+            if event == "promoted"
+            else None
+            if self._current is None
+            else self._current.state
+        )
+        sequence = len(self._journal) + 1
+        previous_sha256 = None if not self._journal else self._journal[-1].sha256
+        entry = JournalEntry(
+            sequence=sequence,
+            sha256="0" * 64,
+            previous_sha256=previous_sha256,
+            event=event,
+            state=state,
+            transaction_id=transaction_id,
+            intent_sha256=pending.intent_sha256,
+            persistent_volumes=observed_volumes,
+        )
+        payload = _canonical_json(entry.as_document())
+        sha256 = hashlib.sha256(payload).hexdigest()
+        committed_entry = JournalEntry(
+            sequence=sequence,
+            sha256=sha256,
+            previous_sha256=previous_sha256,
+            event=event,
+            state=state,
+            transaction_id=transaction_id,
+            intent_sha256=pending.intent_sha256,
+            persistent_volumes=observed_volumes,
+        )
+        journal_path = self._store.journal_path / f"{sequence:020d}.json"
+        try:
+            _publish_private_file(
+                journal_path,
+                payload,
+                replace=False,
+                prefix=".deployment-journal-",
+            )
+        except OSError as error:
+            try:
+                journal_path.lstat()
+            except FileNotFoundError:
+                raise error from None
+            except OSError:
+                pass
+            self._indeterminate_terminal = (event, transaction_id)
+            raise DeploymentTerminalIndeterminateError(
+                event,
+                transaction_id,
+            ) from error
+
+        self._journal = (*self._journal, committed_entry)
+        if event == "promoted":
+            current = CurrentDeployment(
+                journal_sequence=sequence,
+                journal_sha256=sha256,
+                state=pending.intent.target,
+            )
+            self._current = current
+            try:
+                self._publish_current(current)
+            except OSError as error:
+                raise DeploymentTerminalCommittedError(
+                    event,
+                    transaction_id,
+                ) from error
+        self._clear_pending_after_terminal(committed_entry)
+        return self._current
+
+    def commit_promotion(
+        self,
+        transaction_id: str,
+        *,
+        persistent_volumes: Sequence[PersistentVolumeIdentity],
+    ) -> CurrentDeployment:
+        """Commit a verified target; terminal journal durability is authoritative."""
+        self._require_open()
+        current = self._publish_terminal(
+            event="promoted",
+            transaction_id=transaction_id,
+            persistent_volumes=persistent_volumes,
+        )
+        return cast(CurrentDeployment, current)
+
+    def record_rollback(
+        self,
+        transaction_id: str,
+        *,
+        persistent_volumes: Sequence[PersistentVolumeIdentity],
+    ) -> CurrentDeployment | None:
+        """Record independently verified restoration of the prior deployment."""
+        self._require_open()
+        return self._publish_terminal(
+            event="rolled_back",
+            transaction_id=transaction_id,
+            persistent_volumes=persistent_volumes,
+        )
+
+    def record_abort(
+        self,
+        transaction_id: str,
+        *,
+        persistent_volumes: Sequence[PersistentVolumeIdentity],
+    ) -> CurrentDeployment | None:
+        """Record cancellation before production mutation."""
+        self._require_open()
+        return self._publish_terminal(
+            event="aborted",
+            transaction_id=transaction_id,
+            persistent_volumes=persistent_volumes,
+        )
 
     def adopt(
         self,
@@ -825,7 +2092,8 @@ class DeploymentStateTransaction:
     ) -> CurrentDeployment:
         """Record one explicitly observed legacy deployment without overwriting."""
         self._require_open()
-        if self._current is not None or self._journal:
+        self._require_no_recovered_terminal()
+        if self._current is not None or self._journal or self._pending is not None:
             raise DeploymentStateError("deployment state has already been initialized")
 
         selected_id = uuid.uuid4().hex if deployment_id is None else deployment_id

--- a/src/agent/deployment_state_cli.py
+++ b/src/agent/deployment_state_cli.py
@@ -74,9 +74,16 @@ def _inspect(store: DeploymentStateStore) -> int:
     with store.transaction() as transaction:
         current = transaction.current()
         journal = transaction.journal()
+        pending = transaction.pending()
         _emit(
             {
-                "status": "empty" if current is None else "recorded",
+                "status": (
+                    "pending"
+                    if pending is not None
+                    else "empty"
+                    if current is None
+                    else "recorded"
+                ),
                 "current": None if current is None else current.as_document(),
                 "journal": [
                     {
@@ -85,6 +92,7 @@ def _inspect(store: DeploymentStateStore) -> int:
                     }
                     for entry in journal
                 ],
+                "pending": None if pending is None else pending.as_document(),
             }
         )
     return 0
@@ -98,7 +106,11 @@ def _adopt(arguments: argparse.Namespace, store: DeploymentStateStore) -> int:
         else arguments.environment_file
     )
     with store.transaction() as transaction:
-        if transaction.current() is not None:
+        if (
+            transaction.current() is not None
+            or transaction.journal()
+            or transaction.pending() is not None
+        ):
             raise DeploymentStateCliError(
                 "deployment state has already been initialized"
             )

--- a/tests/test_compose_env.py
+++ b/tests/test_compose_env.py
@@ -17,6 +17,7 @@ import pytest
 from agent.compose_env import (
     ComposeEnvironmentError,
     main,
+    parse_compose_environment,
     quote_compose_value,
     serialize_compose_environment,
     write_compose_environment,
@@ -128,6 +129,65 @@ def test_serialize_compose_environment_rejects_missing_keys() -> None:
         )
 
     assert "secret-canary" not in str(error.value)
+
+
+def test_parse_compose_environment_inverts_the_exact_serializer() -> None:
+    """Recover every supported escape without evaluating shell syntax."""
+    environment = {
+        "FIRST": "",
+        "SECOND": (
+            "dollar$VAR${OTHER} quote\" single' backslash\\ tab\t unicode-हॅलो # equals="
+        ),
+    }
+    payload = serialize_compose_environment(
+        ["SECOND", "FIRST"],
+        environment,
+    )
+
+    assert parse_compose_environment(payload, ["SECOND", "FIRST"]) == {
+        "SECOND": environment["SECOND"],
+        "FIRST": "",
+    }
+
+
+@pytest.mark.parametrize(
+    ("payload", "names"),
+    [
+        ('KEY="value"\n', []),
+        ('INVALID-NAME="value"\n', ["INVALID-NAME"]),
+        ('KEY="value"\nKEY="value"\n', ["KEY", "KEY"]),
+        ('KEY="value"', ["KEY"]),
+        ('KEY="before\0after"\n', ["KEY"]),
+        ('KEY="before\rafter"\n', ["KEY"]),
+        ('KEY="value"\nEXTRA="value"\n', ["KEY"]),
+        ('OTHER="value"\n', ["KEY"]),
+        ("KEY=value\n", ["KEY"]),
+        ('KEY="value\n', ["KEY"]),
+        ('KEY="trailing\\"\n', ["KEY"]),
+        ('KEY="$value"\n', ["KEY"]),
+        ('KEY="trailing$"\n', ["KEY"]),
+        ('KEY="raw"quote"\n', ["KEY"]),
+        ('KEY="noncanonical\\q"\n', ["KEY"]),
+    ],
+)
+def test_parse_compose_environment_rejects_noncanonical_payloads(
+    payload: str,
+    names: list[str],
+) -> None:
+    """Reject malformed framing and escapes without reflecting payload bytes."""
+    with pytest.raises(
+        ComposeEnvironmentError,
+        match=(
+            "at least one environment key is required"
+            "|environment key is invalid"
+            "|environment key is duplicated"
+            "|serialized environment is invalid"
+        ),
+    ) as error:
+        parse_compose_environment(payload, names)
+
+    assert "value" not in str(error.value)
+    assert "before" not in str(error.value)
 
 
 def test_write_compose_environment_creates_complete_private_file(

--- a/tests/test_compose_workflow.py
+++ b/tests/test_compose_workflow.py
@@ -245,7 +245,7 @@ def test_workflow_checkout_is_immutable_and_drops_credentials() -> None:
     document = WORKFLOW_PATH.read_text(encoding="utf-8")
     checkout_uses = list(CHECKOUT_USES_PATTERN.finditer(document))
 
-    assert len(checkout_uses) == 4
+    assert len(checkout_uses) == 5
     for checkout_use in checkout_uses:
         checkout_reference = checkout_use.group("reference")
         assert re.fullmatch(r"[0-9a-f]{40}", checkout_reference)
@@ -254,7 +254,7 @@ def test_workflow_checkout_is_immutable_and_drops_credentials() -> None:
     assert {match.group("reference") for match in checkout_uses} == {
         "3d3c42e5aac5ba805825da76410c181273ba90b1"
     }
-    assert document.count("persist-credentials: false") == 4
+    assert document.count("persist-credentials: false") == 5
     assert "secrets." not in document
     assert "packages: write" not in document
     assert "docker/login-action" not in document

--- a/tests/test_deployment_adoption.py
+++ b/tests/test_deployment_adoption.py
@@ -115,10 +115,24 @@ class ObservationBoundary:
         assert timeout == 30
         assert env["GIT_OPTIONAL_LOCKS"] == "0"
         assert env["GIT_TERMINAL_PROMPT"] == "0"
+        assert env["GIT_CONFIG_COUNT"] == "2"
+        assert env["GIT_CONFIG_GLOBAL"] == "/dev/null"
+        assert env["GIT_CONFIG_SYSTEM"] == "/dev/null"
+        assert env["GIT_CONFIG_NOSYSTEM"] == "1"
+        assert env["GIT_NO_REPLACE_OBJECTS"] == "1"
+        assert env["GIT_CONFIG_KEY_0"] == "core.hooksPath"
+        assert env["GIT_CONFIG_VALUE_0"] == "/dev/null"
+        assert env["GIT_CONFIG_KEY_1"] == "core.fsmonitor"
+        assert env["GIT_CONFIG_VALUE_1"] == "false"
         assert env["LC_ALL"] == "C"
         assert env["LANG"] == "C"
         assert "GIT_DIR" not in env
+        assert "OPENROUTER_API_KEY" not in env
         assert env["DOCKER_CONFIG"] == "/private/docker-config"
+        if "DOCKER_HOST" in os.environ:
+            assert env["DOCKER_HOST"] == os.environ["DOCKER_HOST"]
+        if "XDG_RUNTIME_DIR" in os.environ:
+            assert env["XDG_RUNTIME_DIR"] == os.environ["XDG_RUNTIME_DIR"]
 
         selected = tuple(command)
         self.calls.append(selected)
@@ -146,6 +160,8 @@ class ObservationBoundary:
                 "-C",
                 str(self.checkout),
                 "diff",
+                "--no-ext-diff",
+                "--no-textconv",
                 "--quiet",
                 "--",
             ]:
@@ -155,6 +171,8 @@ class ObservationBoundary:
                 str(self.checkout),
                 "diff",
                 "--cached",
+                "--no-ext-diff",
+                "--no-textconv",
                 "--quiet",
                 "--",
             ]:
@@ -747,7 +765,10 @@ def test_default_process_environment_is_sanitized(
         os.environ,
         {
             "DOCKER_CONFIG": "/private/docker-config",
+            "DOCKER_HOST": "unix:///private/docker.sock",
             "GIT_WORK_TREE": "secret",
+            "OPENROUTER_API_KEY": "secret-canary",
+            "XDG_RUNTIME_DIR": "/private/runtime",
         },
         clear=True,
     ):

--- a/tests/test_deployment_adoption.py
+++ b/tests/test_deployment_adoption.py
@@ -30,6 +30,17 @@ IMAGE_REFERENCE = f"ghcr.io/queryplanner/agent@sha256:{'e' * 64}"
 PROJECT = "adk-template"
 SERVICE = "agent"
 SECRET_ENVIRONMENT = b'API_KEY="secret-observation-canary"\n'
+HOST_ENVIRONMENT_NAMES = (
+    "HOME",
+    "PATH",
+    "DOCKER_CONFIG",
+    "DOCKER_HOST",
+    "XDG_RUNTIME_DIR",
+)
+DEFAULT_HOST_ENVIRONMENT = {
+    "PATH": "/usr/bin:/bin",
+    "DOCKER_CONFIG": "/private/docker-config",
+}
 
 
 def _completed(
@@ -64,6 +75,9 @@ class ObservationBoundary:
     image_document: object = field(default_factory=dict)
     fail_command: tuple[str, ...] | None = None
     calls: list[tuple[str, ...]] = field(default_factory=list)
+    expected_host_environment: dict[str, str] = field(
+        default_factory=lambda: dict(DEFAULT_HOST_ENVIRONMENT)
+    )
 
     def __post_init__(self) -> None:
         if self.top_level is None:
@@ -128,11 +142,9 @@ class ObservationBoundary:
         assert env["LANG"] == "C"
         assert "GIT_DIR" not in env
         assert "OPENROUTER_API_KEY" not in env
-        assert env["DOCKER_CONFIG"] == "/private/docker-config"
-        if "DOCKER_HOST" in os.environ:
-            assert env["DOCKER_HOST"] == os.environ["DOCKER_HOST"]
-        if "XDG_RUNTIME_DIR" in os.environ:
-            assert env["XDG_RUNTIME_DIR"] == os.environ["XDG_RUNTIME_DIR"]
+        assert {
+            name: env[name] for name in HOST_ENVIRONMENT_NAMES if name in env
+        } == self.expected_host_environment
 
         selected = tuple(command)
         self.calls.append(selected)
@@ -215,6 +227,13 @@ class ObservationHarness:
     boundary: ObservationBoundary
 
     def arguments(self) -> dict[str, object]:
+        environment = dict(self.boundary.expected_host_environment)
+        environment.update(
+            {
+                "GIT_DIR": "secret-git-override",
+                "LANG": "host-locale",
+            }
+        )
         return {
             "checkout_path": self.checkout,
             "expected_origin": ORIGIN,
@@ -223,12 +242,7 @@ class ObservationHarness:
             "environment_path": self.environment_path,
             "git_executable": self.git,
             "docker_executable": self.docker,
-            "environment": {
-                "PATH": "/usr/bin:/bin",
-                "DOCKER_CONFIG": "/private/docker-config",
-                "GIT_DIR": "secret-git-override",
-                "LANG": "host-locale",
-            },
+            "environment": environment,
         }
 
 
@@ -760,6 +774,11 @@ def test_default_process_environment_is_sanitized(
     """Exercise the production environment path without preserving Git overrides."""
     arguments = observation_harness.arguments()
     arguments["environment"] = None
+    observation_harness.boundary.expected_host_environment = {
+        "DOCKER_CONFIG": "/private/docker-config",
+        "DOCKER_HOST": "unix:///private/docker.sock",
+        "XDG_RUNTIME_DIR": "/private/runtime",
+    }
 
     with patch.dict(
         os.environ,
@@ -773,6 +792,22 @@ def test_default_process_environment_is_sanitized(
         clear=True,
     ):
         observation = _observe(observation_harness, arguments=arguments)
+
+    assert observation is not None
+
+
+def test_explicit_host_environment_ignores_process_optional_fields(
+    observation_harness: ObservationHarness,
+) -> None:
+    """Derive optional Docker fields from the explicit source, not the process."""
+    with patch.dict(
+        os.environ,
+        {
+            "DOCKER_HOST": "unix:///process/docker.sock",
+            "XDG_RUNTIME_DIR": "/process/runtime",
+        },
+    ):
+        observation = _observe(observation_harness)
 
     assert observation is not None
 

--- a/tests/test_deployment_promotion.py
+++ b/tests/test_deployment_promotion.py
@@ -1693,24 +1693,71 @@ def test_run_redacts_process_failures_and_bounds_output(
 ) -> None:
     executable = tmp_path / "tool"
     executable.touch()
+    secret = f"private-{tmp_path.name}"
     real_run = subprocess.run
     timeout_mock = create_autospec(
         real_run,
         spec_set=True,
-        side_effect=subprocess.TimeoutExpired(["tool"], 1),
+        side_effect=subprocess.TimeoutExpired(
+            ["tool", secret],
+            1,
+            output=secret,
+            stderr=secret,
+        ),
     )
     monkeypatch.setattr(subprocess, "run", timeout_mock)
-    with pytest.raises(promotion_module.PromotionError, match="command failed"):
-        promotion_module._run(executable, (), environment={})
+    with pytest.raises(promotion_module.PromotionError) as timeout_error:
+        promotion_module._run(
+            executable,
+            (secret,),
+            operation=promotion_module.CommandOperation.CANDIDATE_START,
+            environment={"PRIVATE": secret},
+        )
+    assert str(timeout_error.value) == (
+        "deployment command timed out during candidate Compose start"
+    )
+    assert secret not in str(timeout_error.value)
 
     failed_mock = create_autospec(
         real_run,
         spec_set=True,
-        return_value=subprocess.CompletedProcess(["tool"], 9, "", "private"),
+        return_value=subprocess.CompletedProcess(
+            ["tool", secret],
+            9,
+            secret,
+            secret,
+        ),
     )
     monkeypatch.setattr(subprocess, "run", failed_mock)
-    with pytest.raises(promotion_module.PromotionError, match="command failed"):
-        promotion_module._run(executable, (), environment={})
+    with pytest.raises(promotion_module.PromotionError) as failed_error:
+        promotion_module._run(
+            executable,
+            (secret,),
+            operation=promotion_module.CommandOperation.CANDIDATE_START,
+            environment={"PRIVATE": secret},
+        )
+    assert str(failed_error.value) == (
+        "deployment command failed during candidate Compose start (exit 9)"
+    )
+    assert secret not in str(failed_error.value)
+
+    os_error_mock = create_autospec(
+        real_run,
+        spec_set=True,
+        side_effect=OSError(secret),
+    )
+    monkeypatch.setattr(subprocess, "run", os_error_mock)
+    with pytest.raises(promotion_module.PromotionError) as os_error:
+        promotion_module._run(
+            executable,
+            (secret,),
+            operation=promotion_module.CommandOperation.CANDIDATE_START,
+            environment={"PRIVATE": secret},
+        )
+    assert str(os_error.value) == (
+        "deployment command could not start during candidate Compose start"
+    )
+    assert secret not in str(os_error.value)
 
     large_mock = create_autospec(
         real_run,
@@ -1724,7 +1771,12 @@ def test_run_redacts_process_failures_and_bounds_output(
     )
     monkeypatch.setattr(subprocess, "run", large_mock)
     with pytest.raises(promotion_module.PromotionError, match="too large"):
-        promotion_module._run(executable, (), environment={})
+        promotion_module._run(
+            executable,
+            (),
+            operation=promotion_module.CommandOperation.CANDIDATE_START,
+            environment={},
+        )
 
 
 def test_missing_environment_and_line_injection_are_redacted(
@@ -2285,7 +2337,12 @@ def test_run_bounds_stderr_output(
     )
     monkeypatch.setattr(subprocess, "run", run_mock)
     with pytest.raises(promotion_module.PromotionError, match="too large"):
-        promotion_module._run(executable, (), environment={})
+        promotion_module._run(
+            executable,
+            (),
+            operation=promotion_module.CommandOperation.CANDIDATE_START,
+            environment={},
+        )
 
 
 def test_main_redacts_real_host_oserror(

--- a/tests/test_deployment_promotion.py
+++ b/tests/test_deployment_promotion.py
@@ -1,0 +1,3061 @@
+"""Transactional promotion controller tests with real state and filesystem code."""
+
+from __future__ import annotations
+
+import errno
+import fcntl
+import io
+import json
+import os
+import runpy
+import shutil
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from unittest.mock import create_autospec
+
+import pytest
+
+from agent import deployment_promotion as promotion_module
+from agent.compose_env import serialize_compose_environment
+from agent.deployment_promotion import (
+    PRODUCTION_ENVIRONMENT_NAMES,
+    PromotionConfig,
+    main,
+    promote,
+)
+from agent.deployment_state import (
+    CandidateReceipt,
+    DeploymentStateStore,
+    PersistentVolumeIdentity,
+)
+
+REAL_SUBPROCESS_RUN = subprocess.run
+REAL_SHUTIL_WHICH = shutil.which
+
+OLD_REVISION = "a" * 40
+TARGET_REVISION = "b" * 40
+OLD_IMAGE_ID = f"sha256:{'c' * 64}"
+TARGET_IMAGE_ID = f"sha256:{'d' * 64}"
+MANUAL_IMAGE_ID = f"sha256:{'9' * 64}"
+OLD_IMAGE = f"ghcr.io/queryplanner/agent@sha256:{'e' * 64}"
+TARGET_IMAGE = f"ghcr.io/queryplanner/agent@sha256:{'f' * 64}"
+MANUAL_IMAGE = f"ghcr.io/queryplanner/agent@sha256:{'8' * 64}"
+OLD_CONTAINER = "1" * 64
+TARGET_CONTAINER = "2" * 64
+CANDIDATE_CONTAINER = "3" * 64
+FRESH_TRANSACTION = f"{'0' * 23}-{OLD_REVISION}"
+PROJECT = "adk-agent"
+SERVICE = "agent"
+ORIGIN = "https://github.com/QueryPlanner/google-adk-on-bare-metal"
+VOLUME = PersistentVolumeIdentity(
+    name="adk-agent_agent_artifacts",
+    driver="local",
+    mountpoint="/var/lib/docker/volumes/adk-agent/_data",
+    destination="/app/src/.adk",
+    created_at="2026-07-28T12:00:00.000000Z",
+)
+REPLACED_VOLUME = PersistentVolumeIdentity(
+    name=VOLUME.name,
+    driver=VOLUME.driver,
+    mountpoint=VOLUME.mountpoint,
+    destination=VOLUME.destination,
+    created_at="2026-07-28T12:00:01.000000Z",
+)
+SECRETS = {
+    "AGENT_NAME": "production-agent",
+    "DATABASE_URL": "postgresql://secret-$VALUE",
+    "OPENROUTER_API_KEY": "openrouter-$(private)",
+    "GOOGLE_API_KEY": "google-`private`",
+    "ROOT_AGENT_MODEL": "openrouter/provider/model",
+    "LANGFUSE_PUBLIC_KEY": "public",
+    "LANGFUSE_SECRET_KEY": "langfuse-secret",
+    "LANGFUSE_BASE_URL": "https://langfuse.example",
+    "LOG_LEVEL": "INFO",
+    "PORT": "8080",
+    "HOST": "0.0." + "0.0",
+}
+
+
+def _private(path: Path, payload: bytes) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
+    path.chmod(0o600)
+    return path
+
+
+@dataclass
+class Host:
+    """Stateful fake for only the Git and Docker process boundaries."""
+
+    checkout: Path
+    release: Path
+    state_dir: Path
+    bin_dir: Path
+    production_exists: bool = True
+    production_revision: str = OLD_REVISION
+    production_image: str = OLD_IMAGE
+    production_image_id: str = OLD_IMAGE_ID
+    production_healthy: bool = True
+    volume_exists: bool = True
+    candidate_exists: bool = False
+    fail_candidate: bool = False
+    fail_target_health: bool = False
+    fail_rollback_up: bool = False
+    fail_target_checkout: bool = False
+    make_current_publish_fail: bool = False
+    make_rollback_cleanup_fail: bool = False
+    target_production_seen: bool = False
+    log: list[tuple[str, ...]] = field(default_factory=list)
+    pending_seen_before_mutation: bool = False
+    lease_probe: Path | None = None
+
+    def executable(self, name: str) -> str:
+        return str(self.bin_dir / name)
+
+    def which(self, name: str, **_kwargs: object) -> str | None:
+        if name in {"git", "docker"}:
+            return self.executable(name)
+        return None
+
+    def completed(
+        self,
+        args: list[str],
+        *,
+        returncode: int = 0,
+        stdout: str = "",
+        stderr: str = "",
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args, returncode, stdout, stderr)
+
+    def run(
+        self,
+        args: list[str],
+        *,
+        cwd: Path | None = None,
+        env: dict[str, str],
+        text: bool,
+        capture_output: bool,
+        check: bool,
+        timeout: int,
+    ) -> subprocess.CompletedProcess[str]:
+        del cwd, text, capture_output, check, timeout
+        if self.lease_probe is not None:
+            descriptor = os.open(self.lease_probe, os.O_RDWR)
+            try:
+                with pytest.raises(OSError) as blocked:
+                    fcntl.flock(
+                        descriptor,
+                        fcntl.LOCK_EX | fcntl.LOCK_NB,
+                    )
+                assert blocked.value.errno in {errno.EACCES, errno.EAGAIN}
+            finally:
+                os.close(descriptor)
+        command = tuple(args)
+        self.log.append(command)
+        surfaced = "\0".join((*args, *env.values()))
+        for name in (
+            "DATABASE_URL",
+            "OPENROUTER_API_KEY",
+            "GOOGLE_API_KEY",
+            "LANGFUSE_SECRET_KEY",
+        ):
+            assert SECRETS[name] not in surfaced
+        if args[0].endswith("/git"):
+            return self._git(args)
+        if args[0].endswith("/docker"):
+            return self._docker(args, env)
+        raise AssertionError(args)
+
+    def _git(self, args: list[str]) -> subprocess.CompletedProcess[str]:
+        selected = args[1:]
+        path = Path(selected[1]) if selected[:1] == ["-C"] else self.checkout
+        tail = selected[2:] if selected[:1] == ["-C"] else selected
+        if tail == ["rev-parse", "--show-toplevel"]:
+            return self.completed(args, stdout=f"{path}\n")
+        if tail == ["remote", "get-url", "origin"]:
+            return self.completed(args, stdout=f"{ORIGIN}\n")
+        if tail == ["rev-parse", "--verify", "HEAD"]:
+            revision = (
+                TARGET_REVISION if path == self.release else self.production_revision
+            )
+            return self.completed(args, stdout=f"{revision}\n")
+        if tail[:1] == ["diff"]:
+            return self.completed(args)
+        if tail[:1] == ["status"]:
+            return self.completed(args)
+        if tail[:3] == ["ls-files", "--error-unmatch", "--"]:
+            return self.completed(args)
+        if "checkout" in tail:
+            assert self.state_dir.joinpath("pending.json").exists()
+            self.pending_seen_before_mutation = True
+            if self.fail_target_checkout and tail[-1] == TARGET_REVISION:
+                return self.completed(args, returncode=41)
+            self.production_revision = tail[-1]
+            return self.completed(args)
+        raise AssertionError(args)
+
+    def _image_document(self, selector: str) -> dict[str, object]:
+        if selector in {TARGET_IMAGE, TARGET_IMAGE_ID}:
+            return {
+                "Id": TARGET_IMAGE_ID,
+                "RepoDigests": [TARGET_IMAGE],
+                "Config": {
+                    "Labels": {"org.opencontainers.image.revision": TARGET_REVISION}
+                },
+            }
+        if selector in {OLD_IMAGE, OLD_IMAGE_ID}:
+            return {
+                "Id": OLD_IMAGE_ID,
+                "RepoDigests": [OLD_IMAGE],
+                "Config": {
+                    "Labels": {"org.opencontainers.image.revision": OLD_REVISION}
+                },
+            }
+        raise AssertionError(selector)
+
+    def _container_document(
+        self,
+        *,
+        candidate: bool,
+    ) -> dict[str, object]:
+        if candidate:
+            project = next(
+                item.rsplit("=", 1)[1]
+                for command in reversed(self.log)
+                for item in command
+                if item.startswith("label=com.docker.compose.project=candidate-")
+            )
+            return {
+                "Id": CANDIDATE_CONTAINER,
+                "Image": TARGET_IMAGE_ID,
+                "State": {"Status": "running", "Health": {"Status": "healthy"}},
+                "Config": {
+                    "Image": TARGET_IMAGE,
+                    "User": "1000:1000",
+                    "Labels": {
+                        "com.docker.compose.project": project,
+                        "com.docker.compose.service": SERVICE,
+                        "com.docker.compose.project.working_dir": str(self.release),
+                    },
+                },
+                "HostConfig": {
+                    "NetworkMode": "none",
+                    "PortBindings": {},
+                    "RestartPolicy": {"Name": "no"},
+                    "CapDrop": ["ALL"],
+                    "SecurityOpt": ["no-new-privileges:true"],
+                },
+                "Mounts": [],
+            }
+        container = (
+            TARGET_CONTAINER if self.production_image == TARGET_IMAGE else OLD_CONTAINER
+        )
+        return {
+            "Id": container,
+            "Image": self.production_image_id,
+            "State": {
+                "Status": "running",
+                "Health": {
+                    "Status": "healthy" if self.production_healthy else "unhealthy"
+                },
+            },
+            "Config": {
+                "Image": self.production_image,
+                "Labels": {
+                    "com.docker.compose.project": PROJECT,
+                    "com.docker.compose.service": SERVICE,
+                    "com.docker.compose.project.working_dir": str(self.checkout),
+                },
+            },
+            "Mounts": (
+                [
+                    {
+                        "Type": "volume",
+                        "Name": VOLUME.name,
+                        "Driver": VOLUME.driver,
+                        "Destination": VOLUME.destination,
+                    }
+                ]
+                if self.volume_exists
+                else []
+            ),
+        }
+
+    def _docker(
+        self,
+        args: list[str],
+        environment: dict[str, str],
+    ) -> subprocess.CompletedProcess[str]:
+        tail = args[1:]
+        if tail[:2] == ["image", "pull"]:
+            return self.completed(args, stdout=f"{tail[2]}\n")
+        if tail[:2] == ["image", "inspect"]:
+            return self.completed(
+                args,
+                stdout=json.dumps([self._image_document(tail[2])]),
+            )
+        if tail[:2] == ["container", "ls"]:
+            project_filter = next(
+                value
+                for value in tail
+                if value.startswith("label=com.docker.compose.project=")
+            )
+            project = project_filter.rsplit("=", 1)[1]
+            if project.startswith("candidate-"):
+                value = CANDIDATE_CONTAINER[:12] if self.candidate_exists else ""
+            else:
+                value = (
+                    (
+                        TARGET_CONTAINER
+                        if self.production_image == TARGET_IMAGE
+                        else OLD_CONTAINER
+                    )[:12]
+                    if self.production_exists
+                    else ""
+                )
+            return self.completed(args, stdout=f"{value}\n" if value else "")
+        if tail[:2] == ["container", "inspect"]:
+            candidate = tail[2].startswith(CANDIDATE_CONTAINER[:12])
+            return self.completed(
+                args,
+                stdout=json.dumps([self._container_document(candidate=candidate)]),
+            )
+        if tail[:2] == ["container", "rm"]:
+            self.production_exists = False
+            return self.completed(args, stdout=f"{tail[-1]}\n")
+        if tail[:2] == ["volume", "inspect"]:
+            document = {
+                "Name": VOLUME.name,
+                "Driver": VOLUME.driver,
+                "Mountpoint": VOLUME.mountpoint,
+                "CreatedAt": VOLUME.created_at,
+            }
+            if self.make_current_publish_fail and self.production_image == TARGET_IMAGE:
+                self.state_dir.chmod(0o500)
+                self.make_current_publish_fail = False
+            if (
+                self.make_rollback_cleanup_fail
+                and self.target_production_seen
+                and self.production_image == OLD_IMAGE
+            ):
+                self.state_dir.chmod(0o500)
+                self.make_rollback_cleanup_fail = False
+            return self.completed(args, stdout=json.dumps([document]))
+        if tail[:1] == ["compose"]:
+            project = tail[tail.index("--project-name") + 1]
+            if "config" in tail:
+                output = f"{environment['IMAGE']}\n" if "--images" in tail else ""
+                return self.completed(args, stdout=output)
+            if "up" in tail:
+                if project.startswith("candidate-"):
+                    self.candidate_exists = True
+                    if self.fail_candidate:
+                        return self.completed(args, returncode=42)
+                else:
+                    selected = environment["IMAGE"]
+                    if selected == OLD_IMAGE and self.fail_rollback_up:
+                        return self.completed(args, returncode=43)
+                    self.production_exists = True
+                    self.production_image = selected
+                    self.production_image_id = (
+                        TARGET_IMAGE_ID if selected == TARGET_IMAGE else OLD_IMAGE_ID
+                    )
+                    self.production_revision = (
+                        TARGET_REVISION if selected == TARGET_IMAGE else OLD_REVISION
+                    )
+                    if selected == TARGET_IMAGE:
+                        self.target_production_seen = True
+                    self.production_healthy = not (
+                        selected == TARGET_IMAGE and self.fail_target_health
+                    )
+                    self.volume_exists = True
+                return self.completed(args)
+            if "down" in tail:
+                assert project.startswith("candidate-")
+                self.candidate_exists = False
+                return self.completed(args)
+        raise AssertionError(args)
+
+
+@pytest.fixture
+def setup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[Host, PromotionConfig, dict[str, str]]:
+    checkout = tmp_path / "checkout"
+    release = tmp_path / "release"
+    state_dir = tmp_path / "state"
+    bin_dir = tmp_path / "bin"
+    checkout.mkdir()
+    release.mkdir()
+    bin_dir.mkdir()
+    for name in ("git", "docker"):
+        selected = bin_dir / name
+        selected.write_text("#!/bin/sh\n", encoding="utf-8")
+        selected.chmod(0o700)
+    for root in (checkout, release):
+        (root / "src/agent").mkdir(parents=True)
+        for relative in (
+            "compose.yaml",
+            "compose.candidate.yaml",
+            "src/agent/deployment_promotion.py",
+        ):
+            (root / relative).write_text("tracked\n", encoding="utf-8")
+    _private(checkout / ".env", b'AGENT_NAME="old"\n')
+    host = Host(checkout, release, state_dir, bin_dir)
+    run_mock = create_autospec(
+        subprocess.run,
+        spec_set=True,
+        side_effect=host.run,
+    )
+    which_mock = create_autospec(
+        shutil.which,
+        spec_set=True,
+        side_effect=host.which,
+    )
+    monkeypatch.setattr(subprocess, "run", run_mock)
+    monkeypatch.setattr(shutil, "which", which_mock)
+    environment = dict(SECRETS) | {
+        "HOME": str(tmp_path),
+        "PATH": str(bin_dir),
+    }
+    config = PromotionConfig(
+        state_dir=state_dir,
+        checkout=checkout,
+        release_checkout=release,
+        expected_origin=ORIGIN,
+        compose_project=PROJECT,
+        compose_service=SERVICE,
+        source_revision=TARGET_REVISION,
+        image_reference=TARGET_IMAGE,
+        adopt_existing=True,
+    )
+    return host, config, environment
+
+
+def _initialize(host: Host, config: PromotionConfig) -> None:
+    with DeploymentStateStore(config.state_dir).transaction() as transaction:
+        transaction.adopt(
+            compose_project=PROJECT,
+            compose_service=SERVICE,
+            source_revision=OLD_REVISION,
+            image_reference=OLD_IMAGE,
+            image_id=OLD_IMAGE_ID,
+            oci_revision=OLD_REVISION,
+            environment_source=host.checkout / ".env",
+            deployment_id="baseline",
+            recorded_at="2026-07-28T11:00:00.000000Z",
+        )
+
+
+def _argv(config: PromotionConfig) -> list[str]:
+    return [
+        "promote",
+        "--state-dir",
+        str(config.state_dir),
+        "--checkout",
+        str(config.checkout),
+        "--release-checkout",
+        str(config.release_checkout),
+        "--expected-origin",
+        config.expected_origin,
+        "--compose-project",
+        config.compose_project,
+        "--compose-service",
+        config.compose_service,
+        "--source-revision",
+        config.source_revision,
+        "--image-reference",
+        config.image_reference,
+        "--adopt-existing",
+    ]
+
+
+def _controller_argv(config: PromotionConfig) -> list[str]:
+    lease_directory = config.release_checkout.with_name(
+        f"{config.release_checkout.name}.lease"
+    )
+    lease_directory.mkdir(mode=0o700)
+    lease = lease_directory / "lock"
+    lease.touch(mode=0o600)
+    lease.chmod(0o600)
+    return [
+        *_argv(config),
+        "--release-lease",
+        str(lease),
+        "--environment-stdin",
+    ]
+
+
+def _pending(
+    host: Host,
+    config: PromotionConfig,
+    *,
+    cutover_started: bool = True,
+) -> None:
+    _initialize(host, config)
+    target_env = _private(
+        config.state_dir.parent / "target-input.env",
+        b'TARGET="yes"\n',
+    )
+    with DeploymentStateStore(config.state_dir).transaction() as transaction:
+        tail = transaction.journal()[-1]
+        receipt = CandidateReceipt(
+            observed_at="2026-07-28T11:30:00.000000Z",
+            compose_project="candidate-pending",
+            compose_service=SERVICE,
+            container_id=CANDIDATE_CONTAINER,
+            image_reference=TARGET_IMAGE,
+            image_id=TARGET_IMAGE_ID,
+            oci_revision=TARGET_REVISION,
+            baseline_journal_sequence=tail.sequence,
+            baseline_journal_sha256=tail.sha256,
+        )
+        pending = transaction.begin_promotion(
+            compose_project=PROJECT,
+            compose_service=SERVICE,
+            source_revision=TARGET_REVISION,
+            image_reference=TARGET_IMAGE,
+            image_id=TARGET_IMAGE_ID,
+            oci_revision=TARGET_REVISION,
+            environment_source=target_env,
+            candidate=receipt,
+            persistent_volumes=(VOLUME,),
+            transaction_id="pending",
+            recorded_at="2026-07-28T11:30:00.000000Z",
+        )
+        if cutover_started:
+            transaction.install_environment(
+                pending.intent.target,
+                host.checkout / ".env",
+            )
+    if cutover_started:
+        host.production_revision = TARGET_REVISION
+        host.production_image = TARGET_IMAGE
+        host.production_image_id = TARGET_IMAGE_ID
+
+
+def _fresh_pending(
+    host: Host,
+    config: PromotionConfig,
+    *,
+    install_environment: bool,
+    production_exists: bool,
+    transaction_id: str = FRESH_TRANSACTION,
+) -> None:
+    host.production_exists = False
+    host.volume_exists = False
+    (host.checkout / ".env").unlink()
+    target_env = _private(
+        config.state_dir.parent / "fresh-target-input.env",
+        b'TARGET="yes"\n',
+    )
+    with DeploymentStateStore(config.state_dir).transaction() as transaction:
+        pending = transaction.begin_promotion(
+            compose_project=PROJECT,
+            compose_service=SERVICE,
+            source_revision=TARGET_REVISION,
+            image_reference=TARGET_IMAGE,
+            image_id=TARGET_IMAGE_ID,
+            oci_revision=TARGET_REVISION,
+            environment_source=target_env,
+            candidate=CandidateReceipt(
+                observed_at="2026-07-28T11:30:00.000000Z",
+                compose_project="candidate-fresh",
+                compose_service=SERVICE,
+                container_id=CANDIDATE_CONTAINER,
+                image_reference=TARGET_IMAGE,
+                image_id=TARGET_IMAGE_ID,
+                oci_revision=TARGET_REVISION,
+                baseline_journal_sequence=None,
+                baseline_journal_sha256=None,
+            ),
+            persistent_volumes=(),
+            transaction_id=transaction_id,
+            recorded_at="2026-07-28T11:30:00.000000Z",
+        )
+        if install_environment:
+            transaction.install_environment(
+                pending.intent.target,
+                host.checkout / ".env",
+            )
+    host.production_exists = production_exists
+    if production_exists:
+        host.production_revision = TARGET_REVISION
+        host.production_image = TARGET_IMAGE
+        host.production_image_id = TARGET_IMAGE_ID
+        host.volume_exists = True
+
+
+def test_existing_deployment_promotes_after_exact_candidate_and_intent(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    host, config, environment = setup
+    _initialize(host, config)
+
+    current = promote(config, environment=environment)
+
+    assert current.state.source_revision == TARGET_REVISION
+    assert host.production_image == TARGET_IMAGE
+    assert host.pending_seen_before_mutation
+    assert not host.candidate_exists
+    store = DeploymentStateStore(config.state_dir)
+    assert [entry.event for entry in store.read_journal()] == [
+        "adopted",
+        "promoted",
+    ]
+    production_up = next(
+        command
+        for command in host.log
+        if "compose" in command
+        and "up" in command
+        and "--project-name" in command
+        and command[command.index("--project-name") + 1] == PROJECT
+    )
+    assert production_up.index("--no-build") < production_up.index("--pull")
+    assert production_up.index("--pull") < production_up.index("--wait")
+    assert "down" not in production_up
+
+
+def test_candidate_failure_leaves_every_production_identity_untouched(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    host, config, environment = setup
+    _initialize(host, config)
+    before_env = (host.checkout / ".env").read_bytes()
+    before_journal = DeploymentStateStore(config.state_dir).read_journal()
+    host.fail_candidate = True
+
+    assert main(_argv(config), environment) == 1
+
+    assert host.production_revision == OLD_REVISION
+    assert host.production_image == OLD_IMAGE
+    assert (host.checkout / ".env").read_bytes() == before_env
+    assert DeploymentStateStore(config.state_dir).read_journal() == before_journal
+    assert not config.state_dir.joinpath("pending.json").exists()
+    assert not host.candidate_exists
+
+
+def test_post_cutover_failure_restores_and_records_rollback(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    host, config, environment = setup
+    _initialize(host, config)
+    host.fail_target_health = True
+
+    assert main(_argv(config), environment) == 1
+
+    assert host.production_revision == OLD_REVISION
+    assert host.production_image == OLD_IMAGE
+    assert host.production_healthy
+    store = DeploymentStateStore(config.state_dir)
+    assert [entry.event for entry in store.read_journal()] == [
+        "adopted",
+        "rolled_back",
+    ]
+    current = store.read_current()
+    assert current is not None
+    assert current.state.source_revision == OLD_REVISION
+    assert not config.state_dir.joinpath("pending.json").exists()
+
+
+def test_rollback_failure_preserves_pending_without_false_terminal(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    host, config, environment = setup
+    _initialize(host, config)
+    host.fail_target_health = True
+    host.fail_rollback_up = True
+
+    assert main(_argv(config), environment) == 1
+
+    assert config.state_dir.joinpath("pending.json").is_file()
+    assert [
+        entry.event for entry in DeploymentStateStore(config.state_dir).read_journal()
+    ] == ["adopted"]
+    surfaced = capsys.readouterr().out + capsys.readouterr().err
+    assert all(value not in surfaced for value in SECRETS.values())
+
+
+def test_pending_entry_recovers_baseline_and_requires_rerun(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    host, config, environment = setup
+    _pending(host, config)
+
+    recovery_environment = {
+        "HOME": environment["HOME"],
+        "PATH": environment["PATH"],
+    }
+    assert main(_argv(config), recovery_environment) == 3
+
+    assert host.production_revision == OLD_REVISION
+    assert host.production_image == OLD_IMAGE
+    assert [
+        entry.event for entry in DeploymentStateStore(config.state_dir).read_journal()
+    ] == [
+        "adopted",
+        "rolled_back",
+    ]
+    assert not config.state_dir.joinpath("pending.json").exists()
+    assert not any("candidate-" in " ".join(command) for command in host.log)
+
+
+def test_pending_pre_cutover_baseline_records_outcome_without_recreate(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    host, config, environment = setup
+    _pending(host, config, cutover_started=False)
+    commands_before = len(host.log)
+
+    assert main(_argv(config), environment) == 3
+
+    assert host.production_revision == OLD_REVISION
+    assert host.production_image == OLD_IMAGE
+    assert (host.checkout / ".env").read_bytes() == b'AGENT_NAME="old"\n'
+    assert [
+        entry.event for entry in DeploymentStateStore(config.state_dir).read_journal()
+    ] == ["adopted", "aborted"]
+    recovery_commands = host.log[commands_before:]
+    assert not any("checkout" in command for command in recovery_commands)
+    assert not any(
+        "compose" in command or command[1:3] == ("container", "rm")
+        for command in recovery_commands
+    )
+
+
+def test_pending_pre_cutover_image_mismatch_fails_without_mutation(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host, config, environment = setup
+    _pending(host, config, cutover_started=False)
+    commands_before = len(host.log)
+
+    def transform(
+        args: list[str],
+        result: subprocess.CompletedProcess[str],
+    ) -> subprocess.CompletedProcess[str]:
+        if args[1:3] == ["image", "inspect"] and args[3] == OLD_IMAGE:
+            document = json.loads(result.stdout)[0]
+            document["Id"] = MANUAL_IMAGE_ID
+            return _completed_json(args, document)
+        return result
+
+    _strict_host_run(monkeypatch, host, transform)
+
+    assert main(_argv(config), environment) == 1
+
+    assert host.production_revision == OLD_REVISION
+    assert host.production_image == OLD_IMAGE
+    assert config.state_dir.joinpath("pending.json").is_file()
+    assert not any(
+        "checkout" in command or "compose" in command
+        for command in host.log[commands_before:]
+    )
+
+
+def test_pending_pre_cutover_unhealthy_runtime_is_recreated_and_verified(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    host, config, environment = setup
+    _pending(host, config, cutover_started=False)
+    host.production_healthy = False
+
+    assert main(_argv(config), environment) == 3
+
+    assert host.production_healthy
+    assert host.production_revision == OLD_REVISION
+    assert host.production_image == OLD_IMAGE
+    assert [
+        entry.event for entry in DeploymentStateStore(config.state_dir).read_journal()
+    ] == ["adopted", "rolled_back"]
+    assert any("compose" in command and "up" in command for command in host.log)
+
+
+def test_pending_pre_cutover_volume_replacement_fails_without_recreate(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host, config, environment = setup
+    _pending(host, config, cutover_started=False)
+    commands_before = len(host.log)
+
+    def transform(
+        args: list[str],
+        result: subprocess.CompletedProcess[str],
+    ) -> subprocess.CompletedProcess[str]:
+        if args[1:3] == ["volume", "inspect"]:
+            document = json.loads(result.stdout)[0]
+            document["CreatedAt"] = REPLACED_VOLUME.created_at
+            return _completed_json(args, document)
+        return result
+
+    _strict_host_run(monkeypatch, host, transform)
+
+    assert main(_argv(config), environment) == 1
+
+    assert host.production_revision == OLD_REVISION
+    assert host.production_image == OLD_IMAGE
+    assert config.state_dir.joinpath("pending.json").is_file()
+    assert not any(
+        "checkout" in command or "compose" in command
+        for command in host.log[commands_before:]
+    )
+
+
+def test_pending_config_mismatch_fails_before_recovery_mutation(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    host, config, environment = setup
+    _pending(host, config)
+    commands_before = len(host.log)
+
+    assert (
+        main(
+            _argv(replace(config, compose_project="different-project")),
+            environment,
+        )
+        == 1
+    )
+
+    assert host.production_revision == TARGET_REVISION
+    assert host.production_image == TARGET_IMAGE
+    assert config.state_dir.joinpath("pending.json").is_file()
+    later = host.log[commands_before:]
+    assert later
+    assert all(
+        "checkout" not in command and "compose" not in command for command in later
+    )
+
+
+def test_pending_manual_image_fails_closed_before_recovery_mutation(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    host, config, environment = setup
+    _pending(host, config)
+    host.production_image = MANUAL_IMAGE
+    host.production_image_id = MANUAL_IMAGE_ID
+    commands_before = len(host.log)
+
+    assert main(_argv(config), environment) == 1
+
+    assert host.production_image == MANUAL_IMAGE
+    assert host.production_image_id == MANUAL_IMAGE_ID
+    assert config.state_dir.joinpath("pending.json").is_file()
+    later = host.log[commands_before:]
+    assert later
+    assert all(
+        "checkout" not in command and "compose" not in command for command in later
+    )
+
+
+@pytest.mark.parametrize("revision", ["7" * 40, "not-a-revision"])
+def test_pending_checkout_drift_fails_before_recovery_mutation(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    revision: str,
+) -> None:
+    host, config, environment = setup
+    _pending(host, config)
+    host.production_revision = revision
+    commands_before = len(host.log)
+
+    assert main(_argv(config), environment) == 1
+
+    assert host.production_revision == revision
+    assert host.production_image == TARGET_IMAGE
+    assert config.state_dir.joinpath("pending.json").is_file()
+    later = host.log[commands_before:]
+    assert later
+    assert all(
+        "checkout" not in command and "compose" not in command for command in later
+    )
+
+
+def test_pending_rejects_mismatched_recorded_baseline_before_docker(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    host, config, environment = setup
+    _pending(host, config)
+    with DeploymentStateStore(config.state_dir).transaction() as transaction:
+        current = transaction.current()
+        pending = transaction.pending()
+        assert current is not None
+        assert pending is not None
+        mismatched = replace(
+            current,
+            state=replace(current.state, compose_project="different-project"),
+        )
+        command_count = len(host.log)
+
+        with pytest.raises(
+            promotion_module.PromotionError,
+            match="baseline Compose identity",
+        ):
+            promotion_module._validate_pending_ownership(
+                pending=pending,
+                current=mismatched,
+                config=config,
+                executables=_executables(host),
+                environment=promotion_module._command_environment(environment),
+            )
+
+    assert all(
+        command[1:3] != ("container", "ls") for command in host.log[command_count:]
+    )
+
+
+def test_pending_fresh_install_before_cutover_aborts_without_checkout_mutation(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    host, config, environment = setup
+    _fresh_pending(
+        host,
+        config,
+        install_environment=False,
+        production_exists=False,
+    )
+    assert host.production_revision == OLD_REVISION
+
+    assert main(_argv(config), environment) == 3
+
+    assert host.production_revision == OLD_REVISION
+    assert not host.production_exists
+    assert not (host.checkout / ".env").exists()
+    assert [
+        entry.event for entry in DeploymentStateStore(config.state_dir).read_journal()
+    ] == ["aborted"]
+
+
+def test_fresh_pending_without_recorded_checkout_baseline_fails_closed(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    host, config, environment = setup
+    _fresh_pending(
+        host,
+        config,
+        install_environment=False,
+        production_exists=False,
+        transaction_id="legacy-fresh",
+    )
+    command_count = len(host.log)
+
+    assert main(_argv(config), environment) == 1
+
+    assert host.production_revision == OLD_REVISION
+    assert not host.production_exists
+    assert config.state_dir.joinpath("pending.json").is_file()
+    assert not any(
+        "checkout" in command or "compose" in command
+        for command in host.log[command_count:]
+    )
+
+
+def test_pending_fresh_install_is_aborted_and_requires_rerun(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    host, config, environment = setup
+    host.production_exists = False
+    host.volume_exists = False
+    (host.checkout / ".env").unlink()
+    target_env = _private(
+        config.state_dir.parent / "fresh-target-input.env",
+        b'TARGET="yes"\n',
+    )
+    with DeploymentStateStore(config.state_dir).transaction() as transaction:
+        pending = transaction.begin_promotion(
+            compose_project=PROJECT,
+            compose_service=SERVICE,
+            source_revision=TARGET_REVISION,
+            image_reference=TARGET_IMAGE,
+            image_id=TARGET_IMAGE_ID,
+            oci_revision=TARGET_REVISION,
+            environment_source=target_env,
+            candidate=CandidateReceipt(
+                observed_at="2026-07-28T11:30:00.000000Z",
+                compose_project="candidate-fresh",
+                compose_service=SERVICE,
+                container_id=CANDIDATE_CONTAINER,
+                image_reference=TARGET_IMAGE,
+                image_id=TARGET_IMAGE_ID,
+                oci_revision=TARGET_REVISION,
+                baseline_journal_sequence=None,
+                baseline_journal_sha256=None,
+            ),
+            persistent_volumes=(),
+            transaction_id=FRESH_TRANSACTION,
+            recorded_at="2026-07-28T11:30:00.000000Z",
+        )
+        transaction.install_environment(pending.intent.target, host.checkout / ".env")
+    host.production_exists = True
+    host.production_revision = TARGET_REVISION
+    host.production_image = TARGET_IMAGE
+    host.production_image_id = TARGET_IMAGE_ID
+    host.volume_exists = True
+
+    assert main(_argv(config), environment) == 3
+
+    assert not host.production_exists
+    assert host.volume_exists
+    assert host.production_revision == OLD_REVISION
+    assert not (host.checkout / ".env").exists()
+    assert [
+        entry.event for entry in DeploymentStateStore(config.state_dir).read_journal()
+    ] == ["aborted"]
+
+
+def test_first_install_commits_new_volume_identity(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    host, config, environment = setup
+    host.production_exists = False
+    host.volume_exists = False
+    (host.checkout / ".env").unlink()
+
+    current = promote(config, environment=environment)
+
+    assert current.state.source_revision == TARGET_REVISION
+    assert host.production_exists
+    assert host.volume_exists
+    assert [
+        entry.event for entry in DeploymentStateStore(config.state_dir).read_journal()
+    ] == ["promoted"]
+
+
+def test_fresh_install_failure_removes_only_owned_container_and_aborts(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    host, config, environment = setup
+    host.production_exists = False
+    host.volume_exists = False
+    host.fail_target_health = True
+    (host.checkout / ".env").unlink()
+
+    assert main(_argv(config), environment) == 1
+
+    assert not host.production_exists
+    assert host.volume_exists
+    assert host.production_revision == OLD_REVISION
+    assert not (host.checkout / ".env").exists()
+    assert [
+        entry.event for entry in DeploymentStateStore(config.state_dir).read_journal()
+    ] == ["aborted"]
+    flattened = [" ".join(command) for command in host.log]
+    assert any("container rm --force" in command for command in flattened)
+    assert not any(
+        f"compose --project-name {PROJECT}" in command and " down " in command
+        for command in flattened
+    )
+
+
+@pytest.mark.parametrize("fault", ["absent", "ambiguous", "wrong-image"])
+def test_fresh_cleanup_proves_exact_service_ownership(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+    fault: str,
+) -> None:
+    host, config, environment = setup
+    _fresh_pending(
+        host,
+        config,
+        install_environment=True,
+        production_exists=fault != "absent",
+    )
+
+    def transform(
+        args: list[str],
+        result: subprocess.CompletedProcess[str],
+    ) -> subprocess.CompletedProcess[str]:
+        if fault == "ambiguous" and args[1:3] == ["container", "ls"]:
+            return host.completed(
+                args,
+                stdout=f"{TARGET_CONTAINER[:12]}\n{'4' * 12}\n",
+            )
+        if fault == "wrong-image" and args[1:3] == ["container", "inspect"]:
+            document = json.loads(result.stdout)[0]
+            document["Image"] = MANUAL_IMAGE_ID
+            return _completed_json(args, document)
+        return result
+
+    _strict_host_run(monkeypatch, host, transform)
+    with DeploymentStateStore(config.state_dir).transaction() as transaction:
+        pending = transaction.pending()
+        assert pending is not None
+        if fault == "absent":
+            promotion_module._remove_owned_service_container(
+                target=pending.intent.target,
+                config=config,
+                executables=_executables(host),
+                environment=promotion_module._command_environment(environment),
+                target_environment_proven=True,
+                verify_target_environment=lambda: True,
+            )
+        else:
+            with pytest.raises(
+                promotion_module.PromotionRecoveryFailedError,
+                match="ambiguous|ownership",
+            ):
+                promotion_module._remove_owned_service_container(
+                    target=pending.intent.target,
+                    config=config,
+                    executables=_executables(host),
+                    environment=promotion_module._command_environment(environment),
+                    target_environment_proven=True,
+                    verify_target_environment=lambda: True,
+                )
+
+    assert config.state_dir.joinpath("pending.json").is_file()
+
+
+def test_fresh_abort_rejects_container_reappearing_after_removal(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host, config, environment = setup
+    _fresh_pending(
+        host,
+        config,
+        install_environment=True,
+        production_exists=True,
+    )
+    removed = False
+
+    def transform(
+        args: list[str],
+        result: subprocess.CompletedProcess[str],
+    ) -> subprocess.CompletedProcess[str]:
+        nonlocal removed
+        if args[1:3] == ["container", "rm"]:
+            removed = True
+        if removed and args[1:3] == ["container", "ls"]:
+            return host.completed(args, stdout=f"{TARGET_CONTAINER[:12]}\n")
+        return result
+
+    _strict_host_run(monkeypatch, host, transform)
+    with DeploymentStateStore(config.state_dir).transaction() as transaction:
+        pending = transaction.pending()
+        assert pending is not None
+        with pytest.raises(
+            promotion_module.PromotionRecoveryFailedError,
+            match="baseline could not be verified",
+        ):
+            promotion_module._abort_fresh_install(
+                transaction=transaction,
+                pending=pending,
+                config=config,
+                executables=_executables(host),
+                environment=promotion_module._command_environment(environment),
+                baseline_revision=OLD_REVISION,
+            )
+
+    assert removed
+    assert config.state_dir.joinpath("pending.json").is_file()
+    assert [
+        entry.event for entry in DeploymentStateStore(config.state_dir).read_journal()
+    ] == []
+
+
+@pytest.mark.parametrize("fault", ["missing", "tampered"])
+def test_fresh_recovery_proves_target_environment_before_container_removal(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    fault: str,
+) -> None:
+    host, config, environment = setup
+    _fresh_pending(
+        host,
+        config,
+        install_environment=True,
+        production_exists=True,
+    )
+    environment_path = config.checkout / ".env"
+    if fault == "missing":
+        environment_path.unlink()
+    else:
+        _private(environment_path, b"TAMPERED=secret\n")
+
+    assert main(_argv(config), environment) == 1
+
+    assert host.production_exists
+    assert host.production_image == TARGET_IMAGE
+    assert not any(command[1:3] == ("container", "rm") for command in host.log)
+    assert config.state_dir.joinpath("pending.json").is_file()
+    assert DeploymentStateStore(config.state_dir).read_journal() == ()
+
+
+def test_fresh_recovery_revalidates_environment_after_container_inspection(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host, config, environment = setup
+    _fresh_pending(
+        host,
+        config,
+        install_environment=True,
+        production_exists=True,
+    )
+    production_lists = 0
+    environment_path = config.checkout / ".env"
+
+    def transform(
+        args: list[str],
+        result: subprocess.CompletedProcess[str],
+    ) -> subprocess.CompletedProcess[str]:
+        nonlocal production_lists
+        if args[1:3] == ["container", "ls"]:
+            production_lists += 1
+            if production_lists == 2:
+                _private(environment_path, b"RACED=secret\n")
+        return result
+
+    _strict_host_run(monkeypatch, host, transform)
+
+    assert main(_argv(config), environment) == 1
+
+    assert production_lists == 2
+    assert host.production_exists
+    assert environment_path.read_bytes() == b"RACED=secret\n"
+    assert not any(command[1:3] == ("container", "rm") for command in host.log)
+    assert config.state_dir.joinpath("pending.json").is_file()
+
+
+def test_terminal_pointer_failure_never_compensates(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    host, config, environment = setup
+    _initialize(host, config)
+    host.make_current_publish_fail = True
+
+    try:
+        assert main(_argv(config), environment) == 4
+    finally:
+        config.state_dir.chmod(0o700)
+
+    assert host.production_revision == TARGET_REVISION
+    assert host.production_image == TARGET_IMAGE
+    assert not any(OLD_IMAGE in command and "up" in command for command in host.log)
+    assert [
+        entry.event for entry in DeploymentStateStore(config.state_dir).read_journal()
+    ] == [
+        "adopted",
+        "promoted",
+    ]
+
+
+def test_reconciled_terminal_stops_invocation_before_host_commands(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    host, config, environment = setup
+    _pending(host, config)
+    store = DeploymentStateStore(config.state_dir)
+    with store.transaction() as transaction:
+        pending = transaction.pending()
+        assert pending is not None
+        stale_pointer = store.pending_path.read_bytes()
+        transaction.record_rollback(
+            pending.transaction_id,
+            persistent_volumes=(VOLUME,),
+        )
+    _private(store.pending_path, stale_pointer)
+    command_count = len(host.log)
+
+    assert main(_argv(config), environment) == 3
+
+    assert len(host.log) == command_count
+    assert not store.pending_path.exists()
+    assert [entry.event for entry in store.read_journal()] == [
+        "adopted",
+        "rolled_back",
+    ]
+
+
+def test_cli_surface_and_fixed_environment_allowlist(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    host, config, environment = setup
+    _initialize(host, config)
+
+    assert tuple(SECRETS) == PRODUCTION_ENVIRONMENT_NAMES
+    assert main(_argv(config), environment) == 0
+
+
+def test_cli_reads_exact_production_environment_from_bounded_stdin(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    """Merge canonical stdin values with only approved host transport settings."""
+    host, config, environment = setup
+    _initialize(host, config)
+    payload = serialize_compose_environment(
+        PRODUCTION_ENVIRONMENT_NAMES,
+        environment,
+    ).encode()
+    host_environment = {
+        "HOME": environment["HOME"],
+        "PATH": environment["PATH"],
+        "DOCKER_CONFIG": "/private/docker-config",
+        "DOCKER_HOST": "unix:///private/docker.sock",
+        "XDG_RUNTIME_DIR": "/private/runtime",
+        "UNAPPROVED_CANARY": "must-not-reach-subprocesses",
+    }
+
+    assert (
+        main(
+            _controller_argv(config),
+            host_environment,
+            io.BytesIO(payload),
+        )
+        == 0
+    )
+
+
+@pytest.mark.parametrize(
+    ("stream", "expected"),
+    [
+        (
+            io.BytesIO(b"x" * (64 * 1024 + 1)),
+            "serialized environment is too large",
+        ),
+        (
+            io.BytesIO(b"\xff"),
+            "serialized environment is not UTF-8",
+        ),
+        (
+            io.BytesIO(b'AGENT_NAME="incomplete"\n'),
+            "serialized environment is invalid",
+        ),
+    ],
+)
+def test_cli_rejects_invalid_stdin_before_host_operations(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    capsys: pytest.CaptureFixture[str],
+    stream: io.BytesIO,
+    expected: str,
+) -> None:
+    """Reject malformed secret transport without invoking Git or Docker."""
+    host, config, environment = setup
+
+    assert (
+        main(
+            _controller_argv(config),
+            {"HOME": environment["HOME"], "PATH": environment["PATH"]},
+            stream,
+        )
+        == 1
+    )
+
+    assert host.log == []
+    captured = capsys.readouterr()
+    assert expected in captured.err
+    assert "incomplete" not in captured.err
+
+
+def test_cli_redacts_stdin_read_failure(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Convert an input transport failure to one secret-free diagnostic."""
+    host, config, environment = setup
+
+    class FailingStream(io.BytesIO):
+        def read(self, size: int | None = -1) -> bytes:
+            del size
+            raise OSError("private transport detail")
+
+    assert (
+        main(
+            _controller_argv(config),
+            {"HOME": environment["HOME"], "PATH": environment["PATH"]},
+            FailingStream(),
+        )
+        == 1
+    )
+
+    assert host.log == []
+    captured = capsys.readouterr()
+    assert captured.err == "ERROR: serialized environment could not be read\n"
+
+
+@pytest.mark.parametrize(
+    "extra_arguments",
+    [
+        ["--environment-stdin"],
+        ["--release-lease", "/private/missing-release-lease"],
+    ],
+)
+def test_cli_requires_release_lease_and_stdin_as_a_pair(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    capsys: pytest.CaptureFixture[str],
+    extra_arguments: list[str],
+) -> None:
+    """Reject either controller transport half before reading or host commands."""
+    host, config, environment = setup
+
+    assert (
+        main(
+            [*_argv(config), *extra_arguments],
+            {"HOME": environment["HOME"], "PATH": environment["PATH"]},
+            io.BytesIO(b"private-canary"),
+        )
+        == 1
+    )
+
+    assert host.log == []
+    captured = capsys.readouterr()
+    assert captured.err == (
+        "ERROR: release lease and serialized environment must be used together\n"
+    )
+    assert "private-canary" not in captured.err
+
+
+def _new_release_lease(tmp_path: Path) -> Path:
+    directory = tmp_path / "release.lease"
+    directory.mkdir(mode=0o700)
+    lease = directory / "lock"
+    lease.touch(mode=0o600)
+    lease.chmod(0o600)
+    return lease
+
+
+@pytest.mark.parametrize(
+    "fault",
+    [
+        "relative",
+        "non-normalized",
+        "missing-parent",
+        "unsafe-parent-mode",
+        "parent-symlink",
+    ],
+)
+def test_release_lease_rejects_unsafe_path_or_directory(
+    tmp_path: Path,
+    fault: str,
+) -> None:
+    """Require a canonical private directory before opening the lease."""
+    lease = _new_release_lease(tmp_path)
+    if fault == "relative":
+        selected = Path("release.lease/lock")
+        message = "absolute normalized"
+    elif fault == "non-normalized":
+        selected = lease.parent / ".." / lease.parent.name / lease.name
+        message = "absolute normalized"
+    elif fault == "missing-parent":
+        selected = tmp_path / "missing" / "lock"
+        message = "directory is unavailable"
+    elif fault == "unsafe-parent-mode":
+        lease.parent.chmod(0o755)
+        selected = lease
+        message = "directory is unsafe"
+    else:
+        target = tmp_path / "target.lease"
+        target.mkdir(mode=0o700)
+        target.joinpath("lock").write_bytes(b"")
+        target.joinpath("lock").chmod(0o600)
+        link = tmp_path / "linked.lease"
+        link.symlink_to(target, target_is_directory=True)
+        selected = link / "lock"
+        message = "absolute normalized"
+
+    with (
+        pytest.raises(promotion_module.PromotionError, match=message),
+        promotion_module._release_lease(selected),
+    ):
+        pytest.fail("unsafe lease was acquired")
+
+
+@pytest.mark.parametrize("fault", ["missing", "symlink", "mode", "hardlink"])
+def test_release_lease_rejects_unsafe_lock_file(
+    tmp_path: Path,
+    fault: str,
+) -> None:
+    """Reject missing, redirected, public, and multiply linked lock files."""
+    lease = _new_release_lease(tmp_path)
+    if fault == "missing":
+        lease.unlink()
+        message = "is unavailable"
+    elif fault == "symlink":
+        lease.unlink()
+        target = tmp_path / "target-lock"
+        target.write_bytes(b"")
+        target.chmod(0o600)
+        lease.symlink_to(target)
+        message = "absolute normalized"
+    elif fault == "mode":
+        lease.chmod(0o644)
+        message = "is unsafe"
+    else:
+        os.link(lease, tmp_path / "second-lock-link")
+        message = "is unsafe"
+
+    with (
+        pytest.raises(promotion_module.PromotionError, match=message),
+        promotion_module._release_lease(lease),
+    ):
+        pytest.fail("unsafe lease was acquired")
+
+
+def test_release_lease_rejects_contention_and_releases_after_failure(
+    tmp_path: Path,
+) -> None:
+    """Fail closed on contention and always unlock after the controlled body."""
+    lease = _new_release_lease(tmp_path)
+    competing = os.open(lease, os.O_RDWR)
+    try:
+        fcntl.flock(competing, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        with (
+            pytest.raises(
+                promotion_module.DeploymentLockBusyError,
+                match="another release controller",
+            ),
+            promotion_module._release_lease(lease),
+        ):
+            pytest.fail("contended lease was acquired")
+    finally:
+        fcntl.flock(competing, fcntl.LOCK_UN)
+        os.close(competing)
+
+    with (
+        pytest.raises(RuntimeError, match="body failure"),
+        promotion_module._release_lease(lease),
+    ):
+        raise RuntimeError("body failure")
+
+    descriptor = os.open(lease, os.O_RDWR)
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+    finally:
+        os.close(descriptor)
+
+
+def test_release_lease_redacts_unexpected_lock_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Convert an unexpected host lock failure to a stable public diagnostic."""
+    lease = _new_release_lease(tmp_path)
+
+    def fail_lock(_descriptor: int, operation: int) -> None:
+        assert operation == fcntl.LOCK_EX | fcntl.LOCK_NB
+        raise OSError(errno.EIO, "private lock detail")
+
+    monkeypatch.setattr(promotion_module.fcntl, "flock", fail_lock)
+
+    with (
+        pytest.raises(
+            promotion_module.PromotionError,
+            match="release lease could not be acquired",
+        ),
+        promotion_module._release_lease(lease),
+    ):
+        pytest.fail("failed lease was acquired")
+
+
+def test_controller_holds_lease_before_stdin_and_through_promotion(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    """Prove the lease spans secret input parsing and every host command."""
+    host, config, environment = setup
+    _initialize(host, config)
+    arguments = _controller_argv(config)
+    lease = (
+        config.release_checkout.with_name(f"{config.release_checkout.name}.lease")
+        / "lock"
+    )
+    host.lease_probe = lease
+    payload = serialize_compose_environment(
+        PRODUCTION_ENVIRONMENT_NAMES,
+        environment,
+    ).encode()
+
+    class LockProbingStream(io.BytesIO):
+        def read(self, size: int | None = -1) -> bytes:
+            descriptor = os.open(lease, os.O_RDWR)
+            try:
+                with pytest.raises(OSError) as blocked:
+                    fcntl.flock(
+                        descriptor,
+                        fcntl.LOCK_EX | fcntl.LOCK_NB,
+                    )
+                assert blocked.value.errno in {errno.EACCES, errno.EAGAIN}
+            finally:
+                os.close(descriptor)
+            return super().read(size)
+
+    assert main(arguments, environment, LockProbingStream(payload)) == 0
+
+    descriptor = os.open(lease, os.O_RDWR)
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+    finally:
+        os.close(descriptor)
+
+
+def test_explicit_adoption_happens_before_promotion(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    _host, config, environment = setup
+
+    promote(config, environment=environment)
+
+    assert [
+        entry.event for entry in DeploymentStateStore(config.state_dir).read_journal()
+    ] == ["adopted", "promoted"]
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("state_dir", Path("relative"), "absolute normalized"),
+        ("expected_origin", f"{ORIGIN}.git", "expected origin"),
+        ("compose_project", "UPPER", "Compose project"),
+        ("compose_service", "bad.name", "Compose service"),
+        ("source_revision", "a" * 39, "source revision"),
+        ("image_reference", "agent:latest", "immutable digest"),
+    ],
+)
+def test_invalid_controller_inputs_fail_before_external_mutation(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    field: str,
+    value: object,
+    message: str,
+) -> None:
+    host, config, environment = setup
+    if field == "state_dir":
+        assert isinstance(value, Path)
+        changed = replace(config, state_dir=value)
+    else:
+        assert isinstance(value, str)
+        if field == "expected_origin":
+            changed = replace(config, expected_origin=value)
+        elif field == "compose_project":
+            changed = replace(config, compose_project=value)
+        elif field == "compose_service":
+            changed = replace(config, compose_service=value)
+        elif field == "source_revision":
+            changed = replace(config, source_revision=value)
+        elif field == "image_reference":
+            changed = replace(config, image_reference=value)
+        else:
+            raise AssertionError(field)
+
+    with pytest.raises(promotion_module.PromotionError, match=message):
+        promote(changed, environment=environment)
+
+    assert not host.log
+
+
+def test_transaction_identity_binds_the_pre_cutover_revision() -> None:
+    selected = promotion_module._new_transaction_id(OLD_REVISION)
+
+    assert len(selected) == 64
+    assert selected.endswith(f"-{OLD_REVISION}")
+    with pytest.raises(
+        promotion_module.PromotionError,
+        match="baseline revision is invalid",
+    ):
+        promotion_module._new_transaction_id("not-a-revision")
+
+
+@pytest.mark.parametrize("value", ["", "bad\nline", "bad\rline", "bad\0line"])
+def test_one_line_rejects_ambiguous_command_output(value: str) -> None:
+    with pytest.raises(promotion_module.PromotionError):
+        promotion_module._one_line(value, "test")
+
+
+@pytest.mark.parametrize("value", ["not-json", "{}", "[]", "[1]", "[{},{}]"])
+def test_json_object_rejects_noncanonical_shape(value: str) -> None:
+    with pytest.raises(promotion_module.PromotionError):
+        promotion_module._json_object(value, "test")
+
+
+def test_typed_output_helpers_reject_wrong_types() -> None:
+    with pytest.raises(promotion_module.PromotionError):
+        promotion_module._mapping({"value": "wrong"}, "value", "test")
+    with pytest.raises(promotion_module.PromotionError):
+        promotion_module._string({"value": 1}, "value", "test")
+
+
+def test_environment_hash_rejects_missing_and_empty(tmp_path: Path) -> None:
+    with pytest.raises(promotion_module.PromotionError):
+        promotion_module._environment_sha256(tmp_path / "missing")
+    empty = tmp_path / "empty"
+    empty.touch()
+    with pytest.raises(promotion_module.PromotionError):
+        promotion_module._environment_sha256(empty)
+
+
+def test_run_redacts_process_failures_and_bounds_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = tmp_path / "tool"
+    executable.touch()
+    real_run = subprocess.run
+    timeout_mock = create_autospec(
+        real_run,
+        spec_set=True,
+        side_effect=subprocess.TimeoutExpired(["tool"], 1),
+    )
+    monkeypatch.setattr(subprocess, "run", timeout_mock)
+    with pytest.raises(promotion_module.PromotionError, match="command failed"):
+        promotion_module._run(executable, (), environment={})
+
+    failed_mock = create_autospec(
+        real_run,
+        spec_set=True,
+        return_value=subprocess.CompletedProcess(["tool"], 9, "", "private"),
+    )
+    monkeypatch.setattr(subprocess, "run", failed_mock)
+    with pytest.raises(promotion_module.PromotionError, match="command failed"):
+        promotion_module._run(executable, (), environment={})
+
+    large_mock = create_autospec(
+        real_run,
+        spec_set=True,
+        return_value=subprocess.CompletedProcess(
+            ["tool"],
+            0,
+            "x" * (promotion_module._MAX_COMMAND_OUTPUT_BYTES + 1),
+            "",
+        ),
+    )
+    monkeypatch.setattr(subprocess, "run", large_mock)
+    with pytest.raises(promotion_module.PromotionError, match="too large"):
+        promotion_module._run(executable, (), environment={})
+
+
+def test_missing_environment_and_line_injection_are_redacted(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _host, config, environment = setup
+    missing = dict(environment)
+    secret = missing.pop("DATABASE_URL")
+    assert main(_argv(config), missing) == 1
+    assert secret not in capsys.readouterr().err
+
+    hostile = dict(environment)
+    hostile["DATABASE_URL"] = "before\nprivate-after"
+    assert main(_argv(config), hostile) == 1
+    assert "private-after" not in capsys.readouterr().err
+
+
+def _strict_run(
+    monkeypatch: pytest.MonkeyPatch,
+    side_effect: object,
+) -> None:
+    run_mock = create_autospec(
+        REAL_SUBPROCESS_RUN,
+        spec_set=True,
+        side_effect=side_effect,
+    )
+    monkeypatch.setattr(subprocess, "run", run_mock)
+
+
+BoundaryTransform = Callable[
+    [list[str], subprocess.CompletedProcess[str]],
+    subprocess.CompletedProcess[str],
+]
+
+
+def _strict_host_run(
+    monkeypatch: pytest.MonkeyPatch,
+    host: Host,
+    transform: BoundaryTransform,
+) -> None:
+    def boundary(
+        args: list[str],
+        *,
+        cwd: Path | None = None,
+        env: dict[str, str],
+        text: bool,
+        capture_output: bool,
+        check: bool,
+        timeout: int,
+    ) -> subprocess.CompletedProcess[str]:
+        result = host.run(
+            args,
+            cwd=cwd,
+            env=env,
+            text=text,
+            capture_output=capture_output,
+            check=check,
+            timeout=timeout,
+        )
+        return transform(args, result)
+
+    _strict_run(monkeypatch, boundary)
+
+
+def _executables(host: Host) -> promotion_module.Executables:
+    return promotion_module.Executables(
+        git=Path(host.executable("git")),
+        docker=Path(host.executable("docker")),
+    )
+
+
+def _completed_json(
+    args: list[str],
+    document: object,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args, 0, json.dumps([document]), "")
+
+
+def test_config_rejects_colliding_and_unavailable_checkouts(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    tmp_path: Path,
+) -> None:
+    host, config, environment = setup
+    with pytest.raises(
+        promotion_module.PromotionError,
+        match="must be distinct",
+    ):
+        promote(
+            replace(config, release_checkout=config.checkout), environment=environment
+        )
+
+    missing = tmp_path / "missing"
+    with pytest.raises(promotion_module.PromotionError, match="is unavailable"):
+        promote(replace(config, release_checkout=missing), environment=environment)
+
+    regular_file = tmp_path / "not-a-checkout"
+    regular_file.write_text("not a directory", encoding="utf-8")
+    with pytest.raises(promotion_module.PromotionError, match="is not a directory"):
+        promote(
+            replace(config, release_checkout=regular_file),
+            environment=environment,
+        )
+
+    assert not host.log
+
+
+@pytest.mark.parametrize("kind", ["missing", "dangling", "directory"])
+def test_executable_resolution_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    kind: str,
+) -> None:
+    selected: str | None
+    if kind == "missing":
+        selected = None
+    elif kind == "dangling":
+        selected = str(tmp_path / "does-not-exist")
+    else:
+        selected = str(tmp_path)
+    which_mock = create_autospec(
+        REAL_SHUTIL_WHICH,
+        spec_set=True,
+        return_value=selected,
+    )
+    monkeypatch.setattr(shutil, "which", which_mock)
+
+    with pytest.raises(promotion_module.PromotionError, match="executable"):
+        promotion_module._resolve_executable("docker", {"PATH": str(tmp_path)})
+
+
+@pytest.mark.parametrize(
+    ("checkout_kind", "fault", "message"),
+    [
+        ("release", "root-unavailable", "release checkout root is unavailable"),
+        ("release", "root-mismatch", "release checkout root does not match"),
+        ("release", "origin", "release checkout origin does not match"),
+        ("release", "revision", "release checkout revision does not match"),
+        ("release", "dirty", "release checkout has tracked changes"),
+        ("production", "root-unavailable", "production checkout root is unavailable"),
+        ("production", "root-mismatch", "production checkout root does not match"),
+        ("production", "origin", "production checkout origin does not match"),
+        ("production", "dirty", "production checkout has tracked changes"),
+    ],
+)
+def test_checkout_proofs_reject_drift_before_promotion(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    checkout_kind: str,
+    fault: str,
+    message: str,
+) -> None:
+    host, config, environment = setup
+    selected_checkout = (
+        config.release_checkout if checkout_kind == "release" else config.checkout
+    )
+
+    def altered_run(
+        args: list[str],
+        *,
+        cwd: Path | None = None,
+        env: dict[str, str],
+        text: bool,
+        capture_output: bool,
+        check: bool,
+        timeout: int,
+    ) -> subprocess.CompletedProcess[str]:
+        result = host.run(
+            args,
+            cwd=cwd,
+            env=env,
+            text=text,
+            capture_output=capture_output,
+            check=check,
+            timeout=timeout,
+        )
+        tail = args[3:] if args[1:2] == ["-C"] else args[1:]
+        path = Path(args[2]) if args[1:2] == ["-C"] else None
+        if path != selected_checkout:
+            return result
+        if fault == "root-unavailable" and tail == [
+            "rev-parse",
+            "--show-toplevel",
+        ]:
+            return host.completed(args, stdout=f"{tmp_path / 'gone'}\n")
+        if fault == "root-mismatch" and tail == ["rev-parse", "--show-toplevel"]:
+            other = (
+                config.checkout
+                if selected_checkout == config.release_checkout
+                else config.release_checkout
+            )
+            return host.completed(args, stdout=f"{other}\n")
+        if fault == "origin" and tail == ["remote", "get-url", "origin"]:
+            return host.completed(
+                args,
+                stdout="https://github.com/QueryPlanner/other\n",
+            )
+        if fault == "revision" and tail == ["rev-parse", "--verify", "HEAD"]:
+            return host.completed(args, stdout=f"{OLD_REVISION}\n")
+        if fault == "dirty" and tail == [
+            "diff",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--quiet",
+            "--",
+        ]:
+            return host.completed(args, returncode=1)
+        return result
+
+    _strict_run(monkeypatch, altered_run)
+
+    with pytest.raises(promotion_module.PromotionError, match=message):
+        promote(config, environment=environment)
+
+
+def test_release_checkout_rejects_ignored_or_untracked_bytes(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reject bytes outside the exact commit before deployment mutation."""
+    host, config, environment = setup
+
+    def transform(
+        args: list[str],
+        result: subprocess.CompletedProcess[str],
+    ) -> subprocess.CompletedProcess[str]:
+        if args[1:3] == ["-C", str(config.release_checkout)] and args[3:] == [
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+            "--ignored=matching",
+        ]:
+            return host.completed(
+                args,
+                stdout="!! src/agent/__pycache__/\n",
+            )
+        return result
+
+    _strict_host_run(monkeypatch, host, transform)
+
+    with pytest.raises(
+        promotion_module.PromotionError,
+        match="untracked or ignored",
+    ):
+        promote(config, environment=environment)
+
+
+@pytest.mark.parametrize(
+    ("document", "message"),
+    [
+        (
+            {
+                "Id": "not-an-image-id",
+                "RepoDigests": [TARGET_IMAGE],
+                "Config": {
+                    "Labels": {"org.opencontainers.image.revision": TARGET_REVISION}
+                },
+            },
+            "local image ID is invalid",
+        ),
+        (
+            {
+                "Id": TARGET_IMAGE_ID,
+                "RepoDigests": "not-a-list",
+                "Config": {
+                    "Labels": {"org.opencontainers.image.revision": TARGET_REVISION}
+                },
+            },
+            "local image digest does not match",
+        ),
+        (
+            {
+                "Id": TARGET_IMAGE_ID,
+                "RepoDigests": [TARGET_IMAGE],
+                "Config": {
+                    "Labels": {"org.opencontainers.image.revision": OLD_REVISION}
+                },
+            },
+            "image OCI revision does not match",
+        ),
+    ],
+)
+def test_image_proof_rejects_unproven_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    document: dict[str, object],
+    message: str,
+) -> None:
+    def boundary(
+        args: list[str],
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        return _completed_json(args, document)
+
+    _strict_run(monkeypatch, boundary)
+    executables = promotion_module.Executables(
+        git=tmp_path / "git",
+        docker=tmp_path / "docker",
+    )
+
+    with pytest.raises(promotion_module.PromotionError, match=message):
+        promotion_module._inspect_image(
+            proof_reference=TARGET_IMAGE,
+            expected_revision=TARGET_REVISION,
+            executables=executables,
+            environment={},
+        )
+
+
+def test_container_list_rejects_non_hex_ids(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def boundary(
+        args: list[str],
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args, 0, "not-a-container\n", "")
+
+    _strict_run(monkeypatch, boundary)
+    with pytest.raises(promotion_module.PromotionError, match="container list"):
+        promotion_module._container_ids(
+            project=PROJECT,
+            service=SERVICE,
+            executables=promotion_module.Executables(
+                git=tmp_path / "git",
+                docker=tmp_path / "docker",
+            ),
+            environment={},
+        )
+
+
+def _volume_mount(
+    *,
+    name: str = VOLUME.name,
+    destination: str = VOLUME.destination,
+    driver: str = VOLUME.driver,
+) -> dict[str, object]:
+    return {
+        "Type": "volume",
+        "Name": name,
+        "Driver": driver,
+        "Destination": destination,
+    }
+
+
+def _volume_document(
+    *,
+    name: str = VOLUME.name,
+    driver: str = VOLUME.driver,
+    mountpoint: str = VOLUME.mountpoint,
+    created_at: str = VOLUME.created_at,
+) -> dict[str, object]:
+    return {
+        "Name": name,
+        "Driver": driver,
+        "Mountpoint": mountpoint,
+        "CreatedAt": created_at,
+    }
+
+
+@pytest.mark.parametrize(
+    ("mounts", "documents", "message"),
+    [
+        ("wrong", [], "mount observation"),
+        ([1], [], "mount observation"),
+        ([_volume_mount(destination="/")], [], "mount identity"),
+        (
+            [_volume_mount()],
+            [_volume_document(driver="different")],
+            "daemon identity does not match",
+        ),
+        (
+            [_volume_mount()],
+            [_volume_document(mountpoint="/")],
+            "daemon identity is invalid",
+        ),
+        (
+            [_volume_mount()],
+            [_volume_document(created_at="not-a-time")],
+            "creation time is invalid",
+        ),
+        (
+            [_volume_mount()],
+            [_volume_document(created_at="2026-07-28T12:00:00")],
+            "creation time is invalid",
+        ),
+        (
+            [_volume_mount()],
+            [_volume_document(created_at="2026-07-28 12:00:00+00:00")],
+            "creation time is invalid",
+        ),
+        (
+            [_volume_mount(), _volume_mount()],
+            [_volume_document(), _volume_document()],
+            "identities are ambiguous",
+        ),
+    ],
+)
+def test_volume_proofs_reject_unsafe_or_ambiguous_mounts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mounts: object,
+    documents: list[dict[str, object]],
+    message: str,
+) -> None:
+    remaining = iter(documents)
+
+    def boundary(
+        args: list[str],
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        return _completed_json(args, next(remaining))
+
+    _strict_run(monkeypatch, boundary)
+    with pytest.raises(promotion_module.PromotionError, match=message):
+        promotion_module._volume_proofs(
+            mounts=mounts,
+            executables=promotion_module.Executables(
+                git=tmp_path / "git",
+                docker=tmp_path / "docker",
+            ),
+            environment={},
+        )
+
+
+@pytest.mark.parametrize(
+    "created_at",
+    [
+        "2026-07-28T12:00:00Z",
+        "2026-07-28T12:00:00.123456789Z",
+        "2026-07-28T17:30:00.123+05:30",
+    ],
+)
+def test_volume_proofs_preserve_exact_daemon_creation_time(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    created_at: str,
+) -> None:
+    def boundary(
+        args: list[str],
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        return _completed_json(args, _volume_document(created_at=created_at))
+
+    _strict_run(monkeypatch, boundary)
+
+    proofs = promotion_module._volume_proofs(
+        mounts=[_volume_mount()],
+        executables=promotion_module.Executables(
+            git=tmp_path / "git",
+            docker=tmp_path / "docker",
+        ),
+        environment={},
+    )
+
+    assert len(proofs) == 1
+    assert proofs[0].created_at == created_at
+    assert proofs[0].recorded_identity().created_at == created_at
+
+
+def test_volume_proofs_ignore_non_volume_mounts(tmp_path: Path) -> None:
+    assert (
+        promotion_module._volume_proofs(
+            mounts=[{"Type": "bind"}],
+            executables=promotion_module.Executables(
+                git=tmp_path / "git",
+                docker=tmp_path / "docker",
+            ),
+            environment={},
+        )
+        == ()
+    )
+
+
+def _container_document(
+    *,
+    container_id: str = TARGET_CONTAINER,
+    status: str = "running",
+    health: str = "healthy",
+    image_reference: str = TARGET_IMAGE,
+    image_id: str = TARGET_IMAGE_ID,
+    project: str = PROJECT,
+) -> dict[str, object]:
+    return {
+        "Id": container_id,
+        "Image": image_id,
+        "State": {"Status": status, "Health": {"Status": health}},
+        "Config": {
+            "Image": image_reference,
+            "Labels": {
+                "com.docker.compose.project": project,
+                "com.docker.compose.service": SERVICE,
+                "com.docker.compose.project.working_dir": "/checkout",
+            },
+        },
+        "Mounts": [],
+    }
+
+
+@pytest.mark.parametrize(
+    ("document", "message"),
+    [
+        (_container_document(container_id="bad"), "container identity"),
+        (_container_document(health="unhealthy"), "running and healthy"),
+        (_container_document(image_id=OLD_IMAGE_ID), "image identity"),
+        (_container_document(project="other"), "Compose labels"),
+    ],
+)
+def test_container_inspection_rejects_identity_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    document: dict[str, object],
+    message: str,
+) -> None:
+    def boundary(
+        args: list[str],
+        **_kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        return _completed_json(args, document)
+
+    _strict_run(monkeypatch, boundary)
+    with pytest.raises(promotion_module.PromotionError, match=message):
+        promotion_module._inspect_container(
+            container_id=TARGET_CONTAINER[:12],
+            expected_checkout=Path("/checkout"),
+            expected_project=PROJECT,
+            expected_service=SERVICE,
+            image=promotion_module.ImageProof(
+                TARGET_IMAGE,
+                TARGET_IMAGE_ID,
+                TARGET_REVISION,
+            ),
+            executables=promotion_module.Executables(
+                git=tmp_path / "git",
+                docker=tmp_path / "docker",
+            ),
+            environment={},
+        )
+
+
+def test_run_bounds_stderr_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = tmp_path / "tool"
+    executable.touch()
+    run_mock = create_autospec(
+        REAL_SUBPROCESS_RUN,
+        spec_set=True,
+        return_value=subprocess.CompletedProcess(
+            ["tool"],
+            0,
+            "",
+            "x" * (promotion_module._MAX_COMMAND_OUTPUT_BYTES + 1),
+        ),
+    )
+    monkeypatch.setattr(subprocess, "run", run_mock)
+    with pytest.raises(promotion_module.PromotionError, match="too large"):
+        promotion_module._run(executable, (), environment={})
+
+
+def test_main_redacts_real_host_oserror(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _host, config, environment = setup
+    blocked = replace(config, state_dir=Path("/dev/null/state"))
+
+    assert main(_argv(blocked), environment) == 1
+    assert "deployment host operation failed" in capsys.readouterr().err
+
+
+def test_module_entrypoint_returns_process_status(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _host, config, _environment = setup
+    monkeypatch.setattr("sys.argv", ["deployment_promotion", *_argv(config)])
+    with pytest.raises(SystemExit) as raised:
+        runpy.run_module("agent.deployment_promotion", run_name="__main__")
+    assert raised.value.code == 1
+
+
+def test_pending_recovery_rejects_ambiguous_production(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host, config, environment = setup
+    _pending(host, config)
+
+    def transform(
+        args: list[str],
+        result: subprocess.CompletedProcess[str],
+    ) -> subprocess.CompletedProcess[str]:
+        if args[1:3] == ["container", "ls"] and any(
+            value == f"label=com.docker.compose.project={PROJECT}" for value in args
+        ):
+            return host.completed(
+                args,
+                stdout=f"{TARGET_CONTAINER[:12]}\n{'4' * 12}\n",
+            )
+        return result
+
+    _strict_host_run(monkeypatch, host, transform)
+
+    assert main(_argv(config), environment) == 1
+    assert config.state_dir.joinpath("pending.json").is_file()
+    assert host.production_revision == TARGET_REVISION
+
+
+def test_pending_recovery_accepts_absent_service_then_restores(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    host, config, environment = setup
+    _pending(host, config)
+    host.production_exists = False
+
+    assert main(_argv(config), environment) == 3
+
+    assert host.production_exists
+    assert host.production_revision == OLD_REVISION
+    assert [
+        entry.event for entry in DeploymentStateStore(config.state_dir).read_journal()
+    ] == ["adopted", "rolled_back"]
+
+
+def test_runtime_observation_returns_none_for_absent_service(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    host, config, environment = setup
+    host.production_exists = False
+
+    assert (
+        promotion_module._observe_runtime(
+            config=config,
+            image=promotion_module.ImageProof(
+                OLD_IMAGE,
+                OLD_IMAGE_ID,
+                OLD_REVISION,
+            ),
+            executables=_executables(host),
+            environment=promotion_module._command_environment(environment),
+        )
+        is None
+    )
+
+
+def test_runtime_observation_rejects_second_read_ambiguity(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host, config, environment = setup
+    production_lists = 0
+
+    def transform(
+        args: list[str],
+        result: subprocess.CompletedProcess[str],
+    ) -> subprocess.CompletedProcess[str]:
+        nonlocal production_lists
+        if args[1:3] == ["container", "ls"] and any(
+            value == f"label=com.docker.compose.project={PROJECT}" for value in args
+        ):
+            production_lists += 1
+            if production_lists == 2:
+                return host.completed(
+                    args,
+                    stdout=f"{OLD_CONTAINER[:12]}\n{'4' * 12}\n",
+                )
+        return result
+
+    _strict_host_run(monkeypatch, host, transform)
+
+    with pytest.raises(promotion_module.PromotionError, match="ambiguous"):
+        promotion_module._observe_runtime(
+            config=config,
+            image=promotion_module.ImageProof(
+                OLD_IMAGE,
+                OLD_IMAGE_ID,
+                OLD_REVISION,
+            ),
+            executables=_executables(host),
+            environment=promotion_module._command_environment(environment),
+        )
+
+
+def test_runtime_observation_rejects_oci_revision_race(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    host, config, environment = setup
+    with pytest.raises(promotion_module.PromotionError, match="image does not match"):
+        promotion_module._observe_runtime(
+            config=config,
+            image=promotion_module.ImageProof(
+                OLD_IMAGE,
+                OLD_IMAGE_ID,
+                TARGET_REVISION,
+            ),
+            executables=_executables(host),
+            environment=promotion_module._command_environment(environment),
+        )
+
+
+def test_baseline_rejects_invalid_checkout_revision(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host, config, environment = setup
+
+    def transform(
+        args: list[str],
+        result: subprocess.CompletedProcess[str],
+    ) -> subprocess.CompletedProcess[str]:
+        if args[1:3] == ["-C", str(config.checkout)] and args[3:] == [
+            "rev-parse",
+            "--verify",
+            "HEAD",
+        ]:
+            return host.completed(args, stdout="not-a-revision\n")
+        return result
+
+    _strict_host_run(monkeypatch, host, transform)
+    with pytest.raises(promotion_module.PromotionError, match="revision is invalid"):
+        promote(config, environment=environment)
+
+
+def test_baseline_redacts_legacy_observation_failure(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    _host, config, environment = setup
+    (config.checkout / ".env").chmod(0o644)
+
+    with pytest.raises(
+        promotion_module.PromotionError,
+        match="observation failed",
+    ):
+        promote(config, environment=environment)
+
+
+def test_baseline_rejects_missing_recorded_runtime(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    host, config, environment = setup
+    _initialize(host, config)
+    host.production_exists = False
+
+    with pytest.raises(
+        promotion_module.PromotionError,
+        match="recorded production deployment is unavailable",
+    ):
+        promote(config, environment=environment)
+
+
+def test_first_install_rejects_unrecorded_environment(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    host, config, environment = setup
+    host.production_exists = False
+
+    with pytest.raises(
+        promotion_module.PromotionError,
+        match="unrecorded production environment",
+    ):
+        promote(config, environment=environment)
+
+
+def test_baseline_rejects_runtime_disappearing_between_proofs(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host, config, environment = setup
+    production_lists = 0
+
+    def transform(
+        args: list[str],
+        result: subprocess.CompletedProcess[str],
+    ) -> subprocess.CompletedProcess[str]:
+        nonlocal production_lists
+        if args[1:3] == ["container", "ls"] and any(
+            value == f"label=com.docker.compose.project={PROJECT}" for value in args
+        ):
+            production_lists += 1
+            if production_lists == 2:
+                return host.completed(args)
+        return result
+
+    _strict_host_run(monkeypatch, host, transform)
+    with pytest.raises(promotion_module.PromotionError, match="disappeared"):
+        promote(config, environment=environment)
+
+
+def test_baseline_requires_explicit_legacy_adoption(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    _host, config, environment = setup
+    with pytest.raises(
+        promotion_module.PromotionError,
+        match="is not recorded",
+    ):
+        promote(replace(config, adopt_existing=False), environment=environment)
+
+
+def test_baseline_rejects_recorded_environment_drift(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    host, config, environment = setup
+    _initialize(host, config)
+    _private(config.checkout / ".env", b'AGENT_NAME="changed"\n')
+
+    with pytest.raises(
+        promotion_module.PromotionError,
+        match="recorded and running",
+    ):
+        promote(config, environment=environment)
+
+
+def test_baseline_rejects_replaced_volume_before_candidate(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host, config, environment = setup
+    _initialize(host, config)
+    promote(config, environment=environment)
+    command_count = len(host.log)
+
+    def transform(
+        args: list[str],
+        result: subprocess.CompletedProcess[str],
+    ) -> subprocess.CompletedProcess[str]:
+        if args[1:3] == ["volume", "inspect"]:
+            document = json.loads(result.stdout)[0]
+            document["CreatedAt"] = REPLACED_VOLUME.created_at
+            return _completed_json(args, document)
+        return result
+
+    _strict_host_run(monkeypatch, host, transform)
+
+    with pytest.raises(
+        promotion_module.PromotionError,
+        match="persistent volume identity changed",
+    ):
+        promote(config, environment=environment)
+
+    assert not any(
+        "candidate-" in " ".join(command) for command in host.log[command_count:]
+    )
+
+
+@pytest.mark.parametrize("fault", ["ambiguous", "volume", "cleanup", "config"])
+def test_candidate_defenses_leave_production_untouched(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+    fault: str,
+) -> None:
+    host, config, environment = setup
+    _initialize(host, config)
+
+    def transform(
+        args: list[str],
+        result: subprocess.CompletedProcess[str],
+    ) -> subprocess.CompletedProcess[str]:
+        candidate_project = next(
+            (
+                args[index + 1]
+                for index, value in enumerate(args)
+                if value == "--project-name" and index + 1 < len(args)
+            ),
+            "",
+        )
+        is_candidate = candidate_project.startswith("candidate-")
+        if (
+            fault == "ambiguous"
+            and args[1:3] == ["container", "ls"]
+            and any(
+                value.startswith(
+                    "label=com.docker.compose.project=candidate-",
+                )
+                for value in args
+            )
+        ):
+            return host.completed(
+                args,
+                stdout=f"{CANDIDATE_CONTAINER[:12]}\n{'4' * 12}\n",
+            )
+        if (
+            fault == "volume"
+            and args[1:3] == ["container", "inspect"]
+            and args[3].startswith(CANDIDATE_CONTAINER[:12])
+        ):
+            document = json.loads(result.stdout)[0]
+            document["Mounts"] = [_volume_mount()]
+            return _completed_json(args, document)
+        if fault == "cleanup" and is_candidate and "down" in args:
+            return host.completed(args, returncode=44)
+        if fault == "config" and is_candidate and "config" in args:
+            return host.completed(args, returncode=45)
+        return result
+
+    _strict_host_run(monkeypatch, host, transform)
+
+    assert main(_argv(config), environment) == 1
+    assert host.production_revision == OLD_REVISION
+    assert host.production_image == OLD_IMAGE
+    assert not config.state_dir.joinpath("pending.json").exists()
+
+
+@pytest.mark.parametrize("fault", ["revision", "dirty"])
+def test_post_intent_checkout_proof_failure_rolls_back(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+    fault: str,
+) -> None:
+    host, config, environment = setup
+    _initialize(host, config)
+    target_checkout_seen = False
+    injected = False
+
+    def transform(
+        args: list[str],
+        result: subprocess.CompletedProcess[str],
+    ) -> subprocess.CompletedProcess[str]:
+        nonlocal target_checkout_seen, injected
+        if (
+            args[0].endswith("/git")
+            and "checkout" in args
+            and args[-1] == TARGET_REVISION
+        ):
+            target_checkout_seen = True
+            return result
+        if target_checkout_seen and not injected:
+            if fault == "revision" and args[3:] == [
+                "rev-parse",
+                "--verify",
+                "HEAD",
+            ]:
+                injected = True
+                return host.completed(args, stdout=f"{OLD_REVISION}\n")
+            if fault == "dirty" and args[3:] == [
+                "diff",
+                "--no-ext-diff",
+                "--no-textconv",
+                "--quiet",
+                "--",
+            ]:
+                injected = True
+                return host.completed(args, returncode=1)
+        return result
+
+    _strict_host_run(monkeypatch, host, transform)
+
+    assert main(_argv(config), environment) == 1
+    assert injected
+    assert host.production_revision == OLD_REVISION
+    assert host.production_image == OLD_IMAGE
+
+
+def test_production_compose_image_drift_rolls_back(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host, config, environment = setup
+    _initialize(host, config)
+    injected = False
+
+    def transform(
+        args: list[str],
+        result: subprocess.CompletedProcess[str],
+    ) -> subprocess.CompletedProcess[str]:
+        nonlocal injected
+        if (
+            not injected
+            and args[1:2] == ["compose"]
+            and "--project-name" in args
+            and args[args.index("--project-name") + 1] == PROJECT
+            and "config" in args
+            and "--images" in args
+        ):
+            injected = True
+            return host.completed(args, stdout=f"{OLD_IMAGE}\n")
+        return result
+
+    _strict_host_run(monkeypatch, host, transform)
+
+    assert main(_argv(config), environment) == 1
+    assert injected
+    assert host.production_revision == OLD_REVISION
+    assert host.production_image == OLD_IMAGE
+
+
+@pytest.mark.parametrize(
+    "fault",
+    ["unavailable", "revision", "volume", "first-install-volume"],
+)
+def test_target_verification_failures_never_commit(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+    fault: str,
+) -> None:
+    host, config, environment = setup
+    if fault == "first-install-volume":
+        host.production_exists = False
+        host.volume_exists = False
+        (host.checkout / ".env").unlink()
+    else:
+        _initialize(host, config)
+    target_up_seen = False
+
+    def transform(
+        args: list[str],
+        result: subprocess.CompletedProcess[str],
+    ) -> subprocess.CompletedProcess[str]:
+        nonlocal target_up_seen
+        if (
+            args[1:2] == ["compose"]
+            and "--project-name" in args
+            and args[args.index("--project-name") + 1] == PROJECT
+            and "up" in args
+            and host.production_image == TARGET_IMAGE
+        ):
+            target_up_seen = True
+        if not target_up_seen:
+            return result
+        if (
+            fault == "unavailable"
+            and args[1:3] == ["container", "ls"]
+            and host.production_image == TARGET_IMAGE
+        ):
+            return host.completed(args)
+        if (
+            fault == "revision"
+            and args[0].endswith("/git")
+            and args[1:3] == ["-C", str(config.checkout)]
+            and args[3:] == ["rev-parse", "--verify", "HEAD"]
+            and host.production_image == TARGET_IMAGE
+        ):
+            return host.completed(args, stdout=f"{OLD_REVISION}\n")
+        if (
+            fault == "volume"
+            and args[1:3] == ["volume", "inspect"]
+            and host.production_image == TARGET_IMAGE
+        ):
+            document = json.loads(result.stdout)[0]
+            document["CreatedAt"] = REPLACED_VOLUME.created_at
+            return _completed_json(args, document)
+        if (
+            fault == "first-install-volume"
+            and args[1:3] == ["container", "inspect"]
+            and args[3].startswith(TARGET_CONTAINER[:12])
+        ):
+            document = json.loads(result.stdout)[0]
+            document["Mounts"] = []
+            return _completed_json(args, document)
+        return result
+
+    _strict_host_run(monkeypatch, host, transform)
+
+    assert main(_argv(config), environment) == 1
+
+    store = DeploymentStateStore(config.state_dir)
+    if fault != "first-install-volume":
+        assert store.read_current() is not None
+    assert store.read_journal()[-1].event in {"rolled_back", "aborted"}
+    assert not config.state_dir.joinpath("pending.json").exists()
+    if fault == "first-install-volume":
+        assert not host.production_exists
+    else:
+        assert host.production_image == OLD_IMAGE
+        assert host.production_revision == OLD_REVISION
+
+
+def test_target_verification_rejects_intent_volume_disagreement(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    host, config, environment = setup
+    _pending(host, config)
+    command_environment = promotion_module._command_environment(environment)
+    executables = _executables(host)
+    with DeploymentStateStore(config.state_dir).transaction() as transaction:
+        pending = transaction.pending()
+        assert pending is not None
+        actual = promotion_module._observe_runtime(
+            config=config,
+            image=promotion_module.ImageProof(
+                TARGET_IMAGE,
+                TARGET_IMAGE_ID,
+                TARGET_REVISION,
+            ),
+            executables=executables,
+            environment=command_environment,
+        )
+        assert actual is not None
+        mismatched = replace(
+            pending,
+            intent=replace(
+                pending.intent,
+                persistent_volumes=(REPLACED_VOLUME,),
+            ),
+        )
+
+        with pytest.raises(
+            promotion_module.PromotionError,
+            match="volume intent does not match",
+        ):
+            promotion_module._verify_target(
+                transaction=transaction,
+                pending=mismatched,
+                baseline_runtime=actual,
+                config=config,
+                executables=executables,
+                environment=command_environment,
+            )
+
+
+def test_restore_baseline_requires_a_recorded_current_state(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    host, config, environment = setup
+    _fresh_pending(
+        host,
+        config,
+        install_environment=False,
+        production_exists=False,
+    )
+    with DeploymentStateStore(config.state_dir).transaction() as transaction:
+        pending = transaction.pending()
+        assert pending is not None
+        command_count = len(host.log)
+        with pytest.raises(
+            promotion_module.PromotionRecoveryFailedError,
+            match="no recorded production baseline",
+        ):
+            promotion_module._restore_baseline(
+                transaction=transaction,
+                pending=pending,
+                current=None,
+                baseline_runtime=None,
+                config=config,
+                executables=_executables(host),
+                environment=promotion_module._command_environment(environment),
+            )
+
+    assert len(host.log) == command_count
+
+
+def test_restore_preflights_recorded_image_before_any_mutation(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host, config, environment = setup
+    _pending(host, config)
+    command_count = len(host.log)
+
+    def transform(
+        args: list[str],
+        result: subprocess.CompletedProcess[str],
+    ) -> subprocess.CompletedProcess[str]:
+        if args[1:3] == ["image", "inspect"] and args[3] == OLD_IMAGE:
+            document = json.loads(result.stdout)[0]
+            document["Id"] = MANUAL_IMAGE_ID
+            return _completed_json(args, document)
+        return result
+
+    _strict_host_run(monkeypatch, host, transform)
+    with DeploymentStateStore(config.state_dir).transaction() as transaction:
+        pending = transaction.pending()
+        current = transaction.current()
+        assert pending is not None
+        assert current is not None
+        with pytest.raises(
+            promotion_module.PromotionRecoveryFailedError,
+            match="baseline image identity",
+        ):
+            promotion_module._restore_baseline(
+                transaction=transaction,
+                pending=pending,
+                current=current,
+                baseline_runtime=None,
+                config=config,
+                executables=_executables(host),
+                environment=promotion_module._command_environment(environment),
+            )
+
+    assert host.production_revision == TARGET_REVISION
+    assert host.production_image == TARGET_IMAGE
+    assert all(
+        "checkout" not in command and "compose" not in command
+        for command in host.log[command_count:]
+    )
+
+
+def test_restore_rejects_baseline_disappearing_after_compose_up(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host, config, environment = setup
+    _pending(host, config)
+    old_up_seen = False
+
+    def transform(
+        args: list[str],
+        result: subprocess.CompletedProcess[str],
+    ) -> subprocess.CompletedProcess[str]:
+        nonlocal old_up_seen
+        if (
+            args[1:2] == ["compose"]
+            and "up" in args
+            and host.production_image == OLD_IMAGE
+        ):
+            old_up_seen = True
+        if old_up_seen and args[1:3] == ["container", "ls"]:
+            return host.completed(args)
+        return result
+
+    _strict_host_run(monkeypatch, host, transform)
+    with DeploymentStateStore(config.state_dir).transaction() as transaction:
+        pending = transaction.pending()
+        current = transaction.current()
+        assert pending is not None
+        assert current is not None
+        with pytest.raises(
+            promotion_module.PromotionRecoveryFailedError,
+            match="did not restore",
+        ):
+            promotion_module._restore_baseline(
+                transaction=transaction,
+                pending=pending,
+                current=current,
+                baseline_runtime=None,
+                config=config,
+                executables=_executables(host),
+                environment=promotion_module._command_environment(environment),
+            )
+
+    assert old_up_seen
+    assert config.state_dir.joinpath("pending.json").is_file()
+
+
+@pytest.mark.parametrize("fault", ["intent", "prior-observation"])
+def test_restore_rejects_any_persistent_volume_identity_change(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    fault: str,
+) -> None:
+    host, config, environment = setup
+    _pending(host, config)
+    command_environment = promotion_module._command_environment(environment)
+    executables = _executables(host)
+    observed_target = promotion_module._observe_runtime(
+        config=config,
+        image=promotion_module.ImageProof(
+            TARGET_IMAGE,
+            TARGET_IMAGE_ID,
+            TARGET_REVISION,
+        ),
+        executables=executables,
+        environment=command_environment,
+    )
+    assert observed_target is not None
+    replaced_proof = promotion_module.VolumeProof(
+        name=REPLACED_VOLUME.name,
+        driver=REPLACED_VOLUME.driver,
+        destination=REPLACED_VOLUME.destination,
+        mountpoint=REPLACED_VOLUME.mountpoint,
+        created_at=REPLACED_VOLUME.created_at,
+    )
+    with DeploymentStateStore(config.state_dir).transaction() as transaction:
+        pending = transaction.pending()
+        current = transaction.current()
+        assert pending is not None
+        assert current is not None
+        selected_pending = (
+            replace(
+                pending,
+                intent=replace(
+                    pending.intent,
+                    persistent_volumes=(REPLACED_VOLUME,),
+                ),
+            )
+            if fault == "intent"
+            else pending
+        )
+        baseline_runtime = (
+            None
+            if fault == "intent"
+            else replace(observed_target, volumes=(replaced_proof,))
+        )
+
+        with pytest.raises(
+            promotion_module.PromotionRecoveryFailedError,
+            match="persistent volume identity",
+        ):
+            promotion_module._restore_baseline(
+                transaction=transaction,
+                pending=selected_pending,
+                current=current,
+                baseline_runtime=baseline_runtime,
+                config=config,
+                executables=executables,
+                environment=command_environment,
+            )
+
+    assert config.state_dir.joinpath("pending.json").is_file()
+
+
+def test_rollback_terminal_commit_is_authoritative_and_not_compensated(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    host, config, environment = setup
+    _initialize(host, config)
+    host.fail_target_health = True
+    host.make_rollback_cleanup_fail = True
+
+    try:
+        assert main(_argv(config), environment) == 4
+    finally:
+        config.state_dir.chmod(0o700)
+
+    store = DeploymentStateStore(config.state_dir)
+    assert [entry.event for entry in store.read_journal()] == [
+        "adopted",
+        "rolled_back",
+    ]
+    assert host.production_image == OLD_IMAGE
+    assert host.production_revision == OLD_REVISION
+    rollback_up_index = max(
+        index
+        for index, command in enumerate(host.log)
+        if "up" in command
+        and "--project-name" in command
+        and command[command.index("--project-name") + 1] == PROJECT
+    )
+    assert not any(
+        "compose" in command for command in host.log[rollback_up_index + 1 :]
+    )

--- a/tests/test_deployment_promotion_runtime.py
+++ b/tests/test_deployment_promotion_runtime.py
@@ -1,0 +1,1481 @@
+"""Opt-in real-Docker proof for atomic VM promotion and verified rollback."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import time
+import uuid
+from collections.abc import Callable, Mapping, Sequence
+from datetime import UTC, datetime
+from functools import partial
+from pathlib import Path
+from urllib.error import URLError
+from urllib.request import ProxyHandler, build_opener
+
+import pytest
+
+from agent.compose_env import (
+    serialize_compose_environment,
+    write_compose_environment,
+)
+from agent.deployment_promotion import PRODUCTION_ENVIRONMENT_NAMES
+from agent.deployment_state import DeploymentStateStore
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+CANDIDATE_COMPOSE_PATH = REPOSITORY_ROOT / "compose.candidate.yaml"
+PROMOTION_MODULE_PATH = REPOSITORY_ROOT / "src" / "agent" / "deployment_promotion.py"
+RUN_ENVIRONMENT_NAME = "RUN_DEPLOYMENT_PROMOTION_INTEGRATION"
+PREFIX_ENVIRONMENT_NAME = "DEPLOYMENT_PROMOTION_TEST_PREFIX"
+PREFIX_PATTERN = re.compile(r"adk-promotion-[a-z0-9][a-z0-9-]{0,23}\Z")
+REVISION_PATTERN = re.compile(r"[0-9a-f]{40}\Z")
+IMAGE_ID_PATTERN = re.compile(r"sha256:[0-9a-f]{64}\Z")
+IMAGE_REFERENCE_PATTERN = re.compile(
+    r"127\.0\.0\.1:[0-9]+/[a-z0-9-]+/agent@sha256:[0-9a-f]{64}\Z"
+)
+CONTAINER_ID_PATTERN = re.compile(r"[0-9a-f]{64}\Z")
+EXPECTED_ORIGIN = "https://github.com/QueryPlanner/google-adk-on-bare-metal"
+REGISTRY_IMAGE_REFERENCE = (
+    "registry@sha256:1be55279f18a2fe1a74edf2664cac61c1bea305b7b4642dab412e7affdcb3e33"
+)
+PRIVATE_CANARIES = (
+    'promotion-old-$-हॅलो-"-\\-canary',
+    'promotion-good-$-हॅलो-"-\\-canary',
+    'promotion-failing-$-हॅलो-"-\\-canary',
+)
+VOLUME_SENTINEL = "atomic-promotion-volume-sentinel"
+PRODUCTION_FAILURE_SENTINEL = "production-only-failure-reached"
+
+PRODUCTION_COMPOSE = """\
+services:
+  agent:
+    image: "${IMAGE:?Set IMAGE to an immutable production image}"
+    pull_policy: never
+    env_file:
+      - "${ENV_FILE:?Set ENV_FILE to the production environment}"
+    environment:
+      AGENT_DIR: "/app/src"
+      HOST: "0.0.0.0"
+      PORT: "8080"
+      ALLOW_ORIGINS: "[]"
+      SERVE_WEB_INTERFACE: "false"
+      RELOAD_AGENTS: "false"
+      ADK_DISABLE_LOAD_DOTENV: "true"
+      OTEL_SDK_DISABLED: "true"
+      OTEL_TRACES_EXPORTER: "none"
+      OTEL_METRICS_EXPORTER: "none"
+      OTEL_LOGS_EXPORTER: "none"
+      PROMOTION_TEST_FAIL: "__PROMOTION_TEST_FAILURE__"
+    volumes:
+      - agent_artifacts:/app/src/.adk
+    restart: "no"
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - >-
+          import urllib.request;
+          urllib.request.build_opener(
+          urllib.request.ProxyHandler({})).open(
+          "http://127.0.0.1:8080/ready", timeout=1).read()
+      interval: 2s
+      timeout: 2s
+      retries: 10
+      start_period: 20s
+    stop_grace_period: 10s
+    command: ["python", "-m", "agent.server"]
+
+volumes:
+  agent_artifacts:
+"""
+
+DERIVATIVE_DOCKERFILE = """\
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+ARG SOURCE_REVISION
+USER root
+COPY promotion-wrapper.sh /usr/local/bin/promotion-wrapper
+RUN chmod 0755 /usr/local/bin/promotion-wrapper
+LABEL org.opencontainers.image.revision="${SOURCE_REVISION}"
+USER app
+ENTRYPOINT ["/usr/local/bin/promotion-wrapper"]
+"""
+
+PROMOTION_WRAPPER = """\
+#!/bin/sh
+set -eu
+if [ "${PROMOTION_TEST_FAIL:-0}" = "1" ] \\
+  && [ "${TELEMETRY_NAMESPACE:-production}" != "candidate" ]; then
+  printf %s production-only-failure-reached \\
+    > /app/src/.adk/promotion-failure-sentinel
+  exit 42
+fi
+exec /app/entrypoint.sh "$@"
+"""
+
+
+def _redact(value: str) -> str:
+    redacted = value
+    for secret in PRIVATE_CANARIES:
+        for candidate in (
+            secret,
+            secret.replace("$", "$$"),
+            json.dumps(secret, ensure_ascii=False)[1:-1],
+            json.dumps(secret, ensure_ascii=True)[1:-1],
+            repr(secret),
+            repr(secret.encode()),
+        ):
+            redacted = redacted.replace(candidate, "[REDACTED]")
+    return redacted
+
+
+def _run(
+    command: Sequence[str],
+    *,
+    environment: Mapping[str, str],
+    cwd: Path = REPOSITORY_ROOT,
+    check: bool = True,
+    timeout: float = 180,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        result = subprocess.run(  # noqa: S603 - fixed/resolved test boundaries
+            list(command),
+            cwd=cwd,
+            env=environment,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as error:
+        stdout = _redact(str(error.stdout or "")[-4_000:])
+        stderr = _redact(str(error.stderr or "")[-4_000:])
+        raise AssertionError(
+            f"{' '.join(command[:3])} exceeded {timeout:g} seconds\n"
+            f"stdout:\n{stdout}\nstderr:\n{stderr}"
+        ) from None
+    if check and result.returncode != 0:
+        stdout = _redact(result.stdout[-4_000:])
+        stderr = _redact(result.stderr[-4_000:])
+        raise AssertionError(
+            f"{' '.join(command[:3])} failed with {result.returncode}\n"
+            f"stdout:\n{stdout}\nstderr:\n{stderr}"
+        )
+    return result
+
+
+def _owned_mutation[MutationResult](
+    cleanup_commands: list[list[str]],
+    cleanup_command: list[str],
+    operation: Callable[[], MutationResult],
+) -> MutationResult:
+    cleanup_commands.append(cleanup_command)
+    return operation()
+
+
+def _execute_exact_cleanup(
+    cleanup_commands: Sequence[Sequence[str]],
+    environment: Mapping[str, str],
+) -> list[str]:
+    failures: list[str] = []
+    for command in reversed(cleanup_commands):
+        if command[-2:] == ["image", "rm"]:
+            continue
+        try:
+            result = _run(
+                command,
+                environment=environment,
+                check=False,
+                timeout=90,
+            )
+        except (AssertionError, OSError) as error:
+            failures.append(_redact(str(error)[-1_000:]))
+            continue
+        if result.returncode != 0 and not any(
+            marker in result.stderr
+            for marker in ("No such", "not found", "does not exist")
+        ):
+            failures.append(_redact(result.stderr[-1_000:]))
+    return failures
+
+
+def _report_cleanup_failures(
+    failures: Sequence[str],
+    primary_error: BaseException | None,
+) -> None:
+    if not failures:
+        return
+    message = "deployment-promotion cleanup failed: " + " | ".join(failures)
+    if primary_error is None:
+        raise AssertionError(message)
+    primary_error.add_note(message)
+
+
+def _base_environment() -> dict[str, str]:
+    environment = {
+        key: os.environ[key]
+        for key in ("HOME", "PATH", "DOCKER_CONFIG", "DOCKER_HOST", "XDG_RUNTIME_DIR")
+        if key in os.environ
+    }
+    environment.update(
+        {
+            "COMPOSE_DISABLE_ENV_FILE": "1",
+            "LANG": "C.UTF-8",
+            "LC_ALL": "C.UTF-8",
+            "PYTHONDONTWRITEBYTECODE": "1",
+        }
+    )
+    return environment
+
+
+def _production_environment(
+    base: Mapping[str, str],
+    *,
+    canary: str,
+    log_level: str,
+) -> dict[str, str]:
+    environment = dict(base)
+    environment.update(
+        {
+            "AGENT_NAME": "deployment-promotion-runtime",
+            "DATABASE_URL": "",
+            "OPENROUTER_API_KEY": canary,
+            "GOOGLE_API_KEY": "",
+            "ROOT_AGENT_MODEL": "gemini-2.5-flash",
+            "LANGFUSE_PUBLIC_KEY": "",
+            "LANGFUSE_SECRET_KEY": "",
+            "LANGFUSE_BASE_URL": "",
+            "LOG_LEVEL": log_level,
+            "PORT": "8080",
+            "HOST": "0.0.0.0",  # noqa: S104 - synthetic container bind
+        }
+    )
+    assert all(name in environment for name in PRODUCTION_ENVIRONMENT_NAMES)
+    return environment
+
+
+def _require_boundaries(environment: Mapping[str, str]) -> tuple[str, str]:
+    docker = shutil.which("docker", path=environment.get("PATH"))
+    git = shutil.which("git", path=environment.get("PATH"))
+    if docker is None or git is None:
+        raise AssertionError("Docker and Git executables are required")
+    _run([docker, "version"], environment=environment, timeout=30)
+    _run([docker, "compose", "version"], environment=environment, timeout=30)
+    return docker, git
+
+
+def _resource_prefix() -> str:
+    configured = os.environ.get(
+        PREFIX_ENVIRONMENT_NAME,
+        f"adk-promotion-{os.getpid()}",
+    ).lower()
+    if PREFIX_PATTERN.fullmatch(configured) is None:
+        raise AssertionError("deployment-promotion Docker prefix is invalid")
+    return f"{configured}-{uuid.uuid4().hex[:8]}"
+
+
+def _git(
+    git: str,
+    environment: Mapping[str, str],
+    *arguments: str,
+    cwd: Path,
+) -> str:
+    return _run(
+        [git, *arguments],
+        environment=environment,
+        cwd=cwd,
+        timeout=30,
+    ).stdout.strip()
+
+
+def _commit_fixture(
+    git: str,
+    environment: Mapping[str, str],
+    checkout: Path,
+    *,
+    phase: str,
+    failure: bool,
+) -> str:
+    (checkout / "compose.yaml").write_text(
+        PRODUCTION_COMPOSE.replace(
+            "__PROMOTION_TEST_FAILURE__",
+            "1" if failure else "0",
+        ),
+        encoding="utf-8",
+    )
+    (checkout / "release.txt").write_text(f"{phase}\n", encoding="ascii")
+    _git(git, environment, "add", ".", cwd=checkout)
+    _git(
+        git,
+        environment,
+        "commit",
+        "-m",
+        f"fixture: {phase}",
+        cwd=checkout,
+    )
+    revision = _git(git, environment, "rev-parse", "HEAD", cwd=checkout)
+    assert REVISION_PATTERN.fullmatch(revision)
+    return revision
+
+
+def _initialize_repository(
+    git: str,
+    environment: Mapping[str, str],
+    checkout: Path,
+) -> tuple[str, str, str]:
+    checkout.mkdir(mode=0o700)
+    (checkout / "src" / "agent").mkdir(parents=True)
+    shutil.copy2(CANDIDATE_COMPOSE_PATH, checkout / "compose.candidate.yaml")
+    shutil.copy2(
+        PROMOTION_MODULE_PATH,
+        checkout / "src" / "agent" / "deployment_promotion.py",
+    )
+    (checkout / ".gitignore").write_text(".env\n", encoding="ascii")
+    _git(git, environment, "init", cwd=checkout)
+    _git(
+        git,
+        environment,
+        "config",
+        "user.email",
+        "runtime@example.invalid",
+        cwd=checkout,
+    )
+    _git(
+        git,
+        environment,
+        "config",
+        "user.name",
+        "Runtime Contract",
+        cwd=checkout,
+    )
+    _git(
+        git,
+        environment,
+        "remote",
+        "add",
+        "origin",
+        EXPECTED_ORIGIN,
+        cwd=checkout,
+    )
+    old_revision = _commit_fixture(
+        git,
+        environment,
+        checkout,
+        phase="old",
+        failure=False,
+    )
+    good_revision = _commit_fixture(
+        git,
+        environment,
+        checkout,
+        phase="good",
+        failure=False,
+    )
+    failing_revision = _commit_fixture(
+        git,
+        environment,
+        checkout,
+        phase="failing",
+        failure=True,
+    )
+    _git(
+        git,
+        environment,
+        "-c",
+        "advice.detachedHead=false",
+        "checkout",
+        "--detach",
+        old_revision,
+        cwd=checkout,
+    )
+    return old_revision, good_revision, failing_revision
+
+
+def _add_release_worktree(
+    git: str,
+    environment: Mapping[str, str],
+    checkout: Path,
+    release_checkout: Path,
+    revision: str,
+) -> None:
+    _git(
+        git,
+        environment,
+        "worktree",
+        "add",
+        "--detach",
+        str(release_checkout),
+        revision,
+        cwd=checkout,
+    )
+    assert (
+        _git(git, environment, "rev-parse", "--verify", "HEAD", cwd=release_checkout)
+        == revision
+    )
+
+
+def _build_base_image(
+    docker: str,
+    environment: Mapping[str, str],
+    *,
+    tag: str,
+    iid_file: Path,
+) -> str:
+    _run(
+        [
+            docker,
+            "build",
+            "--iidfile",
+            str(iid_file),
+            "--tag",
+            tag,
+            str(REPOSITORY_ROOT),
+        ],
+        environment=environment,
+        timeout=900,
+    )
+    image_id = iid_file.read_text(encoding="ascii").strip()
+    assert IMAGE_ID_PATTERN.fullmatch(image_id)
+    return image_id
+
+
+def _write_derivative_context(path: Path) -> None:
+    path.mkdir(mode=0o700)
+    (path / "Dockerfile").write_text(DERIVATIVE_DOCKERFILE, encoding="utf-8")
+    wrapper = path / "promotion-wrapper.sh"
+    wrapper.write_text(PROMOTION_WRAPPER, encoding="utf-8")
+    wrapper.chmod(0o755)
+
+
+def _build_release_image(
+    docker: str,
+    environment: Mapping[str, str],
+    *,
+    context: Path,
+    base_tag: str,
+    tag: str,
+    revision: str,
+    iid_file: Path,
+) -> str:
+    _run(
+        [
+            docker,
+            "build",
+            "--iidfile",
+            str(iid_file),
+            "--tag",
+            tag,
+            "--build-arg",
+            f"BASE_IMAGE={base_tag}",
+            "--build-arg",
+            f"SOURCE_REVISION={revision}",
+            str(context),
+        ],
+        environment=environment,
+        timeout=180,
+    )
+    image_id = iid_file.read_text(encoding="ascii").strip()
+    assert IMAGE_ID_PATTERN.fullmatch(image_id)
+    inspected = _run(
+        [docker, "image", "inspect", "--format", "{{.Id}}", tag],
+        environment=environment,
+        timeout=30,
+    ).stdout.strip()
+    assert inspected == image_id
+    return image_id
+
+
+def _image_identity(
+    docker: str,
+    environment: Mapping[str, str],
+    image: str,
+) -> dict[str, object]:
+    documents = json.loads(
+        _run(
+            [docker, "image", "inspect", image],
+            environment=environment,
+            timeout=30,
+        ).stdout
+    )
+    assert isinstance(documents, list) and len(documents) == 1
+    document = documents[0]
+    assert isinstance(document, dict)
+    return document
+
+
+def _ensure_registry_image(
+    docker: str,
+    environment: Mapping[str, str],
+    cleanup_commands: list[list[str]],
+) -> str:
+    existing = _run(
+        [docker, "image", "inspect", REGISTRY_IMAGE_REFERENCE],
+        environment=environment,
+        check=False,
+        timeout=30,
+    )
+    if existing.returncode != 0:
+        _owned_mutation(
+            cleanup_commands,
+            [docker, "image", "rm", REGISTRY_IMAGE_REFERENCE],
+            lambda: _run(
+                [docker, "image", "pull", REGISTRY_IMAGE_REFERENCE],
+                environment=environment,
+                timeout=180,
+            ),
+        )
+    document = _image_identity(
+        docker,
+        environment,
+        REGISTRY_IMAGE_REFERENCE,
+    )
+    image_id = document.get("Id")
+    assert isinstance(image_id, str)
+    assert IMAGE_ID_PATTERN.fullmatch(image_id)
+    return image_id
+
+
+def _create_registry(
+    docker: str,
+    environment: Mapping[str, str],
+    *,
+    name: str,
+    image_id: str,
+) -> None:
+    _run(
+        [
+            docker,
+            "container",
+            "create",
+            "--name",
+            name,
+            "--publish",
+            "127.0.0.1::5000",
+            image_id,
+        ],
+        environment=environment,
+        timeout=30,
+    )
+    _run(
+        [docker, "container", "start", name],
+        environment=environment,
+        timeout=30,
+    )
+
+
+def _start_registry(
+    docker: str,
+    environment: Mapping[str, str],
+    *,
+    name: str,
+) -> str:
+    endpoint = _run(
+        [docker, "container", "port", name, "5000/tcp"],
+        environment=environment,
+        timeout=30,
+    ).stdout.strip()
+    match = re.fullmatch(r"127\.0\.0\.1:([0-9]+)", endpoint)
+    assert match is not None
+    opener = build_opener(ProxyHandler({}))
+    deadline = time.monotonic() + 30
+    url = f"http://{endpoint}/v2/"
+    while True:
+        try:
+            with opener.open(url, timeout=2) as response:
+                assert response.status == 200
+            return endpoint
+        except URLError:
+            if time.monotonic() >= deadline:
+                raise AssertionError(
+                    "private test registry did not become ready"
+                ) from None
+            time.sleep(0.25)
+
+
+def _push_exact_image(
+    docker: str,
+    environment: Mapping[str, str],
+    cleanup_commands: list[list[str]],
+    *,
+    source_image_id: str,
+    repository_tag: str,
+) -> str:
+    _owned_mutation(
+        cleanup_commands,
+        [docker, "image", "rm", repository_tag],
+        lambda: _run(
+            [docker, "image", "tag", source_image_id, repository_tag],
+            environment=environment,
+            timeout=30,
+        ),
+    )
+    exact_cleanup = [docker, "image", "rm"]
+    cleanup_commands.append(exact_cleanup)
+    _run(
+        [docker, "image", "push", repository_tag],
+        environment=environment,
+        timeout=180,
+    )
+    document = _image_identity(docker, environment, repository_tag)
+    repo_digests = document.get("RepoDigests")
+    assert isinstance(repo_digests, list)
+    repository = repository_tag.rsplit(":", maxsplit=1)[0]
+    matching = [
+        value
+        for value in repo_digests
+        if isinstance(value, str) and value.startswith(f"{repository}@sha256:")
+    ]
+    assert len(matching) == 1
+    exact_reference = matching[0]
+    assert IMAGE_REFERENCE_PATTERN.fullmatch(exact_reference)
+    exact_cleanup.append(exact_reference)
+    return exact_reference
+
+
+def _compose(
+    docker: str,
+    environment: Mapping[str, str],
+    *,
+    checkout: Path,
+    project: str,
+    env_file: Path,
+    image_reference: str,
+    arguments: Sequence[str],
+    timeout: float,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    if not project.startswith("adk-promotion-"):
+        raise AssertionError("refusing to mutate an unowned Compose project")
+    command_environment = dict(environment)
+    command_environment.update(
+        {
+            "ENV_FILE": str(env_file),
+            "IMAGE": image_reference,
+        }
+    )
+    prefix = [
+        docker,
+        "compose",
+        "--project-name",
+        project,
+        "--env-file",
+        str(env_file),
+        "-f",
+        str(checkout / "compose.yaml"),
+    ]
+    configured = _run(
+        [*prefix, "config", "--images"],
+        environment=command_environment,
+        cwd=checkout,
+        timeout=30,
+    ).stdout.splitlines()
+    assert configured == [image_reference]
+    return _run(
+        [*prefix, *arguments],
+        environment=command_environment,
+        cwd=checkout,
+        check=check,
+        timeout=timeout,
+    )
+
+
+def _production_cleanup(
+    docker: str,
+    environment: Mapping[str, str],
+    *,
+    checkout: Path,
+    project: str,
+    env_file: Path,
+    image_reference: str,
+) -> list[str]:
+    try:
+        result = _compose(
+            docker,
+            environment,
+            checkout=checkout,
+            project=project,
+            env_file=env_file,
+            image_reference=image_reference,
+            arguments=(
+                "down",
+                "--volumes",
+                "--remove-orphans",
+                "--timeout",
+                "30",
+            ),
+            timeout=90,
+            check=False,
+        )
+    except (AssertionError, OSError) as error:
+        return [_redact(str(error)[-1_000:])]
+    if result.returncode != 0:
+        return [_redact(result.stderr[-1_000:])]
+    return []
+
+
+def _promotion_cli(
+    environment: Mapping[str, str],
+    *,
+    state_directory: Path,
+    checkout: Path,
+    release_checkout: Path,
+    project: str,
+    revision: str,
+    image_reference: str,
+    adopt_existing: bool,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    command = [
+        sys.executable,
+        "-m",
+        "agent.deployment_promotion",
+        "promote",
+        "--state-dir",
+        str(state_directory),
+        "--checkout",
+        str(checkout),
+        "--release-checkout",
+        str(release_checkout),
+        "--expected-origin",
+        EXPECTED_ORIGIN,
+        "--compose-project",
+        project,
+        "--compose-service",
+        "agent",
+        "--source-revision",
+        revision,
+        "--image-reference",
+        image_reference,
+    ]
+    if adopt_existing:
+        command.append("--adopt-existing")
+    return _run(
+        command,
+        environment=environment,
+        check=check,
+        timeout=360,
+    )
+
+
+def _container_document(
+    docker: str,
+    environment: Mapping[str, str],
+    *,
+    project: str,
+) -> dict[str, object]:
+    short_id = _run(
+        [
+            docker,
+            "container",
+            "ls",
+            "--all",
+            "--filter",
+            f"label=com.docker.compose.project={project}",
+            "--filter",
+            "label=com.docker.compose.service=agent",
+            "--format",
+            "{{.ID}}",
+        ],
+        environment=environment,
+        timeout=30,
+    ).stdout.splitlines()
+    assert len(short_id) == 1
+    documents = json.loads(
+        _run(
+            [docker, "container", "inspect", short_id[0]],
+            environment=environment,
+            timeout=30,
+        ).stdout
+    )
+    assert isinstance(documents, list) and len(documents) == 1
+    document = documents[0]
+    assert isinstance(document, dict)
+    return document
+
+
+def _production_volume_identity(
+    docker: str,
+    environment: Mapping[str, str],
+    container: Mapping[str, object],
+) -> dict[str, str]:
+    mounts = container.get("Mounts")
+    assert isinstance(mounts, list)
+    volumes = [
+        mount
+        for mount in mounts
+        if isinstance(mount, dict) and mount.get("Type") == "volume"
+    ]
+    assert len(volumes) == 1
+    mount = volumes[0]
+    name = mount.get("Name")
+    driver = mount.get("Driver")
+    destination = mount.get("Destination")
+    assert all(isinstance(value, str) for value in (name, driver, destination))
+    documents = json.loads(
+        _run(
+            [docker, "volume", "inspect", str(name)],
+            environment=environment,
+            timeout=30,
+        ).stdout
+    )
+    assert isinstance(documents, list) and len(documents) == 1
+    volume = documents[0]
+    assert isinstance(volume, dict)
+    identity = {
+        "name": str(name),
+        "driver": str(driver),
+        "destination": str(destination),
+        "mountpoint": str(volume.get("Mountpoint")),
+        "created_at": str(volume.get("CreatedAt")),
+    }
+    assert identity["name"] == volume.get("Name")
+    assert identity["driver"] == volume.get("Driver")
+    assert identity["destination"].startswith("/")
+    assert identity["mountpoint"].startswith("/")
+    datetime.fromisoformat(identity["created_at"].replace("Z", "+00:00")).astimezone(
+        UTC
+    )
+    return identity
+
+
+def _write_volume_sentinel(
+    docker: str,
+    environment: Mapping[str, str],
+    container_id: str,
+) -> None:
+    _run(
+        [
+            docker,
+            "container",
+            "exec",
+            container_id,
+            "sh",
+            "-c",
+            f"printf %s {VOLUME_SENTINEL} > /app/src/.adk/promotion-sentinel",
+        ],
+        environment=environment,
+        timeout=30,
+    )
+
+
+def _read_volume_sentinel(
+    docker: str,
+    environment: Mapping[str, str],
+    container_id: str,
+) -> str:
+    return _run(
+        [
+            docker,
+            "container",
+            "exec",
+            container_id,
+            "cat",
+            "/app/src/.adk/promotion-sentinel",
+        ],
+        environment=environment,
+        timeout=30,
+    ).stdout
+
+
+def _read_production_failure_sentinel(
+    docker: str,
+    environment: Mapping[str, str],
+    container_id: str,
+) -> str:
+    return _run(
+        [
+            docker,
+            "container",
+            "exec",
+            container_id,
+            "cat",
+            "/app/src/.adk/promotion-failure-sentinel",
+        ],
+        environment=environment,
+        timeout=30,
+    ).stdout
+
+
+def _container_identity(
+    docker: str,
+    environment: Mapping[str, str],
+    container: str,
+) -> tuple[str, str, str]:
+    document = json.loads(
+        _run(
+            [docker, "container", "inspect", container],
+            environment=environment,
+            timeout=30,
+        ).stdout
+    )[0]
+    return document["Id"], document["State"]["Status"], document["Image"]
+
+
+def _volume_identity(
+    docker: str,
+    environment: Mapping[str, str],
+    volume: str,
+) -> dict[str, object]:
+    documents = json.loads(
+        _run(
+            [docker, "volume", "inspect", volume],
+            environment=environment,
+            timeout=30,
+        ).stdout
+    )
+    assert isinstance(documents, list) and len(documents) == 1
+    document = documents[0]
+    assert isinstance(document, dict)
+    assert all(isinstance(key, str) for key in document)
+    return {str(key): value for key, value in document.items()}
+
+
+def _network_identity(
+    docker: str,
+    environment: Mapping[str, str],
+    network: str,
+) -> str:
+    return _run(
+        [docker, "network", "inspect", "--format", "{{.Id}}", network],
+        environment=environment,
+        timeout=30,
+    ).stdout.strip()
+
+
+def _assert_safe_output(result: subprocess.CompletedProcess[str]) -> None:
+    for canary in PRIVATE_CANARIES:
+        assert canary not in result.stdout
+        assert canary not in result.stderr
+
+
+@pytest.mark.skipif(
+    os.environ.get(RUN_ENVIRONMENT_NAME) != "1",
+    reason="real deployment-promotion Docker proof is opt-in",
+)
+def test_real_docker_promotes_then_restores_exact_verified_baseline(
+    tmp_path: Path,
+) -> None:
+    """Promote one exact digest, then prove automatic full rollback."""
+    base_environment = _base_environment()
+    docker, git = _require_boundaries(base_environment)
+    prefix = _resource_prefix()
+    production_project = f"{prefix}-prod"
+    registry_name = f"{prefix}-registry"
+    repository_name = f"{prefix}/agent"
+    base_tag = f"{prefix}-base:runtime"
+    old_tag = f"{prefix}-old:runtime"
+    good_tag = f"{prefix}-good:runtime"
+    failing_tag = f"{prefix}-failing:runtime"
+    sentinel_image = f"{prefix}-sentinel-image:keep"
+    sentinel_container = f"{prefix}-sentinel-container"
+    sentinel_volume = f"{prefix}-sentinel-volume"
+    sentinel_network = f"{prefix}-sentinel-network"
+    checkout = tmp_path / "production"
+    good_release_checkout = tmp_path / "release-good"
+    failing_release_checkout = tmp_path / "release-failing"
+    state_directory = tmp_path / "deployment-state"
+    derivative_context = tmp_path / "derivative"
+    env_file = checkout / ".env"
+    cleanup_env_file = tmp_path / "cleanup.env"
+
+    cleanup_commands: list[list[str]] = []
+    production_cleanup_armed = False
+    cleanup_image_reference = old_tag
+    primary_error: BaseException | None = None
+    try:
+        old_revision, good_revision, failing_revision = _initialize_repository(
+            git,
+            base_environment,
+            checkout,
+        )
+        _add_release_worktree(
+            git,
+            base_environment,
+            checkout,
+            good_release_checkout,
+            good_revision,
+        )
+        _add_release_worktree(
+            git,
+            base_environment,
+            checkout,
+            failing_release_checkout,
+            failing_revision,
+        )
+        _write_derivative_context(derivative_context)
+
+        _owned_mutation(
+            cleanup_commands,
+            [docker, "image", "rm", base_tag],
+            lambda: _build_base_image(
+                docker,
+                base_environment,
+                tag=base_tag,
+                iid_file=tmp_path / "base.iid",
+            ),
+        )
+        release_images: dict[str, str] = {}
+        for phase, tag, revision in (
+            ("old", old_tag, old_revision),
+            ("good", good_tag, good_revision),
+            ("failing", failing_tag, failing_revision),
+        ):
+            release_images[phase] = _owned_mutation(
+                cleanup_commands,
+                [docker, "image", "rm", tag],
+                partial(
+                    _build_release_image,
+                    docker,
+                    base_environment,
+                    context=derivative_context,
+                    base_tag=base_tag,
+                    tag=tag,
+                    revision=revision,
+                    iid_file=tmp_path / f"{phase}.iid",
+                ),
+            )
+
+        registry_image_id = _ensure_registry_image(
+            docker,
+            base_environment,
+            cleanup_commands,
+        )
+        _owned_mutation(
+            cleanup_commands,
+            [
+                docker,
+                "container",
+                "rm",
+                "--force",
+                "--volumes",
+                registry_name,
+            ],
+            lambda: _create_registry(
+                docker,
+                base_environment,
+                name=registry_name,
+                image_id=registry_image_id,
+            ),
+        )
+        registry_endpoint = _start_registry(
+            docker,
+            base_environment,
+            name=registry_name,
+        )
+
+        references: dict[str, str] = {}
+        for phase in ("old", "good", "failing"):
+            references[phase] = _push_exact_image(
+                docker,
+                base_environment,
+                cleanup_commands,
+                source_image_id=release_images[phase],
+                repository_tag=(f"{registry_endpoint}/{repository_name}:{phase}"),
+            )
+
+        _owned_mutation(
+            cleanup_commands,
+            [docker, "image", "rm", sentinel_image],
+            lambda: _run(
+                [docker, "image", "tag", registry_image_id, sentinel_image],
+                environment=base_environment,
+                timeout=30,
+            ),
+        )
+        sentinel_image_identity = _image_identity(
+            docker,
+            base_environment,
+            sentinel_image,
+        )
+        _owned_mutation(
+            cleanup_commands,
+            [
+                docker,
+                "container",
+                "rm",
+                "--force",
+                "--volumes",
+                sentinel_container,
+            ],
+            lambda: _run(
+                [
+                    docker,
+                    "container",
+                    "create",
+                    "--name",
+                    sentinel_container,
+                    "--network",
+                    "none",
+                    "--entrypoint",
+                    "/bin/true",
+                    registry_image_id,
+                ],
+                environment=base_environment,
+                timeout=30,
+            ),
+        )
+        _run(
+            [docker, "container", "start", "--attach", sentinel_container],
+            environment=base_environment,
+            timeout=30,
+        )
+        sentinel_container_identity = _container_identity(
+            docker,
+            base_environment,
+            sentinel_container,
+        )
+        _owned_mutation(
+            cleanup_commands,
+            [docker, "volume", "rm", sentinel_volume],
+            lambda: _run(
+                [docker, "volume", "create", sentinel_volume],
+                environment=base_environment,
+                timeout=30,
+            ),
+        )
+        sentinel_volume_identity = _volume_identity(
+            docker,
+            base_environment,
+            sentinel_volume,
+        )
+        _owned_mutation(
+            cleanup_commands,
+            [docker, "network", "rm", sentinel_network],
+            lambda: _run(
+                [docker, "network", "create", sentinel_network],
+                environment=base_environment,
+                timeout=30,
+            ),
+        )
+        sentinel_network_identity = _network_identity(
+            docker,
+            base_environment,
+            sentinel_network,
+        )
+
+        old_environment = _production_environment(
+            base_environment,
+            canary=PRIVATE_CANARIES[0],
+            log_level="INFO",
+        )
+        write_compose_environment(
+            env_file,
+            PRODUCTION_ENVIRONMENT_NAMES,
+            old_environment,
+        )
+        write_compose_environment(
+            cleanup_env_file,
+            PRODUCTION_ENVIRONMENT_NAMES,
+            old_environment,
+        )
+        assert stat.S_IMODE(env_file.stat().st_mode) == 0o600
+        cleanup_image_reference = references["old"]
+        production_cleanup_armed = True
+        _compose(
+            docker,
+            base_environment,
+            checkout=checkout,
+            project=production_project,
+            env_file=env_file,
+            image_reference=references["old"],
+            arguments=(
+                "up",
+                "--detach",
+                "--no-build",
+                "--pull",
+                "never",
+                "--wait",
+                "--wait-timeout",
+                "120",
+                "agent",
+            ),
+            timeout=150,
+        )
+        old_container = _container_document(
+            docker,
+            base_environment,
+            project=production_project,
+        )
+        old_container_id = old_container["Id"]
+        old_container_image_id = old_container["Image"]
+        old_container_config = old_container["Config"]
+        old_container_state = old_container["State"]
+        assert isinstance(old_container_id, str)
+        assert isinstance(old_container_image_id, str)
+        assert isinstance(old_container_config, dict)
+        assert isinstance(old_container_state, dict)
+        assert CONTAINER_ID_PATTERN.fullmatch(old_container_id)
+        assert old_container_config["Image"] == references["old"]
+        assert old_container_image_id == release_images["old"]
+        assert old_container_state["Status"] == "running"
+        assert old_container_state["Health"]["Status"] == "healthy"
+        old_volume_identity = _production_volume_identity(
+            docker,
+            base_environment,
+            old_container,
+        )
+        _write_volume_sentinel(
+            docker,
+            base_environment,
+            old_container_id,
+        )
+
+        good_environment = _production_environment(
+            base_environment,
+            canary=PRIVATE_CANARIES[1],
+            log_level="DEBUG",
+        )
+        good_result = _promotion_cli(
+            good_environment,
+            state_directory=state_directory,
+            checkout=checkout,
+            release_checkout=good_release_checkout,
+            project=production_project,
+            revision=good_revision,
+            image_reference=references["good"],
+            adopt_existing=True,
+        )
+        _assert_safe_output(good_result)
+        assert good_result.returncode == 0
+        assert "PROMOTED:" in good_result.stdout
+        cleanup_image_reference = references["good"]
+
+        good_container = _container_document(
+            docker,
+            base_environment,
+            project=production_project,
+        )
+        good_container_id = good_container["Id"]
+        good_container_image_id = good_container["Image"]
+        good_container_config = good_container["Config"]
+        good_container_state = good_container["State"]
+        assert isinstance(good_container_id, str)
+        assert isinstance(good_container_image_id, str)
+        assert isinstance(good_container_config, dict)
+        assert isinstance(good_container_state, dict)
+        assert good_container_config["Image"] == references["good"]
+        assert good_container_image_id == release_images["good"]
+        assert good_container_state["Status"] == "running"
+        assert good_container_state["Health"]["Status"] == "healthy"
+        good_volume_identity = _production_volume_identity(
+            docker,
+            base_environment,
+            good_container,
+        )
+        assert good_volume_identity == old_volume_identity
+        assert (
+            _read_volume_sentinel(
+                docker,
+                base_environment,
+                good_container_id,
+            )
+            == VOLUME_SENTINEL
+        )
+        good_environment_bytes = env_file.read_bytes()
+        assert (
+            good_environment_bytes
+            == serialize_compose_environment(
+                PRODUCTION_ENVIRONMENT_NAMES,
+                good_environment,
+            ).encode()
+        )
+        assert (
+            _git(git, base_environment, "rev-parse", "HEAD", cwd=checkout)
+            == good_revision
+        )
+
+        good_current = DeploymentStateStore(state_directory).read_current()
+        assert good_current is not None
+        assert good_current.state.source_revision == good_revision
+        assert good_current.state.image_reference == references["good"]
+        assert good_current.state.image_id == release_images["good"]
+        assert good_current.state.oci_revision == good_revision
+
+        failing_environment = _production_environment(
+            base_environment,
+            canary=PRIVATE_CANARIES[2],
+            log_level="WARNING",
+        )
+        failing_result = _promotion_cli(
+            failing_environment,
+            state_directory=state_directory,
+            checkout=checkout,
+            release_checkout=failing_release_checkout,
+            project=production_project,
+            revision=failing_revision,
+            image_reference=references["failing"],
+            adopt_existing=False,
+            check=False,
+        )
+        _assert_safe_output(failing_result)
+        assert failing_result.returncode == 1
+        assert "promotion failed; the recorded baseline was restored" in (
+            failing_result.stderr
+        )
+
+        restored_container = _container_document(
+            docker,
+            base_environment,
+            project=production_project,
+        )
+        restored_container_id = restored_container["Id"]
+        restored_image_id = restored_container["Image"]
+        restored_config = restored_container["Config"]
+        restored_state = restored_container["State"]
+        assert isinstance(restored_container_id, str)
+        assert isinstance(restored_config, dict)
+        assert isinstance(restored_state, dict)
+        assert restored_state["Status"] == "running"
+        assert restored_state["Health"]["Status"] == "healthy"
+        assert restored_config["Image"] == references["good"]
+        assert restored_image_id == release_images["good"]
+        assert (
+            _production_volume_identity(
+                docker,
+                base_environment,
+                restored_container,
+            )
+            == good_volume_identity
+        )
+        assert (
+            _read_volume_sentinel(
+                docker,
+                base_environment,
+                restored_container_id,
+            )
+            == VOLUME_SENTINEL
+        )
+        assert (
+            _read_production_failure_sentinel(
+                docker,
+                base_environment,
+                restored_container_id,
+            )
+            == PRODUCTION_FAILURE_SENTINEL
+        )
+        assert env_file.read_bytes() == good_environment_bytes
+        assert hashlib.sha256(env_file.read_bytes()).hexdigest() == (
+            good_current.state.environment_sha256
+        )
+        assert (
+            _git(git, base_environment, "rev-parse", "HEAD", cwd=checkout)
+            == good_revision
+        )
+        assert _git(git, base_environment, "diff", "--quiet", "--", cwd=checkout) == ""
+
+        restored_image = _image_identity(
+            docker,
+            base_environment,
+            str(restored_image_id),
+        )
+        restored_config_document = restored_image["Config"]
+        restored_repo_digests = restored_image["RepoDigests"]
+        assert isinstance(restored_config_document, dict)
+        restored_labels = restored_config_document["Labels"]
+        assert isinstance(restored_labels, dict)
+        assert isinstance(restored_repo_digests, list)
+        assert restored_labels["org.opencontainers.image.revision"] == good_revision
+        assert references["good"] in restored_repo_digests
+
+        store = DeploymentStateStore(state_directory)
+        restored_current = store.read_current()
+        journal = store.read_journal()
+        assert restored_current == good_current
+        assert [entry.event for entry in journal] == [
+            "adopted",
+            "promoted",
+            "rolled_back",
+        ]
+        rollback = journal[-1]
+        promotion = journal[1]
+        assert rollback.state == good_current.state
+        assert promotion.transaction_id is not None
+        assert rollback.transaction_id is not None
+        assert rollback.persistent_volumes[0].as_document() == good_volume_identity
+        assert not store.pending_path.exists()
+        promotion_intent_path = (
+            state_directory / "transactions" / f"{promotion.transaction_id}.json"
+        )
+        promotion_intent_bytes = promotion_intent_path.read_bytes()
+        promotion_intent = json.loads(promotion_intent_bytes)
+        assert promotion_intent["candidate"]["image_reference"] == references["good"]
+        assert promotion_intent["candidate"]["image_id"] == release_images["good"]
+        assert promotion_intent["candidate"]["oci_revision"] == good_revision
+        assert CONTAINER_ID_PATTERN.fullmatch(
+            promotion_intent["candidate"]["container_id"]
+        )
+        intent_path = (
+            state_directory / "transactions" / f"{rollback.transaction_id}.json"
+        )
+        intent_bytes = intent_path.read_bytes()
+        intent = json.loads(intent_bytes)
+        assert intent["candidate"]["image_reference"] == references["failing"]
+        assert intent["candidate"]["image_id"] == release_images["failing"]
+        assert intent["candidate"]["oci_revision"] == failing_revision
+        assert CONTAINER_ID_PATTERN.fullmatch(intent["candidate"]["container_id"])
+        assert intent["target"]["source_revision"] == failing_revision
+        assert intent["baseline_journal_sequence"] == 2
+        for canary in PRIVATE_CANARIES:
+            assert canary.encode() not in promotion_intent_bytes
+            assert canary.encode() not in intent_bytes
+            assert canary.encode() not in store.current_path.read_bytes()
+            for journal_path in store.journal_path.glob("*.json"):
+                assert canary.encode() not in journal_path.read_bytes()
+
+        assert (
+            _container_identity(
+                docker,
+                base_environment,
+                sentinel_container,
+            )
+            == sentinel_container_identity
+        )
+        assert (
+            _volume_identity(
+                docker,
+                base_environment,
+                sentinel_volume,
+            )
+            == sentinel_volume_identity
+        )
+        assert (
+            _network_identity(
+                docker,
+                base_environment,
+                sentinel_network,
+            )
+            == sentinel_network_identity
+        )
+        assert (
+            _image_identity(
+                docker,
+                base_environment,
+                sentinel_image,
+            )
+            == sentinel_image_identity
+        )
+    except BaseException as error:
+        primary_error = error
+        raise
+    finally:
+        failures: list[str] = []
+        if production_cleanup_armed:
+            failures.extend(
+                _production_cleanup(
+                    docker,
+                    base_environment,
+                    checkout=checkout,
+                    project=production_project,
+                    env_file=cleanup_env_file,
+                    image_reference=cleanup_image_reference,
+                )
+            )
+        failures.extend(_execute_exact_cleanup(cleanup_commands, base_environment))
+        _report_cleanup_failures(failures, primary_error)

--- a/tests/test_deployment_promotion_runtime.py
+++ b/tests/test_deployment_promotion_runtime.py
@@ -106,6 +106,8 @@ RUN chmod 0755 /usr/local/bin/promotion-wrapper
 LABEL org.opencontainers.image.revision="${SOURCE_REVISION}"
 USER app
 ENTRYPOINT ["/usr/local/bin/promotion-wrapper"]
+# Docker clears an inherited CMD when a child image sets ENTRYPOINT.
+CMD ["python", "-m", "agent.server"]
 """
 
 PROMOTION_WRAPPER = """\
@@ -489,6 +491,21 @@ def _build_release_image(
         timeout=30,
     ).stdout.strip()
     assert inspected == image_id
+    configured_command = json.loads(
+        _run(
+            [
+                docker,
+                "image",
+                "inspect",
+                "--format",
+                "{{json .Config.Cmd}}",
+                tag,
+            ],
+            environment=environment,
+            timeout=30,
+        ).stdout
+    )
+    assert configured_command == ["python", "-m", "agent.server"]
     return image_id
 
 

--- a/tests/test_deployment_promotion_workflow.py
+++ b/tests/test_deployment_promotion_workflow.py
@@ -1,0 +1,208 @@
+"""Hosted workflow and safety contracts for the real VM promotion proof."""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import yaml  # type: ignore[import-untyped]
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = REPOSITORY_ROOT / ".github" / "workflows" / "test-docker-compose.yml"
+RUNTIME_PATH = REPOSITORY_ROOT / "tests" / "test_deployment_promotion_runtime.py"
+CHECKOUT_PIN = "3d3c42e5aac5ba805825da76410c181273ba90b1"
+SETUP_UV_PIN = "d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86"
+REGISTRY_DIGEST = "1be55279f18a2fe1a74edf2664cac61c1bea305b7b4642dab412e7affdcb3e33"
+
+
+def _workflow() -> dict[str, object]:
+    document = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    assert isinstance(document, dict)
+    return document
+
+
+def _job() -> dict[str, object]:
+    jobs = _workflow()["jobs"]
+    assert isinstance(jobs, dict)
+    selected = jobs["deployment-promotion"]
+    assert isinstance(selected, dict)
+    return selected
+
+
+def _function_source(document: str, name: str) -> str:
+    tree = ast.parse(document)
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == name
+    )
+    return ast.get_source_segment(document, function) or ""
+
+
+def test_promotion_job_is_ephemeral_read_only_and_secret_free() -> None:
+    """Run Docker-root-equivalent behavior only with least-privilege CI access."""
+    workflow = _workflow()
+    job = _job()
+    rendered = yaml.safe_dump(job, sort_keys=False)
+
+    assert workflow["permissions"] == {"contents": "read"}
+    assert job["name"] == "Validate atomic VM promotion and rollback"
+    assert job["runs-on"] == "ubuntu-latest"
+    assert job["timeout-minutes"] == 35
+    assert "permissions" not in job
+    assert ": write" not in rendered
+    assert "secrets." not in rendered
+    assert "github.token" not in rendered
+    assert "GITHUB_TOKEN" not in rendered
+    assert "docker/login-action" not in rendered
+    assert "push: true" not in rendered
+
+
+def test_promotion_job_uses_pinned_locked_focused_boundaries() -> None:
+    """Keep hosted execution reproducible and limited to this exact proof."""
+    steps = _job()["steps"]
+    assert isinstance(steps, list)
+    rendered = yaml.safe_dump(steps, sort_keys=False)
+
+    assert rendered.count("actions/checkout@") == 1
+    assert f"actions/checkout@{CHECKOUT_PIN}" in rendered
+    assert rendered.count("persist-credentials: false") == 1
+    assert rendered.count("astral-sh/setup-uv@") == 1
+    assert f"astral-sh/setup-uv@{SETUP_UV_PIN}" in rendered
+    assert "run: uv python install 3.13" in rendered
+    assert "run: uv sync --locked" in rendered
+    assert rendered.count("uv run pytest") == 1
+    assert "uv run pytest tests/test_deployment_promotion_runtime.py -q" in rendered
+
+
+def test_promotion_job_has_one_unique_explicit_opt_in_namespace() -> None:
+    """Prevent accidental local execution or a shared Compose project."""
+    environment = _job()["env"]
+    assert isinstance(environment, dict)
+    assert environment == {
+        "RUN_DEPLOYMENT_PROMOTION_INTEGRATION": "1",
+        "DEPLOYMENT_PROMOTION_TEST_PREFIX": ("adk-promotion-${{ github.run_id }}"),
+    }
+    assert "COMPOSE_PROJECT_NAME" not in environment
+    assert "github.run_attempt" not in environment["DEPLOYMENT_PROMOTION_TEST_PREFIX"]
+
+
+def test_runtime_uses_one_real_base_and_three_thin_immutable_releases() -> None:
+    """Build the real app once, then vary only wrapper and OCI revision layers."""
+    source = RUNTIME_PATH.read_text(encoding="utf-8")
+    runtime = _function_source(
+        source,
+        "test_real_docker_promotes_then_restores_exact_verified_baseline",
+    )
+
+    assert 'os.environ.get(RUN_ENVIRONMENT_NAME) != "1"' in source
+    assert f'"registry@sha256:{REGISTRY_DIGEST}"' in source
+    assert "registry:2" not in source
+    assert "registry:3" not in source
+    assert runtime.count("_build_base_image(") == 1
+    assert runtime.count("_build_release_image,") == 1
+    assert '("old", old_tag, old_revision)' in runtime
+    assert '("good", good_tag, good_revision)' in runtime
+    assert '("failing", failing_tag, failing_revision)' in runtime
+    assert "FROM ${BASE_IMAGE}" in source
+    assert 'LABEL org.opencontainers.image.revision="${SOURCE_REVISION}"' in source
+    assert "IMAGE_REFERENCE_PATTERN.fullmatch(exact_reference)" in source
+    assert '"image", "pull", config.image_reference' not in runtime
+
+
+def test_runtime_prearms_exact_cleanup_and_never_prunes() -> None:
+    """Leave unrelated VM resources untouched, including on partial failures."""
+    source = RUNTIME_PATH.read_text(encoding="utf-8")
+    owned = _function_source(source, "_owned_mutation")
+    cleanup = _function_source(source, "_execute_exact_cleanup")
+    production_cleanup = _function_source(source, "_production_cleanup")
+    runtime = _function_source(
+        source,
+        "test_real_docker_promotes_then_restores_exact_verified_baseline",
+    )
+
+    for forbidden in (
+        "docker system prune",
+        "docker image prune",
+        "docker builder prune",
+        '"volume", "prune"',
+        '"network", "prune"',
+        '"container", "prune"',
+    ):
+        assert forbidden not in source
+    assert owned.index("cleanup_commands.append") < owned.index("return operation()")
+    assert '"down",' in production_cleanup
+    assert '"--volumes",' in production_cleanup
+    finally_index = runtime.index("finally:")
+    assert "_production_cleanup(" not in runtime[:finally_index]
+    assert "_production_cleanup(" in runtime[finally_index:]
+    assert runtime.index("production_cleanup_armed = True") < runtime.index(
+        "_compose(\n"
+        "            docker,\n"
+        "            base_environment,\n"
+        "            checkout=checkout"
+    )
+    assert cleanup.count("_run(") == 1
+    assert '"system"' not in cleanup
+    assert '"prune"' not in cleanup
+    assert runtime.count("_owned_mutation(") >= 7
+    assert "sentinel_container_identity" in runtime
+    assert "sentinel_volume_identity" in runtime
+    assert "sentinel_network_identity" in runtime
+    assert "sentinel_image_identity" in runtime
+
+
+def test_runtime_proves_success_then_production_only_failure_and_rollback() -> None:
+    """Exercise the actual controller and inspect every restored identity."""
+    source = RUNTIME_PATH.read_text(encoding="utf-8")
+    wrapper = re.search(
+        r'PROMOTION_WRAPPER = """\\\n(?P<body>.*?)\n"""',
+        source,
+        flags=re.DOTALL,
+    )
+    runtime = _function_source(
+        source,
+        "test_real_docker_promotes_then_restores_exact_verified_baseline",
+    )
+
+    assert wrapper is not None
+    assert "PROMOTION_TEST_FAIL" in wrapper.group("body")
+    assert "TELEMETRY_NAMESPACE" in wrapper.group("body")
+    assert '"candidate"' in wrapper.group("body")
+    assert "promotion-failure-sentinel" in wrapper.group("body")
+    assert runtime.count("_promotion_cli(") == 2
+    assert "adopt_existing=True" in runtime
+    assert "adopt_existing=False" in runtime
+    assert "failing_result.returncode == 1" in runtime
+    assert "the recorded baseline was restored" in runtime
+    assert "_read_production_failure_sentinel(" in runtime
+    assert 'restored_state["Health"]["Status"] == "healthy"' in runtime
+    assert 'restored_config["Image"] == references["good"]' in runtime
+    assert 'restored_image_id == release_images["good"]' in runtime
+    assert "restored_labels" in runtime
+    assert "env_file.read_bytes() == good_environment_bytes" in runtime
+    assert "== good_revision" in runtime
+
+
+def test_runtime_proves_candidate_receipt_journal_volume_and_secret_contracts() -> None:
+    """Bind rollback evidence to candidate, state, volume, and private env facts."""
+    source = RUNTIME_PATH.read_text(encoding="utf-8")
+    runtime = _function_source(
+        source,
+        "test_real_docker_promotes_then_restores_exact_verified_baseline",
+    )
+
+    assert "good_volume_identity == old_volume_identity" in runtime
+    assert "VOLUME_SENTINEL" in runtime
+    assert "rollback.persistent_volumes[0].as_document()" in runtime
+    assert 'intent["candidate"]["image_reference"]' in runtime
+    assert 'intent["candidate"]["container_id"]' in runtime
+    assert 'intent["baseline_journal_sequence"] == 2' in runtime
+    assert '"adopted",\n            "promoted",\n            "rolled_back"' in runtime
+    assert "not store.pending_path.exists()" in runtime
+    assert "canary.encode() not in intent_bytes" in runtime
+    assert "canary.encode() not in store.current_path.read_bytes()" in runtime
+    assert "_assert_safe_output(good_result)" in runtime
+    assert "_assert_safe_output(failing_result)" in runtime

--- a/tests/test_deployment_promotion_workflow.py
+++ b/tests/test_deployment_promotion_workflow.py
@@ -92,6 +92,7 @@ def test_promotion_job_has_one_unique_explicit_opt_in_namespace() -> None:
 def test_runtime_uses_one_real_base_and_three_thin_immutable_releases() -> None:
     """Build the real app once, then vary only wrapper and OCI revision layers."""
     source = RUNTIME_PATH.read_text(encoding="utf-8")
+    release_builder = _function_source(source, "_build_release_image")
     runtime = _function_source(
         source,
         "test_real_docker_promotes_then_restores_exact_verified_baseline",
@@ -108,6 +109,9 @@ def test_runtime_uses_one_real_base_and_three_thin_immutable_releases() -> None:
     assert '("failing", failing_tag, failing_revision)' in runtime
     assert "FROM ${BASE_IMAGE}" in source
     assert 'LABEL org.opencontainers.image.revision="${SOURCE_REVISION}"' in source
+    assert 'CMD ["python", "-m", "agent.server"]' in source
+    assert '"{{json .Config.Cmd}}"' in release_builder
+    assert 'configured_command == ["python", "-m", "agent.server"]' in release_builder
     assert "IMAGE_REFERENCE_PATTERN.fullmatch(exact_reference)" in source
     assert '"image", "pull", config.image_reference' not in runtime
 

--- a/tests/test_deployment_state.py
+++ b/tests/test_deployment_state.py
@@ -11,16 +11,22 @@ import stat
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 from unittest.mock import create_autospec, patch
 
 import pytest
 
 from agent import deployment_state as state_module
 from agent.deployment_state import (
+    CandidateReceipt,
     CurrentDeployment,
     DeploymentLockBusyError,
     DeploymentStateError,
     DeploymentStateStore,
+    DeploymentTerminalCommittedError,
+    DeploymentTerminalIndeterminateError,
+    PendingPromotion,
+    PersistentVolumeIdentity,
 )
 
 REVISION = "a" * 40
@@ -30,6 +36,23 @@ IMAGE_REFERENCE = f"ghcr.io/queryplanner/agent@sha256:{'d' * 64}"
 DEPLOYMENT_ID = "adopt-0123456789abcdef"
 RECORDED_AT = "2026-07-28T12:34:56.123456Z"
 ENVIRONMENT_BYTES = b'API_KEY="secret-$-canary"\nEMPTY=""\n'
+TARGET_REVISION = "e" * 40
+TARGET_IMAGE_ID = f"sha256:{'f' * 64}"
+TARGET_IMAGE_REFERENCE = f"ghcr.io/queryplanner/agent@sha256:{'1' * 64}"
+TARGET_ENVIRONMENT_BYTES = b'API_KEY="next-secret-$-canary"\nEMPTY=""\n'
+TRANSACTION_ID = "promote-0123456789abcdef"
+PROMOTION_RECORDED_AT = "2026-07-28T12:35:56.123456Z"
+CANDIDATE_OBSERVED_AT = "2026-07-28T12:35:55.123456Z"
+CANDIDATE_CONTAINER_ID = "2" * 64
+PERSISTENT_VOLUMES = (
+    PersistentVolumeIdentity(
+        name="adk-template-data",
+        driver="local",
+        mountpoint="/var/lib/docker/volumes/adk-template-data/_data",
+        destination="/app/data",
+        created_at="2026-07-27T10:11:12.123456Z",
+    ),
+)
 
 
 def _write_private(path: Path, payload: bytes) -> Path:
@@ -41,6 +64,10 @@ def _write_private(path: Path, payload: bytes) -> Path:
 
 def _environment(tmp_path: Path) -> Path:
     return _write_private(tmp_path / "legacy.env", ENVIRONMENT_BYTES)
+
+
+def _promotion_environment(tmp_path: Path) -> Path:
+    return _write_private(tmp_path / "target.env", TARGET_ENVIRONMENT_BYTES)
 
 
 def _adopt(
@@ -66,6 +93,50 @@ def _adopt(
 
 def _journal_path(store: DeploymentStateStore, sequence: int = 1) -> Path:
     return store.journal_path / f"{sequence:020d}.json"
+
+
+def _candidate(
+    transaction: state_module.DeploymentStateTransaction,
+    **overrides: object,
+) -> CandidateReceipt:
+    journal = transaction.journal()
+    tail = None if not journal else journal[-1]
+    values: dict[str, object] = {
+        "observed_at": CANDIDATE_OBSERVED_AT,
+        "compose_project": "adk-template-candidate",
+        "compose_service": "agent",
+        "container_id": CANDIDATE_CONTAINER_ID,
+        "image_reference": TARGET_IMAGE_REFERENCE,
+        "image_id": TARGET_IMAGE_ID,
+        "oci_revision": TARGET_REVISION,
+        "baseline_journal_sequence": None if tail is None else tail.sequence,
+        "baseline_journal_sha256": None if tail is None else tail.sha256,
+    }
+    values.update(overrides)
+    return CandidateReceipt(**values)  # type: ignore[arg-type]
+
+
+def _begin_promotion(
+    transaction: state_module.DeploymentStateTransaction,
+    environment: Path,
+    *,
+    transaction_id: str = TRANSACTION_ID,
+    candidate_overrides: dict[str, object] | None = None,
+    persistent_volumes: tuple[PersistentVolumeIdentity, ...] = PERSISTENT_VOLUMES,
+) -> PendingPromotion:
+    return transaction.begin_promotion(
+        compose_project="adk-template",
+        compose_service="agent",
+        source_revision=TARGET_REVISION,
+        image_reference=TARGET_IMAGE_REFERENCE,
+        image_id=TARGET_IMAGE_ID,
+        oci_revision=TARGET_REVISION,
+        environment_source=environment,
+        candidate=_candidate(transaction, **(candidate_overrides or {})),
+        persistent_volumes=persistent_volumes,
+        transaction_id=transaction_id,
+        recorded_at=PROMOTION_RECORDED_AT,
+    )
 
 
 def _read_document(path: Path) -> dict[str, object]:
@@ -1367,3 +1438,1892 @@ def test_dangling_current_symlink_is_not_silently_repaired(tmp_path: Path) -> No
         store.read_current()
     assert store.current_path.is_symlink()
     assert not missing_target.exists()
+
+
+def test_schema_v1_adoption_bytes_remain_exact_and_unchanged(
+    tmp_path: Path,
+) -> None:
+    """Keep the original adoption, journal, and current formats byte-exact."""
+    store = DeploymentStateStore(tmp_path / "state")
+    adopted = _adopt(store, _environment(tmp_path))
+    environment_sha256 = hashlib.sha256(ENVIRONMENT_BYTES).hexdigest()
+    state_json = (
+        f'{{"adopted":true,"compose_project":"adk-template",'
+        f'"compose_service":"agent","deployment_id":"{DEPLOYMENT_ID}",'
+        f'"environment_sha256":"{environment_sha256}",'
+        f'"environment_snapshot":"environments/{DEPLOYMENT_ID}.env",'
+        f'"image_id":"{IMAGE_ID}","image_reference":"{IMAGE_REFERENCE}",'
+        f'"oci_revision":"{OCI_REVISION}","recorded_at":"{RECORDED_AT}",'
+        f'"schema_version":1,"source_revision":"{REVISION}"}}'
+    )
+    expected_journal = (
+        '{"event":"adopted","previous_sha256":null,"schema_version":1,'
+        f'"sequence":1,"state":{state_json}}}\n'
+    ).encode()
+    journal_sha256 = hashlib.sha256(expected_journal).hexdigest()
+    expected_current = (
+        f'{{"journal_sequence":1,"journal_sha256":"{journal_sha256}",'
+        f'"schema_version":1,"state":{state_json}}}\n'
+    ).encode()
+
+    assert _journal_path(store).read_bytes() == expected_journal
+    assert store.current_path.read_bytes() == expected_current
+    assert adopted.state.as_document()["schema_version"] == 1
+
+    assert store.read_current() == adopted
+    assert store.read_journal() == (store.read_journal()[0],)
+    assert _journal_path(store).read_bytes() == expected_journal
+    assert store.current_path.read_bytes() == expected_current
+
+
+def test_promotion_round_trips_v2_state_and_exact_environment(
+    tmp_path: Path,
+) -> None:
+    """Persist a complete secret-free intent and make its terminal authoritative."""
+    store = DeploymentStateStore(tmp_path / "state")
+    baseline = _adopt(store, _environment(tmp_path))
+    source = _promotion_environment(tmp_path)
+    installed = tmp_path / "installed.env"
+
+    with store.transaction() as transaction:
+        pending = _begin_promotion(transaction, source)
+        assert transaction.pending() == pending
+        assert pending.intent.baseline_journal_sequence == 1
+        assert pending.intent.baseline_journal_sha256 == baseline.journal_sha256
+        assert pending.intent.baseline_current_sequence == 1
+        assert pending.intent.baseline_current_sha256 == baseline.journal_sha256
+        assert pending.intent.target.adopted is False
+        assert pending.intent.target.as_document()["schema_version"] == 2
+        assert pending.intent.persistent_volumes == PERSISTENT_VOLUMES
+        assert transaction.read_environment(pending.intent.target) == (
+            TARGET_ENVIRONMENT_BYTES
+        )
+        transaction.install_environment(pending.intent.target, installed)
+
+        promoted = transaction.commit_promotion(
+            pending.transaction_id,
+            persistent_volumes=PERSISTENT_VOLUMES,
+        )
+
+        assert promoted.state == pending.intent.target
+        assert promoted.journal_sequence == 2
+        assert promoted.as_document()["schema_version"] == 2
+        assert transaction.current() == promoted
+        assert transaction.pending() is None
+        assert [entry.event for entry in transaction.journal()] == [
+            "adopted",
+            "promoted",
+        ]
+
+    intent_path = store.transactions_path / f"{TRANSACTION_ID}.json"
+    target_snapshot = store.path / promoted.state.environment_snapshot
+    assert installed.read_bytes() == TARGET_ENVIRONMENT_BYTES
+    assert stat.S_IMODE(installed.stat().st_mode) == 0o600
+    assert target_snapshot.read_bytes() == TARGET_ENVIRONMENT_BYTES
+    for private_file in (
+        intent_path,
+        target_snapshot,
+        _journal_path(store, 2),
+        store.current_path,
+    ):
+        assert stat.S_IMODE(private_file.stat().st_mode) == 0o600
+        assert private_file.stat().st_nlink == 1
+    assert stat.S_IMODE(store.transactions_path.stat().st_mode) == 0o700
+    assert not store.pending_path.exists()
+
+    public_bytes = (
+        intent_path.read_bytes()
+        + _journal_path(store, 2).read_bytes()
+        + store.current_path.read_bytes()
+    )
+    assert b"next-secret-$-canary" not in public_bytes
+    assert str(source).encode() not in public_bytes
+    assert store.read_current() == promoted
+    assert store.read_journal()[-1].intent_sha256 == pending.intent_sha256
+
+
+def test_first_install_can_promote_without_an_adopted_baseline(
+    tmp_path: Path,
+) -> None:
+    """Support a fresh VM while binding the first terminal to an empty baseline."""
+    store = DeploymentStateStore(tmp_path / "state")
+    with store.transaction() as transaction:
+        pending = _begin_promotion(
+            transaction,
+            _promotion_environment(tmp_path),
+            persistent_volumes=(),
+        )
+        assert pending.intent.baseline_journal_sequence is None
+        assert pending.intent.baseline_current_sequence is None
+
+        current = transaction.commit_promotion(
+            pending.transaction_id,
+            persistent_volumes=PERSISTENT_VOLUMES,
+        )
+
+    assert current.journal_sequence == 1
+    assert current.state.adopted is False
+    assert store.read_current() == current
+    terminal = store.read_journal()[0]
+    assert terminal.previous_sha256 is None
+    assert terminal.event == "promoted"
+    assert terminal.persistent_volumes == PERSISTENT_VOLUMES
+
+
+@pytest.mark.parametrize(
+    ("method_name", "event"),
+    [
+        ("record_rollback", "rolled_back"),
+        ("record_abort", "aborted"),
+    ],
+)
+def test_nonpromoted_terminal_preserves_baseline_current_bytes(
+    tmp_path: Path,
+    method_name: str,
+    event: str,
+) -> None:
+    """Append history without moving or rewriting the established pointer."""
+    store = DeploymentStateStore(tmp_path / event / "state")
+    baseline = _adopt(store, _environment(tmp_path))
+    baseline_bytes = store.current_path.read_bytes()
+
+    with store.transaction() as transaction:
+        pending = _begin_promotion(transaction, _promotion_environment(tmp_path))
+        terminal_method = getattr(transaction, method_name)
+        result = terminal_method(
+            pending.transaction_id,
+            persistent_volumes=PERSISTENT_VOLUMES,
+        )
+
+        assert result == baseline
+        assert transaction.current() == baseline
+        assert transaction.pending() is None
+
+    assert store.current_path.read_bytes() == baseline_bytes
+    assert store.read_current() == baseline
+    journal = store.read_journal()
+    assert [entry.event for entry in journal] == ["adopted", event]
+    assert journal[-1].state == baseline.state
+
+
+@pytest.mark.parametrize("method_name", ["record_rollback", "record_abort"])
+def test_empty_baseline_terminal_keeps_current_absent(
+    tmp_path: Path,
+    method_name: str,
+) -> None:
+    """Represent a verified non-install outcome without inventing current state."""
+    store = DeploymentStateStore(tmp_path / method_name / "state")
+    with store.transaction() as transaction:
+        pending = _begin_promotion(
+            transaction,
+            _promotion_environment(tmp_path),
+            persistent_volumes=(),
+        )
+        result = getattr(transaction, method_name)(
+            pending.transaction_id,
+            persistent_volumes=(),
+        )
+
+    assert result is None
+    assert store.read_current() is None
+    assert not store.current_path.exists()
+    assert store.read_journal()[0].state is None
+
+
+def test_future_promotion_uses_journal_tail_but_last_established_current(
+    tmp_path: Path,
+) -> None:
+    """Fold current across rollback while chaining the next intent to journal tail."""
+    store = DeploymentStateStore(tmp_path / "state")
+    baseline = _adopt(store, _environment(tmp_path))
+    with store.transaction() as transaction:
+        first = _begin_promotion(transaction, _promotion_environment(tmp_path))
+        assert (
+            transaction.record_rollback(
+                first.transaction_id,
+                persistent_volumes=PERSISTENT_VOLUMES,
+            )
+            == baseline
+        )
+
+    second_id = "promote-fedcba9876543210"
+    second_source = _write_private(
+        tmp_path / "second-target.env",
+        b'API_KEY="third-secret"\n',
+    )
+    with store.transaction() as transaction:
+        second = _begin_promotion(
+            transaction,
+            second_source,
+            transaction_id=second_id,
+        )
+        assert second.intent.baseline_journal_sequence == 2
+        assert second.intent.baseline_current_sequence == 1
+        promoted = transaction.commit_promotion(
+            second.transaction_id,
+            persistent_volumes=PERSISTENT_VOLUMES,
+        )
+
+    assert promoted.journal_sequence == 3
+    assert [entry.event for entry in store.read_journal()] == [
+        "adopted",
+        "rolled_back",
+        "promoted",
+    ]
+    assert store.read_current() == promoted
+
+
+def test_unresolved_pending_survives_restart_and_blocks_new_state(
+    tmp_path: Path,
+) -> None:
+    """Expose recovery work instead of silently replacing an active intent."""
+    store = DeploymentStateStore(tmp_path / "state")
+    _adopt(store, _environment(tmp_path))
+    with store.transaction() as transaction:
+        pending = _begin_promotion(transaction, _promotion_environment(tmp_path))
+
+    with store.transaction() as recovered:
+        assert recovered.pending() == pending
+        with pytest.raises(DeploymentStateError, match="already pending"):
+            _begin_promotion(
+                recovered,
+                _promotion_environment(tmp_path),
+                transaction_id="promote-a23456789abcdef0",
+            )
+        with pytest.raises(DeploymentStateError, match="already been initialized"):
+            recovered.adopt(
+                compose_project="adk-template",
+                compose_service="agent",
+                source_revision=REVISION,
+                image_reference=IMAGE_REFERENCE,
+                image_id=IMAGE_ID,
+                oci_revision=OCI_REVISION,
+                environment_source=_environment(tmp_path),
+            )
+
+
+def test_full_volume_identity_rejects_same_name_driver_and_destination(
+    tmp_path: Path,
+) -> None:
+    """Detect Docker volume replacement even when its friendly fields are reused."""
+    store = DeploymentStateStore(tmp_path / "state")
+    _adopt(store, _environment(tmp_path))
+    replaced_volume = PersistentVolumeIdentity(
+        name=PERSISTENT_VOLUMES[0].name,
+        driver=PERSISTENT_VOLUMES[0].driver,
+        mountpoint=PERSISTENT_VOLUMES[0].mountpoint,
+        destination=PERSISTENT_VOLUMES[0].destination,
+        created_at="2026-07-28T10:11:12.123456Z",
+    )
+
+    with store.transaction() as transaction:
+        pending = _begin_promotion(transaction, _promotion_environment(tmp_path))
+        with pytest.raises(DeploymentStateError, match="identity changed"):
+            transaction.commit_promotion(
+                pending.transaction_id,
+                persistent_volumes=(replaced_volume,),
+            )
+        assert len(transaction.journal()) == 1
+        assert transaction.pending() == pending
+        transaction.record_abort(
+            pending.transaction_id,
+            persistent_volumes=PERSISTENT_VOLUMES,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("name", "../data", "name"),
+        ("driver", "", "driver"),
+        ("mountpoint", "relative", "mountpoint"),
+        ("mountpoint", "/var/lib/../data", "mountpoint"),
+        ("destination", "/", "destination"),
+        ("destination", "/app/../data", "destination"),
+        ("created_at", "2026-02-30T10:11:12Z", "created_at"),
+    ],
+)
+def test_begin_rejects_invalid_volume_identity_before_snapshot(
+    tmp_path: Path,
+    field: str,
+    value: str,
+    message: str,
+) -> None:
+    """Validate daemon volume observations before publishing private bytes."""
+    store = DeploymentStateStore(tmp_path / field / "state")
+    _adopt(store, _environment(tmp_path))
+    values = PERSISTENT_VOLUMES[0].as_document()
+    values[field] = value
+    invalid = PersistentVolumeIdentity(**values)  # type: ignore[arg-type]
+
+    with (
+        store.transaction() as transaction,
+        pytest.raises(DeploymentStateError, match=message),
+    ):
+        _begin_promotion(
+            transaction,
+            _promotion_environment(tmp_path),
+            persistent_volumes=(invalid,),
+        )
+
+    assert not store.pending_path.exists()
+    assert not store.transactions_path.exists()
+
+
+@pytest.mark.parametrize(
+    ("stage", "expected_snapshot", "expected_intent"),
+    [
+        ("snapshot", False, False),
+        ("intent", True, False),
+        ("pending", True, True),
+    ],
+)
+def test_begin_publication_failure_never_returns_without_durable_pending(
+    tmp_path: Path,
+    stage: str,
+    expected_snapshot: bool,
+    expected_intent: bool,
+) -> None:
+    """Leave only pre-mutation residue when a create-only link fails."""
+    store = DeploymentStateStore(tmp_path / stage / "state")
+    _adopt(store, _environment(tmp_path))
+    source = _promotion_environment(tmp_path)
+    snapshot_path = store.environments_path / f"{TRANSACTION_ID}.env"
+    intent_path = store.transactions_path / f"{TRANSACTION_ID}.json"
+    destinations = {
+        "snapshot": snapshot_path,
+        "intent": intent_path,
+        "pending": store.pending_path,
+    }
+    real_link = os.link
+
+    def fail_selected_link(
+        source_path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        destination_path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        *,
+        src_dir_fd: int | None = None,
+        dst_dir_fd: int | None = None,
+        follow_symlinks: bool = True,
+    ) -> None:
+        if Path(os.fsdecode(destination_path)) == destinations[stage]:
+            raise OSError(f"synthetic {stage} link failure")
+        real_link(
+            source_path,
+            destination_path,
+            src_dir_fd=src_dir_fd,
+            dst_dir_fd=dst_dir_fd,
+            follow_symlinks=follow_symlinks,
+        )
+
+    link_boundary = create_autospec(
+        os.link,
+        spec_set=True,
+        side_effect=fail_selected_link,
+    )
+    with (
+        store.transaction() as transaction,
+        patch("agent.deployment_state.os.link", new=link_boundary),
+        pytest.raises(OSError, match=f"{stage} link"),
+    ):
+        _begin_promotion(transaction, source)
+
+    assert snapshot_path.exists() is expected_snapshot
+    assert intent_path.exists() is expected_intent
+    assert not store.pending_path.exists()
+    assert len(store.read_journal()) == 1
+
+
+def test_pending_hard_link_crash_residue_recovers_to_active_pointer(
+    tmp_path: Path,
+) -> None:
+    """Remove the create-only temp alias while preserving the pending final."""
+    store = DeploymentStateStore(tmp_path / "state")
+    _adopt(store, _environment(tmp_path))
+    with store.transaction() as transaction:
+        pending = _begin_promotion(transaction, _promotion_environment(tmp_path))
+    temporary = store.path / ".deployment-pending-crash.tmp"
+    os.link(store.pending_path, temporary)
+    assert store.pending_path.stat().st_nlink == 2
+
+    with store.transaction() as recovered:
+        assert recovered.pending() == pending
+
+    assert not temporary.exists()
+    assert store.pending_path.stat().st_nlink == 1
+
+
+def test_definite_terminal_link_failure_keeps_pending_for_compensation(
+    tmp_path: Path,
+) -> None:
+    """Allow rollback only when the terminal final pathname was never visible."""
+    store = DeploymentStateStore(tmp_path / "state")
+    baseline = _adopt(store, _environment(tmp_path))
+    real_link = os.link
+
+    with store.transaction() as transaction:
+        pending = _begin_promotion(transaction, _promotion_environment(tmp_path))
+        terminal_path = _journal_path(store, 2)
+
+        def reject_terminal_link(
+            source_path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+            destination_path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+            *,
+            src_dir_fd: int | None = None,
+            dst_dir_fd: int | None = None,
+            follow_symlinks: bool = True,
+        ) -> None:
+            if Path(os.fsdecode(destination_path)) == terminal_path:
+                raise OSError("synthetic terminal link failure")
+            real_link(
+                source_path,
+                destination_path,
+                src_dir_fd=src_dir_fd,
+                dst_dir_fd=dst_dir_fd,
+                follow_symlinks=follow_symlinks,
+            )
+
+        link_boundary = create_autospec(
+            os.link,
+            spec_set=True,
+            side_effect=reject_terminal_link,
+        )
+        with (
+            patch("agent.deployment_state.os.link", new=link_boundary),
+            pytest.raises(OSError, match="terminal link"),
+        ):
+            transaction.commit_promotion(
+                pending.transaction_id,
+                persistent_volumes=PERSISTENT_VOLUMES,
+            )
+
+        assert not terminal_path.exists()
+        assert transaction.pending() == pending
+        assert (
+            transaction.record_rollback(
+                pending.transaction_id,
+                persistent_volumes=PERSISTENT_VOLUMES,
+            )
+            == baseline
+        )
+
+
+def test_visible_terminal_directory_fsync_failure_is_indeterminate(
+    tmp_path: Path,
+) -> None:
+    """Never permit compensation after a link-visible, fsync-uncertain terminal."""
+    store = DeploymentStateStore(tmp_path / "state")
+    _adopt(store, _environment(tmp_path))
+    real_fsync = os.fsync
+
+    with store.transaction() as transaction:
+        pending = _begin_promotion(transaction, _promotion_environment(tmp_path))
+        journal_identity = (
+            store.journal_path.stat().st_dev,
+            store.journal_path.stat().st_ino,
+        )
+
+        def reject_journal_directory_sync(descriptor: int) -> None:
+            metadata = os.fstat(descriptor)
+            if (metadata.st_dev, metadata.st_ino) == journal_identity:
+                raise OSError("synthetic terminal directory fsync failure")
+            real_fsync(descriptor)
+
+        sync_boundary = create_autospec(
+            os.fsync,
+            spec_set=True,
+            side_effect=reject_journal_directory_sync,
+        )
+        with (
+            patch("agent.deployment_state.os.fsync", new=sync_boundary),
+            pytest.raises(
+                DeploymentTerminalIndeterminateError,
+                match="publication is indeterminate",
+            ) as captured,
+        ):
+            transaction.commit_promotion(
+                pending.transaction_id,
+                persistent_volumes=PERSISTENT_VOLUMES,
+            )
+
+        assert captured.value.event == "promoted"
+        assert captured.value.transaction_id == TRANSACTION_ID
+        assert _journal_path(store, 2).exists()
+        with pytest.raises(DeploymentTerminalIndeterminateError):
+            transaction.record_rollback(
+                pending.transaction_id,
+                persistent_volumes=(),
+            )
+
+    recovered = store.read_current()
+    assert recovered is not None
+    assert recovered.journal_sequence == 2
+    assert recovered.state.adopted is False
+    assert not store.pending_path.exists()
+
+
+def test_current_replace_failure_reports_committed_and_reconciles(
+    tmp_path: Path,
+) -> None:
+    """Treat the terminal as final even when promoted current publication fails."""
+    store = DeploymentStateStore(tmp_path / "state")
+    baseline = _adopt(store, _environment(tmp_path))
+    real_replace = Path.replace
+
+    def reject_current_replace(source: Path, destination: Path) -> Path:
+        if destination == store.current_path:
+            raise OSError("synthetic promoted current replace failure")
+        return real_replace(source, destination)
+
+    replace_boundary = create_autospec(
+        Path.replace,
+        spec_set=True,
+        side_effect=reject_current_replace,
+    )
+    with store.transaction() as transaction:
+        pending = _begin_promotion(transaction, _promotion_environment(tmp_path))
+        with (
+            patch("pathlib.Path.replace", new=replace_boundary),
+            pytest.raises(
+                DeploymentTerminalCommittedError,
+                match="outcome is committed",
+            ) as captured,
+        ):
+            transaction.commit_promotion(
+                pending.transaction_id,
+                persistent_volumes=PERSISTENT_VOLUMES,
+            )
+        assert captured.value.event == "promoted"
+        assert captured.value.transaction_id == TRANSACTION_ID
+        with pytest.raises(DeploymentTerminalCommittedError):
+            transaction.record_rollback(
+                pending.transaction_id,
+                persistent_volumes=(),
+            )
+
+    assert store.current_path.read_bytes() == state_module._canonical_json(
+        baseline.as_document()
+    )
+    assert store.pending_path.exists()
+    recovered = store.read_current()
+    assert recovered is not None
+    assert recovered.journal_sequence == 2
+    assert recovered.state.adopted is False
+    assert not store.pending_path.exists()
+
+
+def test_pending_unlink_failure_reports_committed_and_reconciles(
+    tmp_path: Path,
+) -> None:
+    """Keep a stale pointer recoverable after the authoritative terminal commit."""
+    store = DeploymentStateStore(tmp_path / "state")
+    _adopt(store, _environment(tmp_path))
+    real_unlink = Path.unlink
+
+    def reject_pending_unlink(selected: Path, missing_ok: bool = False) -> None:
+        if selected == store.pending_path:
+            raise OSError("synthetic pending unlink failure")
+        real_unlink(selected, missing_ok=missing_ok)
+
+    unlink_boundary = create_autospec(
+        Path.unlink,
+        spec_set=True,
+        side_effect=reject_pending_unlink,
+    )
+    with store.transaction() as transaction:
+        pending = _begin_promotion(transaction, _promotion_environment(tmp_path))
+        with (
+            patch("pathlib.Path.unlink", new=unlink_boundary),
+            pytest.raises(DeploymentTerminalCommittedError),
+        ):
+            transaction.commit_promotion(
+                pending.transaction_id,
+                persistent_volumes=PERSISTENT_VOLUMES,
+            )
+        with pytest.raises(DeploymentTerminalCommittedError):
+            transaction.record_abort(
+                pending.transaction_id,
+                persistent_volumes=(),
+            )
+
+    assert store.pending_path.exists()
+    assert store.read_current() is not None
+    assert not store.pending_path.exists()
+
+
+def test_reconciled_terminal_is_exposed_and_blocks_same_transaction_mutation(
+    tmp_path: Path,
+) -> None:
+    """Require a fresh controller invocation after clearing a stale pointer."""
+    store = DeploymentStateStore(tmp_path / "state")
+    _adopt(store, _environment(tmp_path))
+    source = _promotion_environment(tmp_path)
+    with store.transaction() as transaction:
+        assert transaction.recovered_terminal() is None
+        pending = _begin_promotion(transaction, source)
+        stale_pointer = store.pending_path.read_bytes()
+        transaction.record_abort(
+            pending.transaction_id,
+            persistent_volumes=PERSISTENT_VOLUMES,
+        )
+    _write_private(store.pending_path, stale_pointer)
+
+    with store.transaction() as recovered:
+        marker = recovered.recovered_terminal()
+        assert marker is not None
+        assert marker.event == "aborted"
+        assert marker.transaction_id == pending.transaction_id
+        assert recovered.pending() is None
+        with pytest.raises(
+            DeploymentTerminalCommittedError,
+            match="outcome is committed",
+        ):
+            _begin_promotion(recovered, source)
+        with pytest.raises(DeploymentTerminalCommittedError):
+            recovered.install_environment(
+                pending.intent.target,
+                tmp_path / "runtime.env",
+            )
+        with pytest.raises(DeploymentTerminalCommittedError):
+            recovered.remove_environment(
+                pending.intent.target,
+                tmp_path / "runtime.env",
+            )
+        with pytest.raises(DeploymentTerminalCommittedError):
+            recovered.record_rollback(
+                pending.transaction_id,
+                persistent_volumes=PERSISTENT_VOLUMES,
+            )
+
+    assert not store.pending_path.exists()
+    assert [entry.event for entry in store.read_journal()] == [
+        "adopted",
+        "aborted",
+    ]
+
+
+def test_pending_cleanup_fsync_failure_is_committed_with_no_pointer(
+    tmp_path: Path,
+) -> None:
+    """Classify failure after pending unlink as committed, never rollback-safe."""
+    store = DeploymentStateStore(tmp_path / "state")
+    _adopt(store, _environment(tmp_path))
+    real_fsync = os.fsync
+
+    with store.transaction() as transaction:
+        pending = _begin_promotion(transaction, _promotion_environment(tmp_path))
+        root_identity = (store.path.stat().st_dev, store.path.stat().st_ino)
+        root_syncs = 0
+
+        def fail_second_root_sync(descriptor: int) -> None:
+            nonlocal root_syncs
+            metadata = os.fstat(descriptor)
+            if (metadata.st_dev, metadata.st_ino) == root_identity:
+                root_syncs += 1
+                if root_syncs == 2:
+                    raise OSError("synthetic pending cleanup fsync failure")
+            real_fsync(descriptor)
+
+        sync_boundary = create_autospec(
+            os.fsync,
+            spec_set=True,
+            side_effect=fail_second_root_sync,
+        )
+        with (
+            patch("agent.deployment_state.os.fsync", new=sync_boundary),
+            pytest.raises(DeploymentTerminalCommittedError),
+        ):
+            transaction.commit_promotion(
+                pending.transaction_id,
+                persistent_volumes=PERSISTENT_VOLUMES,
+            )
+
+    assert root_syncs == 2
+    assert not store.pending_path.exists()
+    assert store.read_current() is not None
+
+
+@pytest.mark.parametrize("derived_failure", ["current", "current-temp"])
+def test_restart_classifies_derived_repair_failure_as_committed(
+    tmp_path: Path,
+    derived_failure: str,
+) -> None:
+    """Preserve terminal classification while a stale pending proves recovery."""
+    store = DeploymentStateStore(tmp_path / derived_failure / "state")
+    _adopt(store, _environment(tmp_path))
+    real_replace = Path.replace
+
+    def reject_current_replace(source: Path, destination: Path) -> Path:
+        if destination == store.current_path:
+            raise OSError("synthetic current replace failure")
+        return real_replace(source, destination)
+
+    with store.transaction() as transaction:
+        pending = _begin_promotion(transaction, _promotion_environment(tmp_path))
+        with (
+            patch(
+                "pathlib.Path.replace",
+                new=create_autospec(
+                    Path.replace,
+                    spec_set=True,
+                    side_effect=reject_current_replace,
+                ),
+            ),
+            pytest.raises(DeploymentTerminalCommittedError),
+        ):
+            transaction.commit_promotion(
+                pending.transaction_id,
+                persistent_volumes=PERSISTENT_VOLUMES,
+            )
+
+    if derived_failure == "current":
+        store.current_path.chmod(0o644)
+        context: Any = patch.dict({}, {})
+    else:
+        temporary = _write_private(
+            store.path / ".deployment-current-recovery.tmp",
+            b"orphan",
+        )
+        real_unlink = Path.unlink
+
+        def reject_temp_unlink(selected: Path, missing_ok: bool = False) -> None:
+            if selected == temporary:
+                raise OSError("synthetic current temp unlink failure")
+            real_unlink(selected, missing_ok=missing_ok)
+
+        context = patch(
+            "pathlib.Path.unlink",
+            new=create_autospec(
+                Path.unlink,
+                spec_set=True,
+                side_effect=reject_temp_unlink,
+            ),
+        )
+
+    with (
+        context,
+        pytest.raises(DeploymentTerminalCommittedError) as captured,
+        store.transaction(),
+    ):
+        pytest.fail("derived repair unexpectedly completed")
+    assert captured.value.event == "promoted"
+
+    if derived_failure == "current":
+        store.current_path.chmod(0o600)
+    assert store.read_current() is not None
+    assert not store.pending_path.exists()
+
+
+@pytest.mark.parametrize(
+    "created_at",
+    [
+        "2026-07-28T10:11:12Z",
+        "2026-07-28T10:11:12.123456789Z",
+        "2026-07-28T10:11:12.123456789+05:30",
+    ],
+)
+def test_volume_creation_identity_preserves_docker_rfc3339_text(
+    tmp_path: Path,
+    created_at: str,
+) -> None:
+    """Accept representative daemon timestamps without normalizing exact bytes."""
+    volume = PersistentVolumeIdentity(
+        name=PERSISTENT_VOLUMES[0].name,
+        driver=PERSISTENT_VOLUMES[0].driver,
+        mountpoint=PERSISTENT_VOLUMES[0].mountpoint,
+        destination=PERSISTENT_VOLUMES[0].destination,
+        created_at=created_at,
+    )
+    store = DeploymentStateStore(tmp_path / created_at.replace(":", "-") / "state")
+    _adopt(store, _environment(tmp_path))
+
+    with store.transaction() as transaction:
+        pending = _begin_promotion(
+            transaction,
+            _promotion_environment(tmp_path),
+            persistent_volumes=(volume,),
+        )
+        assert pending.intent.persistent_volumes[0].created_at == created_at
+        transaction.record_abort(
+            pending.transaction_id,
+            persistent_volumes=(volume,),
+        )
+
+    assert store.read_journal()[-1].persistent_volumes == (volume,)
+
+
+def test_remove_environment_is_exact_private_and_idempotent(
+    tmp_path: Path,
+) -> None:
+    """Restore absence without exposing bytes and tolerate a prior successful unlink."""
+    store = DeploymentStateStore(tmp_path / "state")
+    destination = tmp_path / "runtime.env"
+    with store.transaction() as transaction:
+        pending = _begin_promotion(
+            transaction,
+            _promotion_environment(tmp_path),
+            persistent_volumes=(),
+        )
+        transaction.install_environment(pending.intent.target, destination)
+        assert destination.read_bytes() == TARGET_ENVIRONMENT_BYTES
+
+        transaction.remove_environment(pending.intent.target, destination)
+        assert not destination.exists()
+        transaction.remove_environment(pending.intent.target, destination)
+        transaction.record_abort(
+            pending.transaction_id,
+            persistent_volumes=(),
+        )
+
+
+def test_verify_installed_environment_is_exact_private_and_read_only(
+    tmp_path: Path,
+) -> None:
+    """Prove exact bytes or absence without changing the runtime path."""
+    store = DeploymentStateStore(tmp_path / "state")
+    destination = tmp_path / "runtime.env"
+    with store.transaction() as transaction:
+        pending = _begin_promotion(
+            transaction,
+            _promotion_environment(tmp_path),
+            persistent_volumes=(),
+        )
+        state = pending.intent.target
+        assert (
+            transaction.verify_installed_environment(
+                state,
+                destination,
+                allow_missing=True,
+            )
+            is False
+        )
+        with pytest.raises(DeploymentStateError, match="environment is missing"):
+            transaction.verify_installed_environment(state, destination)
+
+        transaction.install_environment(state, destination)
+        before = destination.stat()
+        assert transaction.verify_installed_environment(state, destination) is True
+        assert destination.stat() == before
+
+        destination.write_bytes(b"TAMPERED=secret\n")
+        destination.chmod(0o600)
+        with pytest.raises(DeploymentStateError, match="does not match"):
+            transaction.verify_installed_environment(state, destination)
+        assert destination.read_bytes() == b"TAMPERED=secret\n"
+
+        destination.write_bytes(TARGET_ENVIRONMENT_BYTES)
+        destination.chmod(0o600)
+        transaction.remove_environment(state, destination)
+        transaction.record_abort(
+            pending.transaction_id,
+            persistent_volumes=(),
+        )
+
+
+def test_remove_environment_rejects_tampered_or_unsafe_destination(
+    tmp_path: Path,
+) -> None:
+    """Never unlink bytes or pathnames that are not the exact recorded environment."""
+    store = DeploymentStateStore(tmp_path / "state")
+    destination = tmp_path / "runtime.env"
+    with store.transaction() as transaction:
+        pending = _begin_promotion(
+            transaction,
+            _promotion_environment(tmp_path),
+            persistent_volumes=(),
+        )
+        state = pending.intent.target
+        transaction.install_environment(state, destination)
+        destination.write_bytes(b"DIFFERENT=secret\n")
+        destination.chmod(0o600)
+        with pytest.raises(DeploymentStateError, match="does not match"):
+            transaction.remove_environment(state, destination)
+        assert destination.exists()
+
+        destination.write_bytes(TARGET_ENVIRONMENT_BYTES)
+        destination.chmod(0o644)
+        with pytest.raises(DeploymentStateError, match="unsafe permissions"):
+            transaction.remove_environment(state, destination)
+        assert destination.exists()
+        destination.chmod(0o600)
+        transaction.remove_environment(state, destination)
+        transaction.record_abort(
+            pending.transaction_id,
+            persistent_volumes=(),
+        )
+
+
+def test_remove_environment_detects_path_change_before_unlink(
+    tmp_path: Path,
+) -> None:
+    """Revalidate the exact inode metadata immediately before deletion."""
+    store = DeploymentStateStore(tmp_path / "state")
+    destination = tmp_path / "runtime.env"
+    real_lstat = Path.lstat
+    destination_lstats = 0
+
+    with store.transaction() as transaction:
+        pending = _begin_promotion(
+            transaction,
+            _promotion_environment(tmp_path),
+            persistent_volumes=(),
+        )
+        state = pending.intent.target
+        transaction.install_environment(state, destination)
+
+        def change_before_final_lstat(selected: Path) -> os.stat_result:
+            nonlocal destination_lstats
+            if selected == destination:
+                destination_lstats += 1
+                if destination_lstats == 4:
+                    destination.write_bytes(b"CHANGED=after-read\n")
+                    destination.chmod(0o600)
+            return real_lstat(selected)
+
+        lstat_boundary = create_autospec(
+            Path.lstat,
+            spec_set=True,
+            side_effect=change_before_final_lstat,
+        )
+        with (
+            patch("pathlib.Path.lstat", new=lstat_boundary),
+            pytest.raises(DeploymentStateError, match="changed before removal"),
+        ):
+            transaction.remove_environment(state, destination)
+
+        assert destination.exists()
+        destination.write_bytes(TARGET_ENVIRONMENT_BYTES)
+        destination.chmod(0o600)
+        transaction.remove_environment(state, destination)
+        transaction.record_abort(
+            pending.transaction_id,
+            persistent_volumes=(),
+        )
+
+
+def test_remove_environment_fsync_failure_retries_as_absent(
+    tmp_path: Path,
+) -> None:
+    """Make a crash after unlink safe for an idempotent abort retry."""
+    store = DeploymentStateStore(tmp_path / "state")
+    destination = tmp_path / "runtime.env"
+    real_fsync = os.fsync
+    with store.transaction() as transaction:
+        pending = _begin_promotion(
+            transaction,
+            _promotion_environment(tmp_path),
+            persistent_volumes=(),
+        )
+        state = pending.intent.target
+        transaction.install_environment(state, destination)
+        parent_identity = (
+            destination.parent.stat().st_dev,
+            destination.parent.stat().st_ino,
+        )
+
+        def reject_parent_sync(descriptor: int) -> None:
+            metadata = os.fstat(descriptor)
+            if (metadata.st_dev, metadata.st_ino) == parent_identity:
+                raise OSError("synthetic removal directory fsync failure")
+            real_fsync(descriptor)
+
+        sync_boundary = create_autospec(
+            os.fsync,
+            spec_set=True,
+            side_effect=reject_parent_sync,
+        )
+        with (
+            patch("agent.deployment_state.os.fsync", new=sync_boundary),
+            pytest.raises(OSError, match="removal directory fsync"),
+        ):
+            transaction.remove_environment(state, destination)
+
+        assert not destination.exists()
+        transaction.remove_environment(state, destination)
+        transaction.record_abort(
+            pending.transaction_id,
+            persistent_volumes=(),
+        )
+
+
+@pytest.mark.parametrize("tamper", ["mismatch", "duplicate", "unknown-field"])
+def test_terminal_replay_rejects_tampered_volume_observation(
+    tmp_path: Path,
+    tamper: str,
+) -> None:
+    """Revalidate terminal volume evidence instead of trusting canonical JSON."""
+    store = DeploymentStateStore(tmp_path / tamper / "state")
+    _adopt(store, _environment(tmp_path))
+    with store.transaction() as transaction:
+        pending = _begin_promotion(transaction, _promotion_environment(tmp_path))
+        transaction.record_rollback(
+            pending.transaction_id,
+            persistent_volumes=PERSISTENT_VOLUMES,
+        )
+
+    terminal = _read_document(_journal_path(store, 2))
+    volumes = terminal["persistent_volumes"]
+    assert isinstance(volumes, list)
+    first = volumes[0]
+    assert isinstance(first, dict)
+    if tamper == "mismatch":
+        first["created_at"] = "2026-07-28T10:11:12Z"
+        message = "volume identity"
+    elif tamper == "duplicate":
+        volumes.append(dict(first))
+        message = "volume identities"
+    else:
+        first["unexpected"] = "value"
+        message = "volume identity schema"
+    _write_document(_journal_path(store, 2), terminal)
+
+    with pytest.raises(DeploymentStateError, match=message):
+        store.read_journal()
+
+
+@pytest.mark.parametrize(
+    ("tamper", "message"),
+    [
+        ("target-schema", "state schema"),
+        ("compose-project", "Compose identity changed"),
+        ("intent-timestamp", "timestamps"),
+        ("candidate-baseline", "receipt baseline"),
+    ],
+)
+def test_unresolved_intent_revalidates_nested_contracts(
+    tmp_path: Path,
+    tamper: str,
+    message: str,
+) -> None:
+    """Reject a hash-consistent pointer when nested intent evidence is altered."""
+    store = DeploymentStateStore(tmp_path / tamper / "state")
+    _adopt(store, _environment(tmp_path))
+    with store.transaction() as transaction:
+        pending = _begin_promotion(transaction, _promotion_environment(tmp_path))
+
+    intent_path = store.path / pending.intent_path
+    intent = _read_document(intent_path)
+    target = intent["target"]
+    candidate = intent["candidate"]
+    assert isinstance(target, dict)
+    assert isinstance(candidate, dict)
+    if tamper == "target-schema":
+        target["schema_version"] = 1
+    elif tamper == "compose-project":
+        target["compose_project"] = "other-production"
+    elif tamper == "intent-timestamp":
+        intent["recorded_at"] = "2026-07-28T12:35:57.123456Z"
+    else:
+        candidate["baseline_journal_sha256"] = "0" * 64
+    _write_document(intent_path, intent)
+    intent_sha256 = hashlib.sha256(intent_path.read_bytes()).hexdigest()
+    pointer = _read_document(store.pending_path)
+    pointer["intent_sha256"] = intent_sha256
+    _write_document(store.pending_path, pointer)
+
+    with pytest.raises(DeploymentStateError, match=message):
+        store.read_current()
+
+
+def test_promotion_snapshot_tampering_fails_before_pending_is_exposed(
+    tmp_path: Path,
+) -> None:
+    """Bind every recovery intent to its exact private environment bytes."""
+    store = DeploymentStateStore(tmp_path / "state")
+    _adopt(store, _environment(tmp_path))
+    with store.transaction() as transaction:
+        pending = _begin_promotion(transaction, _promotion_environment(tmp_path))
+    snapshot = store.path / pending.intent.target.environment_snapshot
+    snapshot.write_bytes(b'API_KEY="tampered"\n')
+    snapshot.chmod(0o600)
+
+    with pytest.raises(DeploymentStateError, match="snapshot hash"):
+        store.read_current()
+
+
+@pytest.mark.parametrize(
+    ("tamper", "message"),
+    [
+        ("schema", "pending promotion schema"),
+        ("path", "intent path"),
+        ("hash", "intent hash"),
+        ("missing-intent", "intent is missing"),
+    ],
+)
+def test_pending_pointer_tampering_fails_closed(
+    tmp_path: Path,
+    tamper: str,
+    message: str,
+) -> None:
+    """Require the fixed pointer to select one exact immutable intent."""
+    store = DeploymentStateStore(tmp_path / tamper / "state")
+    _adopt(store, _environment(tmp_path))
+    with store.transaction() as transaction:
+        pending = _begin_promotion(transaction, _promotion_environment(tmp_path))
+    pointer = _read_document(store.pending_path)
+    if tamper == "schema":
+        pointer["schema_version"] = 1
+        _write_document(store.pending_path, pointer)
+    elif tamper == "path":
+        pointer["intent_path"] = "transactions/other.json"
+        _write_document(store.pending_path, pointer)
+    elif tamper == "hash":
+        pointer["intent_sha256"] = "0" * 64
+        _write_document(store.pending_path, pointer)
+    else:
+        (store.path / pending.intent_path).unlink()
+
+    with pytest.raises(DeploymentStateError, match=message):
+        store.read_current()
+
+
+def test_v2_nested_parsers_reject_invalid_exact_schemas(
+    tmp_path: Path,
+) -> None:
+    """Exercise every closed v2 schema at its own validation boundary."""
+    store = DeploymentStateStore(tmp_path / "state")
+    with store.transaction() as transaction:
+        pending = _begin_promotion(
+            transaction,
+            _promotion_environment(tmp_path),
+            persistent_volumes=(),
+        )
+        base = pending.intent.as_document()
+
+        with pytest.raises(DeploymentStateError, match="created_at"):
+            state_module._validate_volume_created_at("not-rfc3339")
+        with pytest.raises(DeploymentStateError, match="identity"):
+            state_module._validated_optional_identity(
+                {
+                    "sequence": True,
+                    "sha256": "0" * 64,
+                },
+                "sequence",
+                "sha256",
+            )
+        with pytest.raises(DeploymentStateError, match="must be an object"):
+            state_module._candidate_from_document(None)
+        raw_candidate_schema = base["candidate"]
+        assert isinstance(raw_candidate_schema, dict)
+        candidate_schema = dict(raw_candidate_schema)
+        candidate_schema["unknown"] = True
+        with pytest.raises(DeploymentStateError, match="receipt schema"):
+            state_module._candidate_from_document(candidate_schema)
+        with pytest.raises(DeploymentStateError, match="volume identities"):
+            state_module._validated_volume_identities((object(),))  # type: ignore[arg-type]
+        with pytest.raises(DeploymentStateError, match="volume identities"):
+            state_module._validated_volume_identities(
+                (PERSISTENT_VOLUMES[0], PERSISTENT_VOLUMES[0])
+            )
+        with pytest.raises(DeploymentStateError, match="volume identities"):
+            state_module._volume_identities_from_document({})
+        with pytest.raises(DeploymentStateError, match="must be an object"):
+            state_module._intent_from_document(None)
+        intent_schema = json.loads(json.dumps(base))
+        intent_schema["unknown"] = True
+        with pytest.raises(DeploymentStateError, match="intent schema"):
+            state_module._intent_from_document(intent_schema)
+
+        wrong_target_id = json.loads(json.dumps(base))
+        target = wrong_target_id["target"]
+        assert isinstance(target, dict)
+        target["deployment_id"] = "promote-other123456789"
+        target["environment_snapshot"] = "environments/promote-other123456789.env"
+        with pytest.raises(DeploymentStateError, match="target identity"):
+            state_module._intent_from_document(wrong_target_id)
+
+        future_receipt = json.loads(json.dumps(base))
+        candidate = future_receipt["candidate"]
+        assert isinstance(candidate, dict)
+        candidate["observed_at"] = "2026-07-28T12:35:57.123456Z"
+        with pytest.raises(DeploymentStateError, match="timestamps"):
+            state_module._intent_from_document(future_receipt)
+
+        invalid_current_baseline = json.loads(json.dumps(base))
+        invalid_current_baseline["baseline_current_sequence"] = 2
+        invalid_current_baseline["baseline_current_sha256"] = "0" * 64
+        with pytest.raises(DeploymentStateError, match="current baseline"):
+            state_module._intent_from_document(invalid_current_baseline)
+
+        wrong_receipt_baseline = json.loads(json.dumps(base))
+        candidate = wrong_receipt_baseline["candidate"]
+        assert isinstance(candidate, dict)
+        candidate["baseline_journal_sequence"] = 1
+        candidate["baseline_journal_sha256"] = "0" * 64
+        with pytest.raises(DeploymentStateError, match="receipt baseline"):
+            state_module._intent_from_document(wrong_receipt_baseline)
+
+        wrong_receipt_target = json.loads(json.dumps(base))
+        candidate = wrong_receipt_target["candidate"]
+        assert isinstance(candidate, dict)
+        candidate["compose_project"] = "adk-template"
+        with pytest.raises(DeploymentStateError, match="receipt target"):
+            state_module._intent_from_document(wrong_receipt_target)
+
+        current_document = {
+            "schema_version": 2,
+            "journal_sequence": 1,
+            "journal_sha256": "0" * 64,
+            "state": pending.intent.target.as_document(),
+            "unknown": True,
+        }
+        with pytest.raises(DeploymentStateError, match="current deployment schema"):
+            state_module._current_from_document(current_document)
+        with pytest.raises(DeploymentStateError, match="must be an object"):
+            state_module._pending_from_document(None, intents={})
+
+        transaction.record_abort(
+            pending.transaction_id,
+            persistent_volumes=(),
+        )
+
+
+@pytest.mark.parametrize("unsafe_kind", ["mode", "unknown-path"])
+def test_transaction_directory_rejects_unsafe_contents(
+    tmp_path: Path,
+    unsafe_kind: str,
+) -> None:
+    """Fail closed on a mutable or ambiguous immutable-intent namespace."""
+    store = DeploymentStateStore(tmp_path / unsafe_kind / "state")
+    with store.transaction() as transaction:
+        _begin_promotion(
+            transaction,
+            _promotion_environment(tmp_path),
+            persistent_volumes=(),
+        )
+    if unsafe_kind == "mode":
+        store.transactions_path.chmod(0o755)
+        message = "unsafe permissions"
+    else:
+        _write_private(store.transactions_path / "unknown.txt", b"unknown")
+        message = "unknown path"
+
+    with pytest.raises(DeploymentStateError, match=message):
+        store.read_current()
+
+
+def test_intent_filename_must_match_embedded_transaction_identity(
+    tmp_path: Path,
+) -> None:
+    """Reject a valid intent copied under a different immutable identity."""
+    store = DeploymentStateStore(tmp_path / "state")
+    with store.transaction() as transaction:
+        pending = _begin_promotion(
+            transaction,
+            _promotion_environment(tmp_path),
+            persistent_volumes=(),
+        )
+    original = store.path / pending.intent_path
+    renamed = store.transactions_path / "promote-renamed123456.json"
+    original.rename(renamed)
+
+    with pytest.raises(DeploymentStateError, match="filename and identity"):
+        store.read_current()
+
+
+@pytest.mark.parametrize(
+    ("tamper", "message"),
+    [
+        ("intent-hash", "intent hash"),
+        ("journal-baseline", "journal baseline"),
+        ("current-baseline", "current baseline"),
+        ("compose", "Compose identity"),
+        ("outcome-state", "outcome state"),
+    ],
+)
+def test_terminal_replay_rejects_transition_tampering(
+    tmp_path: Path,
+    tamper: str,
+    message: str,
+) -> None:
+    """Recompute attacker-controlled hashes and still reject invalid transitions."""
+    store = DeploymentStateStore(tmp_path / tamper / "state")
+    _adopt(store, _environment(tmp_path))
+    with store.transaction() as transaction:
+        pending = _begin_promotion(transaction, _promotion_environment(tmp_path))
+        transaction.record_rollback(
+            pending.transaction_id,
+            persistent_volumes=PERSISTENT_VOLUMES,
+        )
+
+    intent_path = store.path / pending.intent_path
+    intent = _read_document(intent_path)
+    terminal = _read_document(_journal_path(store, 2))
+    if tamper == "intent-hash":
+        terminal["intent_sha256"] = "0" * 64
+    elif tamper == "journal-baseline":
+        intent["baseline_journal_sequence"] = 2
+        intent["baseline_journal_sha256"] = "0" * 64
+        candidate = intent["candidate"]
+        assert isinstance(candidate, dict)
+        candidate["baseline_journal_sequence"] = 2
+        candidate["baseline_journal_sha256"] = "0" * 64
+    elif tamper == "current-baseline":
+        intent["baseline_current_sha256"] = "0" * 64
+    elif tamper == "compose":
+        target = intent["target"]
+        assert isinstance(target, dict)
+        target["compose_project"] = "other-production"
+    else:
+        terminal["state"] = intent["target"]
+    if tamper not in {"intent-hash", "outcome-state"}:
+        _write_document(intent_path, intent)
+        terminal["intent_sha256"] = hashlib.sha256(intent_path.read_bytes()).hexdigest()
+    _write_document(_journal_path(store, 2), terminal)
+
+    with pytest.raises(DeploymentStateError, match=message):
+        store.read_journal()
+
+
+def test_terminal_replay_requires_referenced_intent(
+    tmp_path: Path,
+) -> None:
+    """Keep terminal history inseparable from its immutable recovery contract."""
+    store = DeploymentStateStore(tmp_path / "state")
+    _adopt(store, _environment(tmp_path))
+    with store.transaction() as transaction:
+        pending = _begin_promotion(transaction, _promotion_environment(tmp_path))
+        transaction.record_abort(
+            pending.transaction_id,
+            persistent_volumes=PERSISTENT_VOLUMES,
+        )
+    (store.path / pending.intent_path).unlink()
+
+    with pytest.raises(DeploymentStateError, match="intent is missing"):
+        store.read_journal()
+
+
+def test_duplicate_terminal_outcomes_are_rejected(
+    tmp_path: Path,
+) -> None:
+    """Allow exactly one terminal event for each immutable intent hash."""
+    store = DeploymentStateStore(tmp_path / "state")
+    baseline = _adopt(store, _environment(tmp_path))
+    with store.transaction() as transaction:
+        pending = _begin_promotion(transaction, _promotion_environment(tmp_path))
+        transaction.record_abort(
+            pending.transaction_id,
+            persistent_volumes=PERSISTENT_VOLUMES,
+        )
+    second_payload = _journal_path(store, 2).read_bytes()
+    duplicate = {
+        "schema_version": 2,
+        "sequence": 3,
+        "previous_sha256": hashlib.sha256(second_payload).hexdigest(),
+        "event": "rolled_back",
+        "transaction_id": pending.transaction_id,
+        "intent_sha256": pending.intent_sha256,
+        "state": baseline.state.as_document(),
+        "persistent_volumes": [volume.as_document() for volume in PERSISTENT_VOLUMES],
+    }
+    _write_document(_journal_path(store, 3), duplicate)
+
+    with pytest.raises(DeploymentStateError, match="duplicate outcomes"):
+        store.read_journal()
+
+
+def test_pending_baselines_must_match_replayed_state(
+    tmp_path: Path,
+) -> None:
+    """Reject unresolved work when either journal or current moved underneath it."""
+    journal_store = DeploymentStateStore(tmp_path / "journal" / "state")
+    _adopt(journal_store, _environment(tmp_path))
+    with journal_store.transaction() as transaction:
+        _begin_promotion(transaction, _promotion_environment(tmp_path))
+    _append_second_record(journal_store)
+    with pytest.raises(DeploymentStateError, match="journal baseline is stale"):
+        journal_store.read_current()
+
+    current_store = DeploymentStateStore(tmp_path / "current" / "state")
+    _adopt(current_store, _environment(tmp_path))
+    with current_store.transaction() as transaction:
+        pending = _begin_promotion(transaction, _promotion_environment(tmp_path))
+    intent_path = current_store.path / pending.intent_path
+    intent = _read_document(intent_path)
+    intent["baseline_current_sha256"] = "0" * 64
+    _write_document(intent_path, intent)
+    pointer = _read_document(current_store.pending_path)
+    pointer["intent_sha256"] = hashlib.sha256(intent_path.read_bytes()).hexdigest()
+    _write_document(current_store.pending_path, pointer)
+    with pytest.raises(DeploymentStateError, match="current baseline is stale"):
+        current_store.read_current()
+
+
+def test_current_pointer_cannot_select_nonestablishing_terminal(
+    tmp_path: Path,
+) -> None:
+    """Restrict current to adopted/promoted records even before final reconciliation."""
+    store = DeploymentStateStore(tmp_path / "state")
+    baseline = _adopt(store, _environment(tmp_path))
+    with store.transaction() as transaction:
+        first = _begin_promotion(transaction, _promotion_environment(tmp_path))
+        transaction.record_rollback(
+            first.transaction_id,
+            persistent_volumes=PERSISTENT_VOLUMES,
+        )
+    with store.transaction() as transaction:
+        second = _begin_promotion(
+            transaction,
+            _write_private(tmp_path / "other.env", b"OTHER=secret\n"),
+            transaction_id="promote-second123456789",
+        )
+        promoted = transaction.commit_promotion(
+            second.transaction_id,
+            persistent_volumes=PERSISTENT_VOLUMES,
+        )
+    rollback = store.read_journal()[1]
+    bad_current = CurrentDeployment(
+        journal_sequence=rollback.sequence,
+        journal_sha256=rollback.sha256,
+        state=baseline.state,
+    )
+    _write_document(store.current_path, bad_current.as_document())
+    assert promoted.journal_sequence == 3
+
+    with pytest.raises(DeploymentStateError, match="does not establish state"):
+        store.read_current()
+
+
+def test_environment_apis_reject_unrecorded_tampered_and_unsafe_targets(
+    tmp_path: Path,
+) -> None:
+    """Fail closed around recovery byte selection and destination ownership."""
+    store = DeploymentStateStore(tmp_path / "state")
+    baseline = _adopt(store, _environment(tmp_path))
+    with store.transaction() as transaction:
+        assert transaction.read_environment(baseline.state) == ENVIRONMENT_BYTES
+        unrecorded = state_module.DeploymentState(
+            deployment_id="unrecorded-123",
+            recorded_at=RECORDED_AT,
+            compose_project="adk-template",
+            compose_service="agent",
+            source_revision=REVISION,
+            image_reference=IMAGE_REFERENCE,
+            image_id=IMAGE_ID,
+            oci_revision=OCI_REVISION,
+            environment_snapshot="environments/unrecorded-123.env",
+            environment_sha256="0" * 64,
+            adopted=True,
+        )
+        with pytest.raises(DeploymentStateError, match="is not recorded"):
+            transaction.read_environment(unrecorded)
+        with pytest.raises(DeploymentStateError, match="absolute and normalized"):
+            transaction.install_environment(baseline.state, Path("relative.env"))
+        with pytest.raises(DeploymentStateError, match="parent is unavailable"):
+            transaction.install_environment(
+                baseline.state,
+                tmp_path / "missing-parent" / "runtime.env",
+            )
+        unsafe_parent = tmp_path / "unsafe-parent"
+        unsafe_parent.mkdir(mode=0o700)
+        unsafe_parent.chmod(0o777)
+        with pytest.raises(DeploymentStateError, match="parent is unsafe"):
+            transaction.install_environment(
+                baseline.state,
+                unsafe_parent / "runtime.env",
+            )
+        destination = _write_private(tmp_path / "existing.env", b"old")
+        transaction.install_environment(baseline.state, destination)
+        assert destination.read_bytes() == ENVIRONMENT_BYTES
+
+        snapshot = store.path / baseline.state.environment_snapshot
+        snapshot.write_bytes(b"TAMPERED=secret\n")
+        snapshot.chmod(0o600)
+        with pytest.raises(DeploymentStateError, match="snapshot hash"):
+            transaction.read_environment(baseline.state)
+
+
+def test_install_environment_verifies_post_replace_bytes(
+    tmp_path: Path,
+) -> None:
+    """Detect corruption between atomic replacement and independent verification."""
+    store = DeploymentStateStore(tmp_path / "state")
+    baseline = _adopt(store, _environment(tmp_path))
+    destination = tmp_path / "runtime.env"
+    real_replace = Path.replace
+
+    def corrupt_after_replace(source: Path, target: Path) -> Path:
+        replaced = real_replace(source, target)
+        if target == destination:
+            target.write_bytes(b"CORRUPTED=secret\n")
+            target.chmod(0o600)
+        return replaced
+
+    replace_boundary = create_autospec(
+        Path.replace,
+        spec_set=True,
+        side_effect=corrupt_after_replace,
+    )
+    with (
+        store.transaction() as transaction,
+        patch("pathlib.Path.replace", new=replace_boundary),
+        pytest.raises(DeploymentStateError, match="does not match"),
+    ):
+        transaction.install_environment(baseline.state, destination)
+
+
+@pytest.mark.parametrize(
+    ("candidate_overrides", "begin_overrides", "message"),
+    [
+        (
+            {"baseline_journal_sha256": "0" * 64},
+            {},
+            "receipt baseline",
+        ),
+        (
+            {"compose_service": "other"},
+            {},
+            "receipt target",
+        ),
+        (
+            {},
+            {"compose_project": "other-production"},
+            "Compose identity",
+        ),
+    ],
+)
+def test_begin_rejects_runtime_identity_mismatches(
+    tmp_path: Path,
+    candidate_overrides: dict[str, object],
+    begin_overrides: dict[str, object],
+    message: str,
+) -> None:
+    """Validate baseline, candidate, and production identities before snapshotting."""
+    store = DeploymentStateStore(tmp_path / message.replace(" ", "-") / "state")
+    _adopt(store, _environment(tmp_path))
+    with store.transaction() as transaction:
+        arguments: dict[str, object] = {
+            "compose_project": "adk-template",
+            "compose_service": "agent",
+            "source_revision": TARGET_REVISION,
+            "image_reference": TARGET_IMAGE_REFERENCE,
+            "image_id": TARGET_IMAGE_ID,
+            "oci_revision": TARGET_REVISION,
+            "environment_source": _promotion_environment(tmp_path),
+            "candidate": _candidate(transaction, **candidate_overrides),
+            "persistent_volumes": PERSISTENT_VOLUMES,
+            "transaction_id": TRANSACTION_ID,
+            "recorded_at": PROMOTION_RECORDED_AT,
+        }
+        arguments.update(begin_overrides)
+        with pytest.raises(DeploymentStateError, match=message):
+            transaction.begin_promotion(**arguments)  # type: ignore[arg-type]
+
+    assert not list(store.environments_path.glob(f"{TRANSACTION_ID}.env"))
+
+
+def test_oversize_intent_is_rejected_before_any_publication(
+    tmp_path: Path,
+) -> None:
+    """Bound the durable document even with the maximum volume count."""
+    store = DeploymentStateStore(tmp_path / "state")
+    _adopt(store, _environment(tmp_path))
+    long_component = "x" * 3900
+    volumes = tuple(
+        PersistentVolumeIdentity(
+            name=f"volume-{index}",
+            driver="local",
+            mountpoint=f"/var/lib/{index}-{long_component}",
+            destination=f"/app/{index}-{long_component}",
+            created_at="2026-07-28T10:11:12Z",
+        )
+        for index in range(20)
+    )
+
+    with (
+        store.transaction() as transaction,
+        pytest.raises(DeploymentStateError, match="size limit"),
+    ):
+        _begin_promotion(
+            transaction,
+            _promotion_environment(tmp_path),
+            persistent_volumes=volumes,
+        )
+
+    assert not store.transactions_path.exists()
+    assert not (store.environments_path / f"{TRANSACTION_ID}.env").exists()
+    assert not store.pending_path.exists()
+
+
+def test_orphan_intent_identity_cannot_be_reused(
+    tmp_path: Path,
+) -> None:
+    """Retain pre-mutation residue while forbidding transaction-ID reuse."""
+    store = DeploymentStateStore(tmp_path / "state")
+    _adopt(store, _environment(tmp_path))
+    real_link = os.link
+
+    def reject_pending_link(
+        source_path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        destination_path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        *,
+        src_dir_fd: int | None = None,
+        dst_dir_fd: int | None = None,
+        follow_symlinks: bool = True,
+    ) -> None:
+        if Path(os.fsdecode(destination_path)) == store.pending_path:
+            raise OSError("synthetic pending link failure")
+        real_link(
+            source_path,
+            destination_path,
+            src_dir_fd=src_dir_fd,
+            dst_dir_fd=dst_dir_fd,
+            follow_symlinks=follow_symlinks,
+        )
+
+    with (
+        store.transaction() as transaction,
+        patch(
+            "agent.deployment_state.os.link",
+            new=create_autospec(
+                os.link,
+                spec_set=True,
+                side_effect=reject_pending_link,
+            ),
+        ),
+        pytest.raises(OSError, match="pending link"),
+    ):
+        _begin_promotion(transaction, _promotion_environment(tmp_path))
+
+    with (
+        store.transaction() as transaction,
+        pytest.raises(DeploymentStateError, match="already exists"),
+    ):
+        _begin_promotion(transaction, _promotion_environment(tmp_path))
+
+
+def test_terminal_methods_reject_invalid_or_missing_pending_identity(
+    tmp_path: Path,
+) -> None:
+    """Require one exact loaded pending identity for every outcome."""
+    empty_store = DeploymentStateStore(tmp_path / "empty" / "state")
+    with (
+        empty_store.transaction() as transaction,
+        pytest.raises(DeploymentStateError, match="no promotion"),
+    ):
+        transaction.record_abort(
+            TRANSACTION_ID,
+            persistent_volumes=(),
+        )
+
+    store = DeploymentStateStore(tmp_path / "pending" / "state")
+    with store.transaction() as transaction:
+        pending = _begin_promotion(
+            transaction,
+            _promotion_environment(tmp_path),
+            persistent_volumes=(),
+        )
+        with pytest.raises(DeploymentStateError, match="identity is invalid"):
+            transaction.record_abort(
+                "../invalid",
+                persistent_volumes=(),
+            )
+        with pytest.raises(DeploymentStateError, match="does not match"):
+            transaction.record_abort(
+                "promote-other123456789",
+                persistent_volumes=(),
+            )
+        with pytest.raises(DeploymentStateError, match="journal event"):
+            transaction._publish_terminal(
+                event="unknown",
+                transaction_id=pending.transaction_id,
+                persistent_volumes=(),
+            )
+        transaction.record_abort(
+            pending.transaction_id,
+            persistent_volumes=(),
+        )
+
+
+def test_indeterminate_terminal_when_visibility_check_itself_fails(
+    tmp_path: Path,
+) -> None:
+    """Forbid compensation when the final pathname cannot be inspected."""
+    store = DeploymentStateStore(tmp_path / "state")
+    _adopt(store, _environment(tmp_path))
+    real_link = os.link
+    real_lstat = Path.lstat
+    with store.transaction() as transaction:
+        pending = _begin_promotion(transaction, _promotion_environment(tmp_path))
+        terminal_path = _journal_path(store, 2)
+
+        def reject_terminal_link(
+            source_path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+            destination_path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+            *,
+            src_dir_fd: int | None = None,
+            dst_dir_fd: int | None = None,
+            follow_symlinks: bool = True,
+        ) -> None:
+            if Path(os.fsdecode(destination_path)) == terminal_path:
+                raise OSError("synthetic terminal link uncertainty")
+            real_link(
+                source_path,
+                destination_path,
+                src_dir_fd=src_dir_fd,
+                dst_dir_fd=dst_dir_fd,
+                follow_symlinks=follow_symlinks,
+            )
+
+        def reject_terminal_lstat(selected: Path) -> os.stat_result:
+            if selected == terminal_path:
+                raise PermissionError("synthetic terminal visibility uncertainty")
+            return real_lstat(selected)
+
+        with (
+            patch(
+                "agent.deployment_state.os.link",
+                new=create_autospec(
+                    os.link,
+                    spec_set=True,
+                    side_effect=reject_terminal_link,
+                ),
+            ),
+            patch(
+                "pathlib.Path.lstat",
+                new=create_autospec(
+                    Path.lstat,
+                    spec_set=True,
+                    side_effect=reject_terminal_lstat,
+                ),
+            ),
+            pytest.raises(DeploymentTerminalIndeterminateError),
+        ):
+            transaction.commit_promotion(
+                pending.transaction_id,
+                persistent_volumes=PERSISTENT_VOLUMES,
+            )
+
+
+def test_internal_readers_preserve_unsafe_path_errors(
+    tmp_path: Path,
+) -> None:
+    """Do not reinterpret present-but-unsafe intent or pending paths as absent."""
+    store = DeploymentStateStore(tmp_path / "state")
+    with store.transaction() as transaction:
+        pending = _begin_promotion(
+            transaction,
+            _promotion_environment(tmp_path),
+            persistent_volumes=(),
+        )
+        store.transactions_path.chmod(0o755)
+        with pytest.raises(DeploymentStateError, match="unsafe permissions"):
+            transaction._intent_files()
+        store.transactions_path.chmod(0o700)
+
+        store.pending_path.chmod(0o644)
+        with pytest.raises(DeploymentStateError, match="unsafe permissions"):
+            transaction._read_pending_file()
+        store.pending_path.chmod(0o600)
+
+        terminal = state_module.JournalEntry(
+            sequence=1,
+            sha256="0" * 64,
+            previous_sha256=None,
+            event="aborted",
+            state=None,
+            transaction_id=pending.transaction_id,
+            intent_sha256=pending.intent_sha256,
+            persistent_volumes=(),
+        )
+        original_journal = transaction._journal
+        transaction._journal = (terminal, terminal)
+        with pytest.raises(DeploymentStateError, match="duplicate terminal"):
+            transaction._terminal_for_pending(pending)
+        transaction._journal = original_journal
+        transaction.record_abort(
+            pending.transaction_id,
+            persistent_volumes=(),
+        )
+
+
+def test_unclean_pending_terminal_must_remain_journal_tail(
+    tmp_path: Path,
+) -> None:
+    """Reject later history after a terminal whose pending cleanup never completed."""
+    store = DeploymentStateStore(tmp_path / "state")
+    baseline = _adopt(store, _environment(tmp_path))
+    real_unlink = Path.unlink
+
+    def reject_pending_unlink(selected: Path, missing_ok: bool = False) -> None:
+        if selected == store.pending_path:
+            raise OSError("synthetic stale pending cleanup failure")
+        real_unlink(selected, missing_ok=missing_ok)
+
+    with store.transaction() as transaction:
+        pending = _begin_promotion(transaction, _promotion_environment(tmp_path))
+        with (
+            patch(
+                "pathlib.Path.unlink",
+                new=create_autospec(
+                    Path.unlink,
+                    spec_set=True,
+                    side_effect=reject_pending_unlink,
+                ),
+            ),
+            pytest.raises(DeploymentTerminalCommittedError),
+        ):
+            transaction.record_rollback(
+                pending.transaction_id,
+                persistent_volumes=PERSISTENT_VOLUMES,
+            )
+
+    terminal_payload = _journal_path(store, 2).read_bytes()
+    later = {
+        "schema_version": 1,
+        "sequence": 3,
+        "previous_sha256": hashlib.sha256(terminal_payload).hexdigest(),
+        "event": "adopted",
+        "state": baseline.state.as_document(),
+    }
+    _write_document(_journal_path(store, 3), later)
+
+    with pytest.raises(DeploymentStateError, match="not the journal tail"):
+        store.read_current()
+
+
+def test_terminal_hard_link_recovery_fsync_failure_is_indeterminate(
+    tmp_path: Path,
+) -> None:
+    """Preserve terminal uncertainty while cleaning a link-visible crash residue."""
+    store = DeploymentStateStore(tmp_path / "state")
+    with store.transaction() as transaction:
+        pending = _begin_promotion(
+            transaction,
+            _promotion_environment(tmp_path),
+            persistent_volumes=(),
+        )
+        transaction.commit_promotion(
+            pending.transaction_id,
+            persistent_volumes=PERSISTENT_VOLUMES,
+        )
+    terminal_path = _journal_path(store)
+    temporary = store.journal_path / ".deployment-journal-terminal-crash.tmp"
+    os.link(terminal_path, temporary)
+    journal_identity = (
+        store.journal_path.stat().st_dev,
+        store.journal_path.stat().st_ino,
+    )
+    real_fsync = os.fsync
+
+    def reject_journal_recovery_sync(descriptor: int) -> None:
+        metadata = os.fstat(descriptor)
+        if (metadata.st_dev, metadata.st_ino) == journal_identity:
+            raise OSError("synthetic terminal recovery directory fsync failure")
+        real_fsync(descriptor)
+
+    sync_boundary = create_autospec(
+        os.fsync,
+        spec_set=True,
+        side_effect=reject_journal_recovery_sync,
+    )
+    with (
+        patch("agent.deployment_state.os.fsync", new=sync_boundary),
+        pytest.raises(DeploymentTerminalIndeterminateError) as captured,
+        store.transaction(),
+    ):
+        pytest.fail("terminal recovery unexpectedly completed")
+
+    assert captured.value.event == "promoted"
+    assert captured.value.transaction_id == TRANSACTION_ID
+    assert not temporary.exists()
+    assert store.read_current() is not None

--- a/tests/test_deployment_state_cli.py
+++ b/tests/test_deployment_state_cli.py
@@ -17,7 +17,7 @@ from unittest.mock import create_autospec, patch
 
 import pytest
 
-from agent.deployment_state import DeploymentStateStore
+from agent.deployment_state import CandidateReceipt, DeploymentStateStore
 from agent.deployment_state_cli import main
 
 ORIGIN = "https://github.com/QueryPlanner/google-adk-on-bare-metal"
@@ -90,12 +90,22 @@ class CliExternalBoundary:
             ]:
                 return _completed(command, stdout=f"{ORIGIN}\n")
             if arguments in (
-                ["-C", str(self.checkout), "diff", "--quiet", "--"],
+                [
+                    "-C",
+                    str(self.checkout),
+                    "diff",
+                    "--no-ext-diff",
+                    "--no-textconv",
+                    "--quiet",
+                    "--",
+                ],
                 [
                     "-C",
                     str(self.checkout),
                     "diff",
                     "--cached",
+                    "--no-ext-diff",
+                    "--no-textconv",
                     "--quiet",
                     "--",
                 ],
@@ -263,6 +273,7 @@ def test_inspect_empty_state_is_secret_free_json(
         "status": "empty",
         "current": None,
         "journal": [],
+        "pending": None,
     }
     assert captured.err == ""
     assert stat_mode(state_dir) == 0o700
@@ -299,6 +310,7 @@ def test_adopt_then_inspect_exact_state(
     inspected = json.loads(inspected_output.out)
     assert inspected["status"] == "recorded"
     assert inspected["current"] == adopted["current"]
+    assert inspected["pending"] is None
     assert len(inspected["journal"]) == 1
     assert inspected["journal"][0]["sha256"] == adopted["current"]["journal_sha256"]
     assert "secret-cli-canary" not in inspected_output.out
@@ -376,6 +388,73 @@ def test_existing_state_fails_before_reobservation(
     captured = capsys.readouterr()
     assert "already been initialized" in captured.err
     assert captured.out == ""
+    forbidden_which.assert_not_called()
+
+
+def test_inspect_pending_state_and_reject_adoption_before_observation(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Expose recovery status without secrets or reinterpreting pending state."""
+    checkout, _ = _checkout(tmp_path)
+    state_dir = tmp_path / "state"
+    target_environment = tmp_path / "target.env"
+    target_environment.write_bytes(b'PRIVATE_KEY="pending-secret-canary"\n')
+    target_environment.chmod(0o600)
+    receipt = CandidateReceipt(
+        observed_at="2026-07-28T10:00:00.000000Z",
+        compose_project="adk-template-candidate",
+        compose_service="agent",
+        container_id=CONTAINER_ID,
+        image_reference=IMAGE_REFERENCE,
+        image_id=IMAGE_ID,
+        oci_revision=OCI_REVISION,
+        baseline_journal_sequence=None,
+        baseline_journal_sha256=None,
+    )
+    store = DeploymentStateStore(state_dir)
+    with store.transaction() as transaction:
+        pending = transaction.begin_promotion(
+            compose_project="adk-template",
+            compose_service="agent",
+            source_revision=OCI_REVISION,
+            image_reference=IMAGE_REFERENCE,
+            image_id=IMAGE_ID,
+            oci_revision=OCI_REVISION,
+            environment_source=target_environment,
+            candidate=receipt,
+            persistent_volumes=(),
+            transaction_id="pending-cli-1234567890",
+            recorded_at="2026-07-28T10:00:01.000000Z",
+        )
+
+    assert main(["inspect", "--state-dir", str(state_dir)]) == 0
+
+    captured = capsys.readouterr()
+    inspected = json.loads(captured.out)
+    assert inspected == {
+        "status": "pending",
+        "current": None,
+        "journal": [],
+        "pending": pending.as_document(),
+    }
+    assert "pending-secret-canary" not in captured.out
+    assert captured.err == ""
+
+    forbidden_which = create_autospec(
+        shutil.which,
+        spec_set=True,
+        side_effect=AssertionError("external observation should not run"),
+    )
+    with patch(
+        "agent.deployment_state_cli.shutil.which",
+        new=forbidden_which,
+    ):
+        assert main(_adopt_arguments(state_dir, checkout)) == 1
+
+    rejected = capsys.readouterr()
+    assert "already been initialized" in rejected.err
+    assert rejected.out == ""
     forbidden_which.assert_not_called()
 
 
@@ -489,7 +568,7 @@ def test_module_entrypoint_exits_with_main_status(
 
 
 def test_project_registers_operator_cli() -> None:
-    """Expose the reviewed module through the installed project command."""
+    """Expose both reviewed deployment modules through installed commands."""
     pyproject = tomllib.loads(
         (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text(
             encoding="utf-8"
@@ -498,4 +577,7 @@ def test_project_registers_operator_cli() -> None:
 
     assert pyproject["project"]["scripts"]["deployment-state"] == (
         "agent.deployment_state_cli:main"
+    )
+    assert pyproject["project"]["scripts"]["deployment-promote"] == (
+        "agent.deployment_promotion:main"
     )

--- a/tests/test_deployment_workflow.py
+++ b/tests/test_deployment_workflow.py
@@ -1,845 +1,642 @@
-"""Deployment workflow safety contract tests."""
+"""High-trust OpenSSH deployment workflow and script contract tests."""
 
-import os
+from __future__ import annotations
+
+import re
 import shlex
 import shutil
+import stat
 import subprocess
+import sys
+from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import NamedTuple
+from typing import cast
 
 import pytest
 import yaml  # type: ignore[import-untyped]
 
-WORKFLOW_PATH = (
-    Path(__file__).resolve().parents[1] / ".github" / "workflows" / "docker-publish.yml"
-)
-EXPECTED_DEPLOY_GUARD = (
-    "github.event_name == 'workflow_dispatch' && "
-    "github.ref == 'refs/heads/main' && "
-    "inputs.deploy"
-)
-EXPECTED_DEPLOY_CLAUSES = {
-    "github.event_name == 'workflow_dispatch'",
-    "github.ref == 'refs/heads/main'",
-    "inputs.deploy",
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "docker-publish.yml"
+BOOTSTRAP_PATH = ROOT / "scripts" / "deployment_bootstrap.sh"
+CLEANUP_PATH = ROOT / "scripts" / "deployment_cleanup.sh"
+REVISION = "a" * 40
+DIGEST = f"sha256:{'b' * 64}"
+REPOSITORY = "MixedOwner/Mixed-Repository"
+PROJECT_NAME = "Mixed-Repository"
+RUN_ID = "12345"
+RUN_ATTEMPT = "2"
+ORIGIN = f"https://github.com/{REPOSITORY}"
+PRODUCTION_NAMES = {
+    "AGENT_NAME",
+    "DATABASE_URL",
+    "OPENROUTER_API_KEY",
+    "GOOGLE_API_KEY",
+    "ROOT_AGENT_MODEL",
+    "LANGFUSE_PUBLIC_KEY",
+    "LANGFUSE_SECRET_KEY",
+    "LANGFUSE_BASE_URL",
+    "LOG_LEVEL",
+    "PORT",
+    "HOST",
 }
-VALID_SHA = "a" * 40
-VALID_DIGEST = f"sha256:{'b' * 64}"
-EXPECTED_IMAGE = f"ghcr.io/mixedowner/mixed-repository@{VALID_DIGEST}"
-EXPECTED_ORIGIN = "https://github.com/MixedOwner/Mixed-Repository"
-EXPECTED_PROJECT = "adk-mixed-repository"
-SECRET_CANARIES = {
-    "DATABASE_URL": "postgresql://user:p$UNSET@database/agent",
-    "OPENROUTER_API_KEY": "$(printf command-substitution)",
-    "GOOGLE_API_KEY": "`printf backtick-substitution`",
-    "ROOT_AGENT_MODEL": "openrouter/provider/model",
-    "LANGFUSE_PUBLIC_KEY": "public-key",
-    "LANGFUSE_SECRET_KEY": "secret-key",
-    "LANGFUSE_HOST": "https://observability.example",
+EXPECTED_PINS = {
+    "actions/checkout": "11d5960a326750d5838078e36cf38b85af677262",
+    "docker/setup-qemu-action": "c7c53464625b32c7a7e944ae62b3e17d2b600130",
+    "docker/setup-buildx-action": "8d2750c68a42422c14e847fe6c8ac0403b4cbd6f",
+    "docker/login-action": "c94ce9fb468520275223c153574b00df6fe4bcc9",
+    "docker/metadata-action": "c299e40c65443455700f0fdfc63efafe5b349051",
+    "docker/build-push-action": "ca052bb54ab0790a636c9b5f226502c73d547a25",
 }
 
 
-class DeployHarness(NamedTuple):
-    """Synthetic remote host boundaries for the tracked deployment script."""
-
-    environment: dict[str, str]
-    docker_log: Path
-    event_log: Path
-    git_log: Path
-    git_state: Path
-    home: Path
+def _workflow() -> dict[str, object]:
+    document = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    assert isinstance(document, dict)
+    return document
 
 
-def _indented_block(document: str, heading: str, indentation: int) -> str:
-    """Return the lines nested beneath an exact YAML heading."""
-    lines = document.splitlines()
-    start = lines.index(f"{' ' * indentation}{heading}") + 1
-    block: list[str] = []
-
-    for line in lines[start:]:
-        if line and not line.startswith(" " * (indentation + 1)):
-            break
-        block.append(line)
-
-    return "\n".join(block)
+def _job(name: str) -> dict[str, object]:
+    jobs = _workflow()["jobs"]
+    assert isinstance(jobs, dict)
+    job = jobs[name]
+    assert isinstance(job, dict)
+    return job
 
 
-def _deploy_guard(document: str) -> str:
-    """Extract and normalize the deploy job condition."""
-    deploy_block = _indented_block(document, "deploy:", 2)
-    lines = deploy_block.splitlines()
-    condition_start = lines.index("    if: >-") + 1
-    condition_lines: list[str] = []
-
-    for line in lines[condition_start:]:
-        if not line.startswith("      "):
-            break
-        condition_lines.append(line.strip())
-
-    return " ".join(condition_lines)
+def _steps(job: str) -> list[dict[str, object]]:
+    steps = _job(job)["steps"]
+    assert isinstance(steps, list)
+    return cast(list[dict[str, object]], steps)
 
 
-def _deploy_script(document: str) -> str:
-    """Extract the remote shell program from the deployment action."""
-    deploy_block = _indented_block(document, "deploy:", 2)
-    lines = deploy_block.splitlines()
-    script_start = lines.index("          script: |") + 1
-    script_lines: list[str] = []
-
-    for line in lines[script_start:]:
-        if line and not line.startswith("            "):
-            break
-        script_lines.append(line[12:] if line else "")
-
-    return "\n".join(script_lines)
+def _step(job: str, name: str) -> dict[str, object]:
+    matches = [step for step in _steps(job) if step.get("name") == name]
+    assert len(matches) == 1
+    return matches[0]
 
 
-def _materialize_deploy_script(script: str) -> str:
-    """Replace non-provenance GitHub expressions with deterministic values."""
-    replacements = {
-        "${{ github.event.repository.name }}": "Mixed-Repository",
-        "${{ github.repository }}": "MixedOwner/Mixed-Repository",
-    }
-    replacements.update(
-        {
-            "${{ secrets." + secret_name + " }}": secret_value
-            for secret_name, secret_value in SECRET_CANARIES.items()
-        }
+def _run_text(step: dict[str, object]) -> str:
+    value = step["run"]
+    assert isinstance(value, str)
+    return value
+
+
+def _run(
+    command: list[str],
+    *,
+    cwd: Path,
+    environment: dict[str, str] | None = None,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603 - fixed test boundaries in tmp_path
+        command,
+        cwd=cwd,
+        env=environment,
+        input=input_text,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
     )
 
-    for expression, value in replacements.items():
-        script = script.replace(expression, value)
 
-    assert "${{" not in script
-    return script
+def _git(
+    git: str,
+    cwd: Path,
+    *arguments: str,
+    input_text: str | None = None,
+) -> str:
+    result = _run(
+        [git, *arguments],
+        cwd=cwd,
+        input_text=input_text,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
 
 
-def _write_executable(path: Path, content: str) -> None:
-    """Write one executable fake boundary."""
-    path.write_text(content, encoding="utf-8")
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
     path.chmod(0o755)
 
 
-@pytest.fixture
-def deploy_harness(tmp_path: Path) -> DeployHarness:
-    """Provide strict fake Git and Docker boundaries on an isolated host."""
-    bin_directory = tmp_path / "bin"
-    home = tmp_path / "home"
-    docker_log = tmp_path / "docker.log"
-    event_log = tmp_path / "events.log"
-    git_log = tmp_path / "git.log"
-    git_state = tmp_path / "git.state"
-    bin_directory.mkdir()
-    home.mkdir()
-    docker_log.touch()
-    event_log.touch()
-    git_log.touch()
-
-    _write_executable(
-        bin_directory / "git",
-        """#!/bin/sh
-set -eu
-
-printf '%s\\n' "$*" >> "$FAKE_GIT_LOG"
-printf 'git|%s\\n' "$*" >> "$FAKE_EVENT_LOG"
-
-case "$1" in
-  clone)
-    exit_code=${FAKE_GIT_CLONE_EXIT:-0}
-    [ "$exit_code" -eq 0 ] || exit "$exit_code"
-    mkdir -p "$3/.git"
-    ;;
-  remote)
-    [ "${2:-}" = "get-url" ] && [ "${3:-}" = "origin" ] || exit 99
-    exit_code=${FAKE_GIT_REMOTE_EXIT:-0}
-    [ "$exit_code" -eq 0 ] || exit "$exit_code"
-    printf '%s\\n' "${FAKE_GIT_ORIGIN}"
-    ;;
-  diff)
-    if [ "${2:-}" = "--cached" ]; then
-      if [ -f "$FAKE_GIT_STATE" ]; then
-        exit "${FAKE_GIT_STAGED_AFTER_EXIT:-0}"
-      fi
-      exit "${FAKE_GIT_STAGED_BEFORE_EXIT:-0}"
-    fi
-    if [ -f "$FAKE_GIT_STATE" ]; then
-      exit "${FAKE_GIT_UNSTAGED_AFTER_EXIT:-0}"
-    fi
-    exit "${FAKE_GIT_UNSTAGED_BEFORE_EXIT:-0}"
-    ;;
-  fetch)
-    exit "${FAKE_GIT_FETCH_EXIT:-0}"
-    ;;
-  checkout)
-    exit_code=${FAKE_GIT_CHECKOUT_EXIT:-0}
-    [ "$exit_code" -eq 0 ] || exit "$exit_code"
-    : > "$FAKE_GIT_STATE"
-    ;;
-  rev-parse)
-    exit_code=${FAKE_GIT_REV_PARSE_EXIT:-0}
-    [ "$exit_code" -eq 0 ] || exit "$exit_code"
-    printf '%s\\n' "${FAKE_GIT_HEAD:-$DEPLOY_SHA}"
-    ;;
-  ls-files)
-    exit "${FAKE_GIT_LS_FILES_EXIT:-0}"
-    ;;
-  *)
-    exit 99
-    ;;
-esac
-""",
-    )
-
-    _write_executable(
-        bin_directory / "docker",
-        """#!/bin/sh
-set -eu
-
-printf 'IMAGE=%s|%s\\n' "${IMAGE:-}" "$*" >> "$FAKE_DOCKER_LOG"
-printf 'docker|IMAGE=%s|%s\\n' "${IMAGE:-}" "$*" >> "$FAKE_EVENT_LOG"
-
-if [ "$1" = "compose" ]; then
-  operation=${8:-}
-  case "$operation" in
-    config)
-      exit_code=${FAKE_DOCKER_CONFIG_EXIT:-0}
-      [ "$exit_code" -eq 0 ] || exit "$exit_code"
-      printf '%s\\n' "${FAKE_DOCKER_CONFIG_IMAGE:-$IMAGE}"
-      ;;
-    pull)
-      exit "${FAKE_DOCKER_PULL_EXIT:-0}"
-      ;;
-    up)
-      exit "${FAKE_DOCKER_UP_EXIT:-0}"
-      ;;
-    ps)
-      exit_code=${FAKE_DOCKER_PS_EXIT:-0}
-      [ "$exit_code" -eq 0 ] || exit "$exit_code"
-      printf '%s' "${FAKE_DOCKER_CONTAINER_ID-agent-container}"
-      ;;
-    *)
-      exit 98
-      ;;
-  esac
-  exit 0
-fi
-
-if [ "$1" = "inspect" ]; then
-  case "$5" in
-    *Config.Image*)
-      exit_code=${FAKE_DOCKER_CONFIG_INSPECT_EXIT:-0}
-      [ "$exit_code" -eq 0 ] || exit "$exit_code"
-      printf '%s\\n' "${FAKE_DOCKER_RUNNING_IMAGE:-$IMAGE}"
-      ;;
-    *.Image*)
-      exit_code=${FAKE_DOCKER_IMAGE_ID_EXIT:-0}
-      [ "$exit_code" -eq 0 ] || exit "$exit_code"
-      printf '%s\\n' "${FAKE_DOCKER_IMAGE_ID-sha256:platform-image}"
-      ;;
-    *)
-      exit 97
-      ;;
-  esac
-  exit 0
-fi
-
-if [ "$1" = "image" ] && [ "$2" = "inspect" ]; then
-  exit_code=${FAKE_DOCKER_REVISION_EXIT:-0}
-  [ "$exit_code" -eq 0 ] || exit "$exit_code"
-  printf '%s\\n' "${FAKE_DOCKER_REVISION:-$DEPLOY_SHA}"
-  exit 0
-fi
-
-if [ "$1" = "image" ] && [ "$2" = "prune" ]; then
-  exit "${FAKE_DOCKER_PRUNE_EXIT:-0}"
-fi
-
-exit 96
-""",
-    )
-
-    environment = {
-        "FAKE_DOCKER_LOG": str(docker_log),
-        "FAKE_EVENT_LOG": str(event_log),
-        "FAKE_GIT_LOG": str(git_log),
-        "FAKE_GIT_ORIGIN": EXPECTED_ORIGIN,
-        "FAKE_GIT_STATE": str(git_state),
-        "HOME": str(home),
-        "LANG": "C",
-        "PATH": f"{bin_directory}:/usr/bin:/bin",
-    }
-    return DeployHarness(
-        environment,
-        docker_log,
-        event_log,
-        git_log,
-        git_state,
-        home,
-    )
+@dataclass(frozen=True, slots=True)
+class GitHarness:
+    home: Path
+    project: Path
+    release: Path
+    lease: Path
+    environment: dict[str, str]
+    revision: str
+    git_log: Path
+    hook_canary: Path
+    fsmonitor_canary: Path
+    diff_canary: Path
+    site_canary: Path
+    git: str
 
 
-def _run_deploy_script(
-    script: str,
-    harness: DeployHarness,
-    **environment_overrides: str,
-) -> subprocess.CompletedProcess[str]:
-    """Execute the materialized remote program against synthetic boundaries."""
-    environment = (
-        harness.environment
-        | {
-            "DEPLOY_SHA": VALID_SHA,
-            "IMAGE_DIGEST": VALID_DIGEST,
-        }
-        | environment_overrides
-    )
-    return subprocess.run(  # noqa: S603 - execute the tracked trusted script
-        ["/bin/sh"],
-        input=_materialize_deploy_script(script),
-        cwd=WORKFLOW_PATH.parents[2],
-        env=environment,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-
-
-def _evaluate_guard(
-    expression: str,
+def _git_harness(
+    tmp_path: Path,
     *,
-    event_name: str,
-    git_ref: str,
-    deploy: bool | None,
-) -> bool:
-    """Evaluate the supported clauses extracted from the workflow guard."""
-    clauses = tuple(clause.strip() for clause in expression.split("&&"))
-    outcomes = {
-        "github.event_name == 'workflow_dispatch'": (event_name == "workflow_dispatch"),
-        "github.ref == 'refs/heads/main'": git_ref == "refs/heads/main",
-        "inputs.deploy": deploy is True,
+    worktree_failure: str = "none",
+) -> GitHarness:
+    git = shutil.which("git")
+    assert git is not None
+    home = tmp_path / "home"
+    project = home / PROJECT_NAME
+    binary = tmp_path / "bin"
+    home.mkdir()
+    project.mkdir()
+    binary.mkdir()
+
+    _git(git, project, "init", "-q")
+    _git(git, project, "config", "user.name", "Deployment Test")
+    _git(git, project, "config", "user.email", "deployment@example.test")
+    tracked = {
+        ".gitignore": ".env\n__pycache__/\n*.pyc\n",
+        ".gitattributes": "compose.yaml diff=canary\n",
+        "compose.yaml": "services: {}\n",
+        "compose.candidate.yaml": "services: {}\n",
+        "src/agent/__init__.py": "",
+        "src/agent/compose_env.py": "VALUE = 'compose'\n",
+        "src/agent/deployment_adoption.py": "VALUE = 'adoption'\n",
+        "src/agent/deployment_promotion.py": "VALUE = 'promotion'\n",
+        "src/agent/deployment_state.py": "VALUE = 'state'\n",
     }
+    for relative, content in tracked.items():
+        path = project / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    _git(git, project, "add", ".")
+    _git(git, project, "commit", "-qm", "test release")
+    revision = _git(git, project, "rev-parse", "HEAD")
+    _git(git, project, "remote", "add", "origin", ORIGIN)
+    environment_path = project / ".env"
+    environment_path.write_text('PRIVATE="unchanged"\n', encoding="utf-8")
+    environment_path.chmod(0o600)
 
-    assert len(clauses) == len(EXPECTED_DEPLOY_CLAUSES)
-    assert set(clauses) == EXPECTED_DEPLOY_CLAUSES
-    return all(outcomes[clause] for clause in clauses)
-
-
-def _workflow_script() -> str:
-    """Read the current remote deployment program."""
-    return _deploy_script(WORKFLOW_PATH.read_text(encoding="utf-8"))
-
-
-def test_workflow_exposes_explicit_deploy_confirmation() -> None:
-    document = WORKFLOW_PATH.read_text(encoding="utf-8")
-    trigger_block = _indented_block(document, "on:", 0)
-    dispatch_block = _indented_block(trigger_block, "workflow_dispatch:", 2)
-    deploy_block = _indented_block(document, "deploy:", 2)
-
-    assert "  push:" in trigger_block
-    assert "  workflow_dispatch:" in trigger_block
-    assert "    inputs:" in dispatch_block
-    assert "      deploy:" in dispatch_block
-    assert "        required: true" in dispatch_block
-    assert "        type: boolean" in dispatch_block
-    assert "        default: false" in dispatch_block
-    assert "    needs: build" in deploy_block
-
-
-def test_reusable_quality_call_grants_only_codecov_oidc_permissions() -> None:
-    """Keep the called quality workflow authenticated and least privilege."""
-    document = WORKFLOW_PATH.read_text(encoding="utf-8")
-    quality_block = _indented_block(document, "quality:", 2)
-    permissions = _indented_block(quality_block, "permissions:", 4)
-
-    assert permissions.splitlines() == [
-        "      contents: read",
-        "      id-token: write",
-    ]
-    assert "    uses: ./.github/workflows/code-quality.yml" in quality_block
-    assert "secrets:" not in quality_block
-    assert "packages: write" not in quality_block
-
-
-def test_build_digest_is_passed_as_data_to_serialized_deploy() -> None:
-    """Bind the remote deployment to build output without script interpolation."""
-    document = WORKFLOW_PATH.read_text(encoding="utf-8")
-    build_block = _indented_block(document, "build:", 2)
-    deploy_block = _indented_block(document, "deploy:", 2)
-    concurrency = _indented_block(deploy_block, "concurrency:", 4)
-    script = _deploy_script(document)
-
-    assert "      digest: ${{ steps.build-push.outputs.digest }}" in build_block
-    assert "      - name: Record immutable image reference" in build_block
-    assert '            >> "$GITHUB_STEP_SUMMARY"' in build_block
-    assert "          DEPLOY_SHA: ${{ github.sha }}" in deploy_block
-    assert "          IMAGE_DIGEST: ${{ needs.build.outputs.digest }}" in deploy_block
-    assert "          envs: DEPLOY_SHA,IMAGE_DIGEST" in deploy_block
-    assert concurrency.splitlines() == [
-        "      group: production-deployment",
-        "      cancel-in-progress: false",
-        "      queue: max",
-    ]
-    assert "${{ github.sha }}" not in script
-    assert "${{ needs.build.outputs.digest }}" not in script
-
-
-def test_remote_script_forbids_mutable_or_destructive_deploy_operations() -> None:
-    """Require detached provenance and one explicit Compose configuration."""
-    script = _workflow_script()
-
-    for forbidden in (
-        "git pull",
-        "git reset",
-        "git clean",
-        "checkout --force",
-        "checkout -f",
-        "ghcr.io/${{ github.repository }}:main",
-    ):
-        assert forbidden not in script
-
-    assert 'git checkout --detach "$DEPLOY_SHA"' in script
-    assert script.count('docker compose --project-name "$DEPLOY_PROJECT"') == 4
-    assert script.count("--env-file .env -f compose.yaml") == 4
-    assert script.count("docker inspect --type container") == 2
-
-
-def test_compose_resolves_one_exact_digest_without_repository_secrets(
-    tmp_path: Path,
-) -> None:
-    """Resolve the deploy image and trace service identity with real Compose."""
-    docker = shutil.which("docker")
-    if docker is None:
-        pytest.skip("Docker CLI is unavailable")
-
-    compose_path = WORKFLOW_PATH.parents[2] / "compose.yaml"
-    (tmp_path / "compose.yaml").write_text(
-        compose_path.read_text(encoding="utf-8"),
-        encoding="utf-8",
-    )
-    (tmp_path / ".env").write_text(
-        "AGENT_NAME=production-agent\n",
-        encoding="utf-8",
-    )
-    environment = {
-        "COMPOSE_DISABLE_ENV_FILE": "1",
-        "HOME": os.environ.get("HOME", str(tmp_path)),
-        "IMAGE": EXPECTED_IMAGE,
-        "LANG": "C",
-        "PATH": os.environ["PATH"],
-    }
-
-    result = subprocess.run(  # noqa: S603 - resolved Docker, fixed arguments
-        [
-            docker,
-            "compose",
-            "--project-name",
-            EXPECTED_PROJECT,
-            "--env-file",
-            ".env",
-            "-f",
-            "compose.yaml",
-            "config",
-        ],
-        cwd=tmp_path,
-        env=environment,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-
-    assert result.returncode == 0, result.stderr
-    resolved = yaml.safe_load(result.stdout)
-    agent = resolved["services"]["agent"]
-
-    assert agent["image"] == EXPECTED_IMAGE
-    assert agent["environment"]["AGENT_NAME"] == "production-agent"
-
-
-@pytest.mark.parametrize(
-    ("field", "invalid_value"),
-    [
-        ("DEPLOY_SHA", ""),
-        ("DEPLOY_SHA", "a" * 39),
-        ("DEPLOY_SHA", "a" * 41),
-        ("DEPLOY_SHA", "A" * 40),
-        ("DEPLOY_SHA", "g" * 40),
-        ("DEPLOY_SHA", f"{'a' * 39}\n"),
-        ("DEPLOY_SHA", "$(touch should-not-run)"),
-        ("IMAGE_DIGEST", ""),
-        ("IMAGE_DIGEST", f"sha256:{'b' * 63}"),
-        ("IMAGE_DIGEST", f"sha256:{'b' * 65}"),
-        ("IMAGE_DIGEST", f"sha256:{'B' * 64}"),
-        ("IMAGE_DIGEST", f"sha256:{'g' * 64}"),
-        ("IMAGE_DIGEST", f"sha256:{'b' * 63}\n"),
-        ("IMAGE_DIGEST", f"sha512:{'b' * 64}"),
-        ("IMAGE_DIGEST", "b" * 64),
-        ("IMAGE_DIGEST", "$(touch should-not-run)"),
-    ],
-)
-def test_invalid_provenance_fails_before_side_effects(
-    deploy_harness: DeployHarness,
-    field: str,
-    invalid_value: str,
-) -> None:
-    """Reject malformed provenance as data before touching Git or Docker."""
-    sentinel = deploy_harness.home / "should-not-run"
-    value = invalid_value.replace("should-not-run", str(sentinel))
-
-    result = _run_deploy_script(
-        _workflow_script(),
-        deploy_harness,
-        **{field: value},
-    )
-
-    assert result.returncode != 0
-    assert "ERROR: Invalid " in result.stdout
-    assert deploy_harness.git_log.read_text(encoding="utf-8") == ""
-    assert deploy_harness.docker_log.read_text(encoding="utf-8") == ""
-    assert not (deploy_harness.home / "Mixed-Repository").exists()
-    assert not sentinel.exists()
-
-
-@pytest.mark.parametrize("existing_checkout", [False, True])
-def test_remote_deploy_uses_exact_commit_digest_and_literal_secrets(
-    deploy_harness: DeployHarness,
-    existing_checkout: bool,
-) -> None:
-    """Deploy one exact revision and preserve shell-sensitive secret bytes."""
-    project_directory = deploy_harness.home / "Mixed-Repository"
-    if existing_checkout:
-        (project_directory / ".git").mkdir(parents=True)
-
-    result = _run_deploy_script(_workflow_script(), deploy_harness)
-
-    assert result.returncode == 0, result.stderr
-    git_commands = deploy_harness.git_log.read_text(encoding="utf-8").splitlines()
-    expected_after_clone = [
-        "remote get-url origin",
-        "diff --quiet --",
-        "diff --cached --quiet --",
-        f"fetch --no-tags origin {VALID_SHA}",
-        f"checkout --detach {VALID_SHA}",
-        "rev-parse --verify HEAD",
-        "diff --quiet --",
-        "diff --cached --quiet --",
-        "ls-files --error-unmatch -- compose.yaml",
-    ]
-    if existing_checkout:
-        assert git_commands == expected_after_clone
-    else:
-        assert git_commands == [
-            f"clone {EXPECTED_ORIGIN} {project_directory}",
-            *expected_after_clone,
-        ]
-
-    compose_prefix = (
-        f"compose --project-name {EXPECTED_PROJECT} --env-file .env -f compose.yaml"
-    )
-    assert deploy_harness.docker_log.read_text(encoding="utf-8").splitlines() == [
-        f"IMAGE={EXPECTED_IMAGE}|{compose_prefix} config --images",
-        f"IMAGE={EXPECTED_IMAGE}|{compose_prefix} pull agent",
-        (
-            f"IMAGE={EXPECTED_IMAGE}|{compose_prefix} "
-            "up --no-build --wait --wait-timeout 180 agent"
-        ),
-        f"IMAGE={EXPECTED_IMAGE}|{compose_prefix} ps --quiet agent",
-        (
-            f"IMAGE={EXPECTED_IMAGE}|inspect --type container "
-            "--format {{.Config.Image}} agent-container"
-        ),
-        (
-            f"IMAGE={EXPECTED_IMAGE}|inspect --type container "
-            "--format {{.Image}} agent-container"
-        ),
-        (
-            f"IMAGE={EXPECTED_IMAGE}|image inspect --format "
-            '{{ index .Config.Labels "org.opencontainers.image.revision" }} '
-            "sha256:platform-image"
-        ),
-        f"IMAGE={EXPECTED_IMAGE}|image prune -f",
-    ]
-    environment_document = (project_directory / ".env").read_text(encoding="utf-8")
-    for secret_value in SECRET_CANARIES.values():
-        assert secret_value in environment_document
-    assert "LANGFUSE_BASE_URL=https://observability.example\n" in environment_document
-    assert "\nLANGFUSE_HOST=" not in environment_document
-
-
-def test_remote_deploy_checks_out_real_git_commit_detached(
-    deploy_harness: DeployHarness,
-    tmp_path: Path,
-) -> None:
-    """Independently prove the tracked program reaches an exact detached commit."""
-    real_git = shutil.which("git")
-    assert real_git is not None
-
-    remote = tmp_path / "remote.git"
-    seed = tmp_path / "seed"
-    project = deploy_harness.home / "Mixed-Repository"
-    git_environment = {
-        "HOME": str(deploy_harness.home),
-        "LANG": "C",
-        "PATH": "/usr/bin:/bin",
-    }
-
-    def run_git(*arguments: str, cwd: Path | None = None) -> str:
-        result = subprocess.run(  # noqa: S603 - resolved Git, controlled arguments
-            [real_git, *arguments],
-            cwd=cwd,
-            env=git_environment,
-            text=True,
-            capture_output=True,
-            check=True,
-        )
-        return result.stdout.strip()
-
-    run_git("init", "--bare", str(remote))
-    run_git("init", str(seed))
-    run_git("-C", str(seed), "config", "user.email", "test@example.com")
-    run_git("-C", str(seed), "config", "user.name", "Test Author")
-    tracked_file = seed / "tracked.txt"
-    tracked_file.write_text("first\n", encoding="utf-8")
-    (seed / "compose.yaml").write_text(
-        "services:\n  agent:\n    image: agent\n",
-        encoding="utf-8",
-    )
-    run_git("-C", str(seed), "add", "tracked.txt", "compose.yaml")
-    run_git("-C", str(seed), "commit", "-m", "first")
-    run_git("-C", str(seed), "remote", "add", "origin", str(remote))
-    run_git("-C", str(seed), "push", "origin", "HEAD:main")
-    run_git("--git-dir", str(remote), "symbolic-ref", "HEAD", "refs/heads/main")
-    run_git("clone", str(remote), str(project))
-    run_git("-C", str(project), "remote", "set-url", "origin", EXPECTED_ORIGIN)
-
-    tracked_file.write_text("second\n", encoding="utf-8")
-    run_git("-C", str(seed), "add", "tracked.txt")
-    run_git("-C", str(seed), "commit", "-m", "second")
-    target_sha = run_git("-C", str(seed), "rev-parse", "HEAD")
-    run_git("-C", str(seed), "push", "origin", "HEAD:main")
-
-    real_bin = tmp_path / "real-bin"
-    real_bin.mkdir()
-    shutil.copy2(
-        Path(deploy_harness.environment["PATH"].split(":", maxsplit=1)[0]) / "docker",
-        real_bin / "docker",
-    )
+    hook_canary = tmp_path / "post-checkout-ran"
+    fsmonitor_canary = tmp_path / "fsmonitor-ran"
+    diff_canary = tmp_path / "external-diff-ran"
+    site_canary = tmp_path / "sitecustomize-ran"
+    hook = project / ".git" / "hooks" / "post-checkout"
+    _write_executable(hook, f"#!/bin/sh\n: > {shlex.quote(str(hook_canary))}\n")
+    fsmonitor = tmp_path / "fsmonitor"
     _write_executable(
-        real_bin / "git",
-        f"""#!/bin/sh
-set -eu
-if [ "$1" = "fetch" ] && [ "$2" = "--no-tags" ] && [ "$3" = "origin" ]; then
-  exec {shlex.quote(real_git)} fetch --no-tags {shlex.quote(str(remote))} "$4"
+        fsmonitor,
+        f"#!/bin/sh\n: > {shlex.quote(str(fsmonitor_canary))}\nprintf '\\n'\n",
+    )
+    external_diff = tmp_path / "external-diff"
+    _write_executable(
+        external_diff,
+        f"#!/bin/sh\n: > {shlex.quote(str(diff_canary))}\nexit 1\n",
+    )
+    _git(git, project, "config", "core.fsmonitor", str(fsmonitor))
+    _git(git, project, "config", "diff.canary.command", str(external_diff))
+
+    empty_tree = _git(git, project, "mktree", input_text="")
+    malicious = _git(
+        git,
+        project,
+        "commit-tree",
+        empty_tree,
+        input_text="replacement\n",
+    )
+    _git(git, project, "replace", revision, malicious)
+
+    sitecustomize = home / "sitecustomize.py"
+    sitecustomize.write_text(
+        f"from pathlib import Path\nPath({str(site_canary)!r}).write_text('loaded')\n",
+        encoding="utf-8",
+    )
+
+    git_log = tmp_path / "git.log"
+    quoted_git = shlex.quote(git)
+    quoted_log = shlex.quote(str(git_log))
+    failure_body = ""
+    if worktree_failure == "registered":
+        failure_body = f"""
+if [ "$IS_WORKTREE_ADD" -eq 1 ]; then
+  {quoted_git} "$@"
+  STATUS=$?
+  [ "$STATUS" -eq 0 ] || exit "$STATUS"
+  exit 47
 fi
-exec {shlex.quote(real_git)} "$@"
+"""
+    elif worktree_failure == "partial":
+        failure_body = """
+if [ "$IS_WORKTREE_ADD" -eq 1 ]; then
+  LAST=
+  PREVIOUS=
+  for ARG in "$@"; do
+    PREVIOUS=$LAST
+    LAST=$ARG
+  done
+  mkdir -p "$PREVIOUS"
+  printf partial > "$PREVIOUS/partial"
+  exit 47
+fi
+"""
+    _write_executable(
+        binary / "git",
+        f"""#!/bin/sh
+set -u
+printf '%s\\n' "$*" >> {quoted_log}
+IS_FETCH=0
+IS_WORKTREE=0
+IS_WORKTREE_ADD=0
+for ARG in "$@"; do
+  if [ "$ARG" = fetch ]; then IS_FETCH=1; fi
+  if [ "$ARG" = worktree ]; then IS_WORKTREE=1; continue; fi
+  if [ "$IS_WORKTREE" -eq 1 ] && [ "$ARG" = add ]; then
+    IS_WORKTREE_ADD=1
+  fi
+done
+if [ "$IS_FETCH" -eq 1 ]; then exit 0; fi
+{failure_body}
+exec {quoted_git} "$@"
 """,
     )
-
-    result = _run_deploy_script(
-        _workflow_script(),
-        deploy_harness,
-        DEPLOY_SHA=target_sha,
-        PATH=f"{real_bin}:/usr/bin:/bin",
+    _write_executable(binary / "flock", "#!/bin/sh\nexit 0\n")
+    _write_executable(
+        binary / "python3",
+        f'#!/bin/sh\nexec {shlex.quote(sys.executable)} "$@"\n',
     )
+    environment = {
+        "HOME": str(home),
+        "PATH": f"{binary}:/usr/bin:/bin:/usr/sbin:/sbin",
+        "PYTHONPATH": str(home),
+        "GIT_DIR": str(tmp_path / "hostile-git-dir"),
+        "GIT_WORK_TREE": str(tmp_path / "hostile-work-tree"),
+        "GIT_INDEX_FILE": str(tmp_path / "hostile-index"),
+        "GIT_OBJECT_DIRECTORY": str(tmp_path / "hostile-objects"),
+        "GIT_EXEC_PATH": str(tmp_path / "hostile-exec"),
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "core.hooksPath",
+        "GIT_CONFIG_VALUE_0": str(project / ".git" / "hooks"),
+    }
+    release = home / f"{PROJECT_NAME}.release-{RUN_ID}-{RUN_ATTEMPT}"
+    return GitHarness(
+        home=home,
+        project=project,
+        release=release,
+        lease=Path(f"{release}.lease"),
+        environment=environment,
+        revision=revision,
+        git_log=git_log,
+        hook_canary=hook_canary,
+        fsmonitor_canary=fsmonitor_canary,
+        diff_canary=diff_canary,
+        site_canary=site_canary,
+        git=git,
+    )
+
+
+def _bootstrap(harness: GitHarness) -> subprocess.CompletedProcess[str]:
+    return _run(
+        [
+            "/bin/sh",
+            str(BOOTSTRAP_PATH),
+            harness.revision,
+            DIGEST,
+            RUN_ID,
+            RUN_ATTEMPT,
+            PROJECT_NAME,
+            REPOSITORY,
+        ],
+        cwd=ROOT,
+        environment=harness.environment,
+    )
+
+
+def _cleanup(harness: GitHarness) -> subprocess.CompletedProcess[str]:
+    return _run(
+        [
+            "/bin/sh",
+            str(CLEANUP_PATH),
+            harness.revision,
+            DIGEST,
+            RUN_ID,
+            RUN_ATTEMPT,
+            PROJECT_NAME,
+            REPOSITORY,
+        ],
+        cwd=ROOT,
+        environment=harness.environment,
+    )
+
+
+def test_external_actions_are_pinned_to_reviewed_commits() -> None:
+    uses: list[str] = []
+    for job in ("build", "deploy"):
+        for step in _steps(job):
+            if isinstance(step.get("uses"), str):
+                uses.append(cast(str, step["uses"]))
+
+    assert all(re.fullmatch(r"[^@]+@[0-9a-f]{40}", value) for value in uses)
+    assert {
+        value.split("@", maxsplit=1)[0]: value.split("@", maxsplit=1)[1]
+        for value in uses
+    } == EXPECTED_PINS
+
+
+def test_deploy_is_manual_bounded_read_only_and_serialized() -> None:
+    deploy = _job("deploy")
+    condition = " ".join(str(deploy["if"]).split())
+
+    assert condition == (
+        "github.event_name == 'workflow_dispatch' && "
+        "github.ref == 'refs/heads/main' && inputs.deploy"
+    )
+    assert deploy["permissions"] == {"contents": "read"}
+    assert deploy["timeout-minutes"] == 50
+    assert deploy["concurrency"] == {
+        "group": "production-deployment",
+        "cancel-in-progress": False,
+    }
+    assert deploy["env"] == {
+        "DEPLOY_SHA": "${{ github.sha }}",
+        "IMAGE_DIGEST": "${{ needs.build.outputs.digest }}",
+        "DEPLOY_RUN_ID": "${{ github.run_id }}",
+        "DEPLOY_RUN_ATTEMPT": "${{ github.run_attempt }}",
+    }
+
+
+def test_production_secrets_are_scoped_only_to_isolated_serializer() -> None:
+    serializer = _step("deploy", "Serialize production environment")
+    transport = _step("deploy", "Run locked transactional deployment")
+    serializer_environment = cast(dict[str, str], serializer["env"])
+    transport_environment = cast(dict[str, str], transport["env"])
+    serializer_command = _run_text(serializer)
+    transport_script = _run_text(transport)
+
+    assert set(serializer_environment) == PRODUCTION_NAMES | {"TRANSPORT_DIR"}
+    assert set(transport_environment) == {
+        "TRANSPORT_DIR",
+        "SERVER_HOST",
+        "SERVER_USER",
+        "SSH_PRIVATE_KEY",
+        "SERVER_HOST_FINGERPRINT",
+    }
+    for step in _steps("deploy"):
+        if step.get("name") == "Serialize production environment":
+            continue
+        environment = step.get("env", {})
+        assert isinstance(environment, dict)
+        assert PRODUCTION_NAMES.isdisjoint(environment)
+    assert serializer_command.startswith(
+        'python3 -I -S -B "$GITHUB_WORKSPACE/src/agent/compose_env.py"'
+    )
+    assert "PYTHONPATH" not in serializer_command
+    assert "-m agent" not in serializer_command
+    prepare_script = _run_text(_step("deploy", "Prepare private deployment transport"))
+    assert "src/agent/compose_env.py" in prepare_script
+    assert 'git ls-tree "$DEPLOY_SHA" -- "$SOURCE_PATH"' in prepare_script
+    assert 'if [ ! -f "$SOURCE_PATH" ] || [ -L "$SOURCE_PATH" ]' in prepare_script
+    assert "100644:blob|100755:blob" in prepare_script
+    assert "${{ secrets.DATABASE_URL }}" not in transport_script
+    assert "${{ secrets.OPENROUTER_API_KEY }}" not in transport_script
+    assert PRODUCTION_NAMES.isdisjoint(transport_script.split())
+    assert PRODUCTION_NAMES.isdisjoint(
+        BOOTSTRAP_PATH.read_text(encoding="utf-8").split()
+    )
+    assert PRODUCTION_NAMES.isdisjoint(CLEANUP_PATH.read_text(encoding="utf-8").split())
+
+
+def test_openssh_transport_is_strict_direct_and_lease_gated() -> None:
+    script = _run_text(_step("deploy", "Run locked transactional deployment"))
+    controller = script[
+        script.index('CONTROLLER_COMMAND="') : script.index("CONTROLLER_STATUS=$?")
+    ]
+
+    assert "appleboy" not in WORKFLOW_PATH.read_text(encoding="utf-8")
+    for option in (
+        "-F /dev/null",
+        ' -i "$IDENTITY_FILE"',
+        "StrictHostKeyChecking=yes",
+        '"UserKnownHostsFile=$KNOWN_HOSTS"',
+        "GlobalKnownHostsFile=/dev/null",
+        "IdentitiesOnly=yes",
+        "IdentityAgent=none",
+        "ForwardAgent=no",
+        "ForwardX11=no",
+        "ClearAllForwardings=yes",
+        "RequestTTY=no",
+    ):
+        assert option in script
+    assert "unset SSH_PRIVATE_KEY" in script
+    assert "unset SERVER_HOST_FINGERPRINT" in script
+    assert script.index("unset SSH_PRIVATE_KEY") < script.index("ssh-keyscan")
+    assert 'if [ "$MATCHING_KEYS" -ne 1 ]' in script
+    assert "scripts/deployment_bootstrap.sh" in script
+    assert "scripts/deployment_cleanup.sh" in script
+    assert "<<'REMOTE_" not in script
+    assert "PHYSICAL_HOME=" in controller
+    assert "exec env -i" in controller
+    assert "python3 -I -S -B" in controller
+    assert 'runpy.run_module(\\"agent.deployment_promotion\\"' in controller
+    assert "--release-lease" in controller
+    assert "--environment-stdin" in controller
+    assert "git " not in controller
+    assert "flock" not in controller
+    assert "CONTROLLER_FILE" not in script
+    assert "REMOTE_CLEANUP_ALLOWED=0" not in controller
+    assert "124|137|143|255" in script
+    assert script.count("checking the lease") == 2
+    assert "timeout --signal=TERM --kill-after=30s 8m" in script
+    assert "timeout --signal=TERM --kill-after=30s 30m" in script
+    assert "timeout --signal=TERM --kill-after=15s 2m" in script
+
+
+def test_scripts_are_posix_shell_and_encode_exact_cleanup_order() -> None:
+    for path in (BOOTSTRAP_PATH, CLEANUP_PATH):
+        result = _run(["/bin/sh", "-n", str(path)], cwd=ROOT)
+        assert result.returncode == 0, result.stderr
+
+    bootstrap = BOOTSTRAP_PATH.read_text(encoding="utf-8")
+    cleanup = CLEANUP_PATH.read_text(encoding="utf-8")
+    assert bootstrap.index("WORKTREE_CLEANUP_ARMED=1") < bootstrap.index("worktree add")
+    assert bootstrap.index("Legacy .env permissions block deployment") < (
+        bootstrap.index("git_safe clone")
+    )
+    assert "--no-ext-diff --no-textconv" in bootstrap
+    assert "GIT_NO_REPLACE_OBJECTS=1" in bootstrap
+    assert "GIT_TEMPLATE_DIR=/dev/null" in bootstrap
+    assert "-c core.hooksPath=/dev/null" in bootstrap
+    assert "-c core.fsmonitor=false" in bootstrap
+    assert "BOOTSTRAP_LEASE_READY:%s:%s" in bootstrap
+    assert "worktree remove \\\n          --force" in bootstrap
+    assert "shutil.rmtree.avoids_symlink_attacks" in bootstrap
+    assert 'ls-tree "$DEPLOY_SHA" -- "$TARGET_PATH"' in bootstrap
+    assert "100644|100755" in bootstrap
+    assert '[ ! -f "$RELEASE_DIR/$TARGET_PATH" ]' in bootstrap
+    assert '[ -L "$RELEASE_DIR/$TARGET_PATH" ]' in bootstrap
+    assert 'worktree remove "$RELEASE_DIR"' in cleanup
+    assert "worktree remove --force" not in cleanup
+    assert "--ignored=matching" in bootstrap
+    assert "--ignored=matching" in cleanup
+    for forbidden in ("reset --hard", "git clean", "docker compose down", "prune"):
+        assert forbidden not in bootstrap
+        assert forbidden not in cleanup
+
+
+def test_real_git_bootstrap_ignores_hooks_site_config_and_replace_refs(
+    tmp_path: Path,
+) -> None:
+    harness = _git_harness(tmp_path)
+
+    result = _bootstrap(harness)
 
     assert result.returncode == 0, result.stderr
-    assert run_git("-C", str(project), "rev-parse", "HEAD") == target_sha
-    symbolic_ref = subprocess.run(  # noqa: S603 - resolved Git, controlled arguments
-        [real_git, "-C", str(project), "symbolic-ref", "--quiet", "HEAD"],
-        env=git_environment,
-        text=True,
-        capture_output=True,
-        check=False,
+    assert f"BOOTSTRAP_LEASE_READY:{RUN_ID}:{RUN_ATTEMPT}" in result.stdout
+    assert harness.release.is_dir()
+    assert (harness.release / "compose.yaml").read_text() == "services: {}\n"
+    assert _git(harness.git, harness.release, "rev-parse", "HEAD") == harness.revision
+    assert stat.S_IMODE(harness.lease.stat().st_mode) == 0o700
+    assert stat.S_IMODE((harness.lease / "lock").stat().st_mode) == 0o600
+    assert not harness.hook_canary.exists()
+    assert not harness.fsmonitor_canary.exists()
+    assert not harness.diff_canary.exists()
+    assert not harness.site_canary.exists()
+
+    cleanup = _cleanup(harness)
+
+    assert cleanup.returncode == 0, cleanup.stderr
+    assert not harness.release.exists()
+    assert not harness.lease.exists()
+    assert (harness.project / ".env").read_text() == 'PRIVATE="unchanged"\n'
+
+
+def test_legacy_0644_environment_fails_before_git_mutation(tmp_path: Path) -> None:
+    harness = _git_harness(tmp_path)
+    (harness.project / ".env").chmod(0o644)
+
+    result = _bootstrap(harness)
+
+    assert result.returncode == 1
+    assert "Legacy .env permissions block deployment" in result.stdout
+    assert f'chmod 600 "{harness.project}/.env"' in result.stdout
+    log = (
+        harness.git_log.read_text(encoding="utf-8") if harness.git_log.exists() else ""
     )
-    assert symbolic_ref.returncode == 1
-    assert (project / "tracked.txt").read_text(encoding="utf-8") == "second\n"
+    assert " fetch " not in f" {log} "
+    assert " worktree " not in f" {log} "
+    assert not harness.release.exists()
+    assert not harness.lease.exists()
 
 
-def test_remote_deploy_accepts_equivalent_dot_git_origin(
-    deploy_harness: DeployHarness,
+def test_external_diff_is_disabled_on_dirty_primary_checkout(
+    tmp_path: Path,
 ) -> None:
-    """Allow Git's conventional suffix without accepting another repository."""
-    project_directory = deploy_harness.home / "Mixed-Repository"
-    (project_directory / ".git").mkdir(parents=True)
-
-    result = _run_deploy_script(
-        _workflow_script(),
-        deploy_harness,
-        FAKE_GIT_ORIGIN=f"{EXPECTED_ORIGIN}.git",
+    harness = _git_harness(tmp_path)
+    (harness.project / "compose.yaml").write_text(
+        "services:\n  changed: {}\n",
+        encoding="utf-8",
     )
+
+    result = _bootstrap(harness)
+
+    assert result.returncode == 1
+    assert "Tracked worktree changes block deployment" in result.stdout
+    assert not harness.diff_canary.exists()
+    assert "--no-ext-diff --no-textconv --quiet" in harness.git_log.read_text()
+    assert not harness.release.exists()
+
+
+def test_bootstrap_rejects_tracked_required_symlink(tmp_path: Path) -> None:
+    """Reject a clean tracked symlink before Python or Compose can follow it."""
+    harness = _git_harness(tmp_path)
+    _git(harness.git, harness.project, "replace", "-d", harness.revision)
+    outside = tmp_path / "outside-controller.py"
+    outside.write_text("PRIVATE_CANARY = 'outside-commit'\n", encoding="utf-8")
+    controller = harness.project / "src" / "agent" / "deployment_promotion.py"
+    controller.unlink()
+    controller.symlink_to(outside)
+    _git(harness.git, harness.project, "add", "src/agent/deployment_promotion.py")
+    _git(harness.git, harness.project, "commit", "-qm", "tracked symlink")
+    selected = replace(
+        harness,
+        revision=_git(harness.git, harness.project, "rev-parse", "HEAD"),
+    )
+
+    result = _bootstrap(selected)
+
+    assert result.returncode == 1
+    assert "unsafe required file type" in result.stdout
+    assert not selected.release.exists()
+    assert not selected.lease.exists()
+
+
+@pytest.mark.parametrize("failure_mode", ["registered", "partial"])
+def test_post_materialization_failure_removes_only_owned_release(
+    tmp_path: Path,
+    failure_mode: str,
+) -> None:
+    harness = _git_harness(tmp_path, worktree_failure=failure_mode)
+
+    result = _bootstrap(harness)
+
+    assert result.returncode == 47, result.stderr
+    assert not harness.release.exists()
+    assert not harness.lease.exists()
+    listing = _git(harness.git, harness.project, "worktree", "list", "--porcelain")
+    assert str(harness.release) not in listing
+    if failure_mode == "registered":
+        assert "worktree remove --force" in harness.git_log.read_text()
+
+
+def test_cleanup_handles_marker_without_materialized_release(tmp_path: Path) -> None:
+    harness = _git_harness(tmp_path)
+    result = _bootstrap(harness)
+    assert result.returncode == 0, result.stderr
+    remove = _run(
+        [
+            harness.git,
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-C",
+            str(harness.project),
+            "worktree",
+            "remove",
+            "--force",
+            str(harness.release),
+        ],
+        cwd=ROOT,
+    )
+    assert remove.returncode == 0, remove.stderr
+
+    cleanup = _cleanup(harness)
+
+    assert cleanup.returncode == 0, cleanup.stderr
+    assert not harness.lease.exists()
+
+
+def test_cleanup_rejects_ignored_bytecode_and_preserves_release(
+    tmp_path: Path,
+) -> None:
+    harness = _git_harness(tmp_path)
+    result = _bootstrap(harness)
+    assert result.returncode == 0, result.stderr
+    cache = harness.release / "src" / "agent" / "__pycache__"
+    cache.mkdir()
+    (cache / "deployment_promotion.cpython-313.pyc").write_bytes(b"canary")
+
+    cleanup = _cleanup(harness)
+
+    assert cleanup.returncode == 1
+    assert "not exact-clean" in cleanup.stdout
+    assert harness.release.exists()
+    assert harness.lease.exists()
+
+
+def test_cleanup_is_verified_noop_when_bootstrap_created_nothing(
+    tmp_path: Path,
+) -> None:
+    harness = _git_harness(tmp_path)
+
+    result = _cleanup(harness)
 
     assert result.returncode == 0, result.stderr
-
-
-def test_remote_deploy_rejects_non_git_project_path(
-    deploy_harness: DeployHarness,
-) -> None:
-    """Never overwrite an operator-owned path that is not this checkout."""
-    project_directory = deploy_harness.home / "Mixed-Repository"
-    project_directory.mkdir()
-    sentinel = project_directory / "operator-owned"
-    sentinel.write_text("preserve\n", encoding="utf-8")
-
-    result = _run_deploy_script(_workflow_script(), deploy_harness)
-
-    assert result.returncode != 0
-    assert "path exists without a Git checkout" in result.stdout
-    assert deploy_harness.git_log.read_text(encoding="utf-8") == ""
-    assert deploy_harness.docker_log.read_text(encoding="utf-8") == ""
-    assert sentinel.read_text(encoding="utf-8") == "preserve\n"
-
-
-def test_remote_deploy_rejects_untracked_only_compose_file(
-    deploy_harness: DeployHarness,
-) -> None:
-    """Do not let a host file replace config deleted by the exact commit."""
-    project_directory = deploy_harness.home / "Mixed-Repository"
-    (project_directory / ".git").mkdir(parents=True)
-    untracked_compose = project_directory / "compose.yaml"
-    untracked_compose.write_text("operator-owned\n", encoding="utf-8")
-
-    result = _run_deploy_script(
-        _workflow_script(),
-        deploy_harness,
-        FAKE_GIT_LS_FILES_EXIT="1",
-    )
-
-    assert result.returncode != 0
-    assert "does not track compose.yaml" in result.stdout
-    assert deploy_harness.docker_log.read_text(encoding="utf-8") == ""
-    assert not (project_directory / ".env").exists()
-    assert untracked_compose.read_text(encoding="utf-8") == "operator-owned\n"
-
-
-@pytest.mark.parametrize(
-    ("environment", "expected_message", "forbidden_event"),
-    [
-        (
-            {"FAKE_GIT_ORIGIN": "https://github.com/other/repository"},
-            "unexpected origin",
-            "git|fetch",
-        ),
-        (
-            {"FAKE_GIT_UNSTAGED_BEFORE_EXIT": "31"},
-            "Tracked worktree changes",
-            "git|fetch",
-        ),
-        (
-            {"FAKE_GIT_STAGED_BEFORE_EXIT": "32"},
-            "Staged changes",
-            "git|fetch",
-        ),
-        (
-            {"FAKE_GIT_HEAD": "c" * 40},
-            "Checked-out commit does not match",
-            "docker|",
-        ),
-        (
-            {"FAKE_GIT_UNSTAGED_AFTER_EXIT": "33"},
-            "Checkout left tracked",
-            "docker|",
-        ),
-        (
-            {"FAKE_GIT_STAGED_AFTER_EXIT": "34"},
-            "Checkout left staged",
-            "docker|",
-        ),
-    ],
-)
-def test_checkout_provenance_failures_stop_before_docker(
-    deploy_harness: DeployHarness,
-    environment: dict[str, str],
-    expected_message: str,
-    forbidden_event: str,
-) -> None:
-    """Keep unrelated origins, dirty trees, and SHA drift out of deployment."""
-    project_directory = deploy_harness.home / "Mixed-Repository"
-    (project_directory / ".git").mkdir(parents=True)
-    existing_env = project_directory / ".env"
-    existing_env.write_text("operator-owned\n", encoding="utf-8")
-
-    result = _run_deploy_script(
-        _workflow_script(),
-        deploy_harness,
-        **environment,
-    )
-
-    assert result.returncode != 0
-    assert expected_message in result.stdout
-    assert forbidden_event not in deploy_harness.event_log.read_text(encoding="utf-8")
-    assert existing_env.read_text(encoding="utf-8") == "operator-owned\n"
-
-
-@pytest.mark.parametrize(
-    ("environment", "forbidden_fragment"),
-    [
-        ({"FAKE_GIT_CLONE_EXIT": "40"}, "git|remote"),
-        ({"FAKE_GIT_FETCH_EXIT": "41"}, "git|checkout"),
-        ({"FAKE_GIT_CHECKOUT_EXIT": "42"}, "git|rev-parse"),
-        ({"FAKE_GIT_REV_PARSE_EXIT": "43"}, "docker|"),
-        ({"FAKE_DOCKER_CONFIG_EXIT": "51"}, " pull agent"),
-        ({"FAKE_DOCKER_CONFIG_IMAGE": "ghcr.io/other@sha256:bad"}, " pull agent"),
-        ({"FAKE_DOCKER_PULL_EXIT": "52"}, " up --no-build"),
-        ({"FAKE_DOCKER_UP_EXIT": "53"}, " ps --quiet agent"),
-        ({"FAKE_DOCKER_PS_EXIT": "54"}, "inspect --type container"),
-        ({"FAKE_DOCKER_CONTAINER_ID": ""}, "inspect --type container"),
-        ({"FAKE_DOCKER_CONFIG_INSPECT_EXIT": "55"}, "format {{.Image}}"),
-        (
-            {"FAKE_DOCKER_RUNNING_IMAGE": "ghcr.io/other@sha256:bad"},
-            "format {{.Image}}",
-        ),
-        ({"FAKE_DOCKER_IMAGE_ID_EXIT": "56"}, "image inspect"),
-        ({"FAKE_DOCKER_IMAGE_ID": ""}, "image inspect"),
-        ({"FAKE_DOCKER_REVISION_EXIT": "57"}, "image prune"),
-        ({"FAKE_DOCKER_REVISION": "d" * 40}, "image prune"),
-    ],
-)
-def test_deploy_boundary_failure_stops_later_actions(
-    deploy_harness: DeployHarness,
-    environment: dict[str, str],
-    forbidden_fragment: str,
-) -> None:
-    """Propagate each external failure without continuing or pruning."""
-    result = _run_deploy_script(
-        _workflow_script(),
-        deploy_harness,
-        **environment,
-    )
-
-    assert result.returncode != 0
-    assert forbidden_fragment not in deploy_harness.event_log.read_text(
-        encoding="utf-8"
-    )
-    assert "image prune -f" not in deploy_harness.docker_log.read_text(encoding="utf-8")
-
-
-@pytest.mark.parametrize(
-    ("event_name", "git_ref", "deploy", "expected"),
-    [
-        ("push", "refs/heads/main", True, False),
-        ("push", "refs/tags/v1.0.0", True, False),
-        ("workflow_dispatch", "refs/heads/feature", True, False),
-        ("workflow_dispatch", "refs/tags/main", True, False),
-        ("workflow_dispatch", "refs/heads/main", False, False),
-        ("workflow_dispatch", "refs/heads/main", None, False),
-        ("workflow_dispatch", "refs/heads/main", True, True),
-        ("schedule", "refs/heads/main", True, False),
-    ],
-)
-def test_deploy_guard_requires_manual_main_confirmation(
-    event_name: str,
-    git_ref: str,
-    deploy: bool | None,
-    expected: bool,
-) -> None:
-    document = WORKFLOW_PATH.read_text(encoding="utf-8")
-    guard = _deploy_guard(document)
-
-    assert guard == EXPECTED_DEPLOY_GUARD
-    assert (
-        _evaluate_guard(
-            guard,
-            event_name=event_name,
-            git_ref=git_ref,
-            deploy=deploy,
-        )
-        is expected
-    )
+    assert not harness.release.exists()
+    assert not harness.lease.exists()


### PR DESCRIPTION
## What

Add a lock-held transactional VM promotion controller with durable intent, independently verified cutover, and exact rollback or fresh-install abort.

## Why

The previous direct SSH cutover could leave Git, the private environment, Docker runtime, persistent-volume identity, and durable deployment state disagreeing after a failure or lost connection.

## How

- Record canonical candidate receipts, pending intent, and strict terminal outcomes.
- Promote in place from an exact detached commit and verify source, digest, image ID, OCI revision, health, environment, and volume identity.
- Restore and prove the recorded baseline after post-intent failures.
- Use pinned system OpenSSH with host-key pinning, stdin-only secret transport, physical-home normalization, and lease-gated cleanup.
- Reject hooks, fsmonitor, external diff, replace refs, untracked bytes, unsafe file modes, and tracked symlink provenance.
- Add hosted real-Docker success and production-only rollback proofs.

## Tests

- [x] `uv sync --locked`
- [x] `uv run ruff format --check`
- [x] `uv run ruff check --no-fix --output-format=github`
- [x] `uv run mypy .`
- [x] `uv run pytest --cov=src --cov-report=xml --cov-report=term-missing` (1,063 passed, 9 skipped, 100% statement and branch coverage)
- [x] Hosted `deployment-promotion` real-Docker proof

## Related Issues

Fixes #119

Related #111