### PR TITLE
feat: gate VM promotion on ADK eval

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -86,12 +86,75 @@ jobs:
             "$REGISTRY" "$IMAGE_NAME" "$IMAGE_DIGEST" \
             >> "$GITHUB_STEP_SUMMARY"
 
-  deploy:
-    needs: build
+  production_eval:
+    name: Gate production on ADK compatibility
+    needs: quality
     if: >-
       github.event_name == 'workflow_dispatch' &&
       github.ref == 'refs/heads/main' &&
       inputs.deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout evaluation revision
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify evaluation revision
+        env:
+          EVALUATION_SHA: ${{ github.sha }}
+        run: |
+          set -eu
+          if [ "$(git rev-parse --verify HEAD)" != "$EVALUATION_SHA" ]; then
+            echo "ERROR: Evaluation checkout does not match the requested commit."
+            exit 1
+          fi
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Install Python
+        run: uv python install 3.13
+
+      - name: Install locked evaluation dependencies
+        run: uv sync --locked --no-default-groups --group eval
+
+      - name: Run committed ADK compatibility evaluation
+        env:
+          ADK_DISABLE_LOAD_DOTENV: "true"
+          GOOGLE_API_KEY: ""
+          MEM0_EMBEDDER_DIMS: ""
+          MEM0_EMBEDDER_MODEL: __disabled_for_adk_compatibility_eval__
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          OTEL_SDK_DISABLED: "true"
+          PYTEST_ADDOPTS: ""
+          PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
+          PYTEST_PLUGINS: ""
+          ROOT_AGENT_MODEL: google/gemini-2.5-flash
+        run: >-
+          uv run --locked --no-sync --no-default-groups --group eval
+          pytest --noconftest --confcutdir=tests/eval
+          -o addopts= -p no:cacheprovider
+          tests/eval/production_adk_eval.py -q --tb=line
+          --disable-warnings --show-capture=no
+
+  deploy:
+    needs: [build, production_eval]
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
+      inputs.deploy &&
+      needs.build.result == 'success' &&
+      needs.production_eval.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 50
     permissions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,10 @@ dev = [
     "pyyaml>=6.0.3,<7.0.0",
     "ipykernel>=7.0.0,<8.0.0",
 ]
+eval = [
+    "google-adk[eval]==1.36.2",
+    "pytest>=8.3.4,<9.0.0",
+]
 
 [build-system]
 requires = ["uv_build>=0.8.21,<0.9.0"]

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -5,7 +5,16 @@ ADK → LiteLLM → OpenRouter → tool-call path. It requires an
 `OPENROUTER_API_KEY` in the process environment; never add that key to the
 repository or the command line.
 
-Run it with:
+Install the committed evaluation dependencies:
+
+```bash
+uv sync --locked --no-default-groups --group eval
+```
+
+The `eval` dependency group pins `google-adk[eval]==1.36.2`, including the
+response-matching dependencies, in `uv.lock`.
+
+Then expose `OPENROUTER_API_KEY` to the process environment and run:
 
 ```bash
 ADK_DISABLE_LOAD_DOTENV=true \
@@ -13,14 +22,21 @@ GOOGLE_API_KEY= \
 MEM0_EMBEDDER_DIMS= \
 MEM0_EMBEDDER_MODEL=__disabled_for_adk_compatibility_eval__ \
 OTEL_SDK_DISABLED=true \
+PYTEST_ADDOPTS= \
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
+PYTEST_PLUGINS= \
 ROOT_AGENT_MODEL=google/gemini-2.5-flash \
-uv run --with 'google-adk[eval]==1.36.2' adk eval \
-  src/agent tests/eval/adk_compatibility.evalset.json \
-  --config_file_path=tests/eval/adk_compatibility.config.json \
-  --print_detailed_results
+uv run --locked --no-sync --no-default-groups --group eval \
+  pytest --noconftest --confcutdir=tests/eval \
+  -o addopts= -p no:cacheprovider \
+  tests/eval/production_adk_eval.py \
+  -q --tb=line --disable-warnings --show-capture=no
 ```
 
 The Mem0 sentinel deliberately leaves the optional memory integration disabled
 so this check isolates the framework and model tool-call boundary. The eval
 must report one `example_tool` call, a `1.0` trajectory score, and a passing
-response-match score.
+response-match score. The gate parses ADK's ephemeral structured result and
+requires both metrics to be explicitly `PASSED`; it also captures ADK's output
+and fails unless the terminal summary contains exactly one passed case and zero
+failed cases.

--- a/tests/eval/production_adk_eval.py
+++ b/tests/eval/production_adk_eval.py
@@ -1,0 +1,298 @@
+"""Explicit real-model gate for a production VM deployment."""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import shutil
+import tempfile
+import warnings
+from pathlib import Path
+
+from click.testing import CliRunner
+from google.adk.cli.cli_tools_click import main as adk_cli
+from google.adk.evaluation.eval_case import get_all_tool_calls
+from google.adk.evaluation.eval_config import EvalConfig
+from google.adk.evaluation.eval_metrics import EvalMetricResult, EvalStatus
+from google.adk.evaluation.eval_result import EvalSetResult
+from google.adk.evaluation.eval_set import EvalSet
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+EVAL_SET_PATH = REPOSITORY_ROOT / "tests" / "eval" / "adk_compatibility.evalset.json"
+EVAL_CONFIG_PATH = REPOSITORY_ROOT / "tests" / "eval" / "adk_compatibility.config.json"
+EXPECTED_ENVIRONMENT = {
+    "ADK_DISABLE_LOAD_DOTENV": "true",
+    "GOOGLE_API_KEY": "",
+    "MEM0_EMBEDDER_DIMS": "",
+    "MEM0_EMBEDDER_MODEL": "__disabled_for_adk_compatibility_eval__",
+    "OTEL_SDK_DISABLED": "true",
+    "PYTEST_ADDOPTS": "",
+    "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
+    "PYTEST_PLUGINS": "",
+    "ROOT_AGENT_MODEL": "google/gemini-2.5-flash",
+}
+EXPECTED_CRITERIA = {
+    "tool_trajectory_avg_score": {
+        "threshold": 1.0,
+        "match_type": "EXACT",
+    },
+    "response_match_score": 0.8,
+}
+EXPECTED_TOOL_CALL = {"args": {}, "name": "example_tool"}
+EXPECTED_INVOCATION = {
+    "invocation_id": "example_tool_once_invocation",
+    "user_content": {
+        "role": "user",
+        "parts": [
+            {
+                "text": (
+                    "Call example_tool exactly once. Then reply with exactly: "
+                    "Successfully used example_tool."
+                )
+            }
+        ],
+    },
+    "final_response": {
+        "role": "model",
+        "parts": [{"text": "Successfully used example_tool."}],
+    },
+    "intermediate_data": {"tool_uses": [EXPECTED_TOOL_CALL]},
+}
+EXPECTED_EVAL_SET = {
+    "eval_set_id": "adk_compatibility",
+    "name": "Google ADK compatibility",
+    "description": "Verifies the template's real LiteLLM tool-call path.",
+    "eval_cases": [
+        {
+            "eval_id": "example_tool_once",
+            "conversation": [EXPECTED_INVOCATION],
+            "session_input": {
+                "app_name": "agent",
+                "user_id": "adk-compatibility-eval",
+                "state": {},
+            },
+        }
+    ],
+}
+EXPECTED_EVAL_CONFIG = {"criteria": EXPECTED_CRITERIA}
+EXPECTED_METRIC_THRESHOLDS = {
+    "tool_trajectory_avg_score": 1.0,
+    "response_match_score": 0.8,
+}
+SUMMARY_MARKER = "Eval Run Summary\n"
+EXPECTED_SUMMARY = "adk_compatibility:\n  Tests passed: 1\n  Tests failed: 0"
+
+
+def _require_runtime_contract() -> str:
+    for name, expected in EXPECTED_ENVIRONMENT.items():
+        if os.environ.get(name) != expected:
+            raise AssertionError(
+                f"{name} does not match the production evaluation contract"
+            )
+
+    provider_key = os.environ.get("OPENROUTER_API_KEY")
+    if provider_key is None or not provider_key.strip():
+        raise AssertionError(
+            "OPENROUTER_API_KEY is required for the production evaluation"
+        )
+    return provider_key
+
+
+def _require_committed_eval_contract() -> None:
+    try:
+        eval_set_document = json.loads(EVAL_SET_PATH.read_text(encoding="utf-8"))
+        eval_config_document = json.loads(EVAL_CONFIG_PATH.read_text(encoding="utf-8"))
+        eval_set = EvalSet.model_validate(eval_set_document)
+        eval_config = EvalConfig.model_validate(eval_config_document)
+    except (OSError, ValueError):
+        raise AssertionError("The production evaluation assets are invalid") from None
+
+    if (
+        eval_set_document != EXPECTED_EVAL_SET
+        or eval_config_document != EXPECTED_EVAL_CONFIG
+    ):
+        raise AssertionError("The production evaluation assets are invalid")
+
+    if eval_set.eval_set_id != "adk_compatibility":
+        raise AssertionError("The production EvalSet identity is invalid")
+    if [case.eval_id for case in eval_set.eval_cases] != ["example_tool_once"]:
+        raise AssertionError("The production EvalSet must contain exactly one case")
+
+    conversation = eval_set.eval_cases[0].conversation
+    if conversation is None or len(conversation) != 1:
+        raise AssertionError("The production EvalSet must contain one invocation")
+    expected_tools = [
+        {"args": tool.args, "name": tool.name}
+        for tool in get_all_tool_calls(conversation[0].intermediate_data)
+    ]
+    if expected_tools != [EXPECTED_TOOL_CALL]:
+        raise AssertionError("The production EvalSet tool trajectory is invalid")
+    if eval_config.model_dump(mode="json")["criteria"] != EXPECTED_CRITERIA:
+        raise AssertionError("The production evaluation criteria are invalid")
+
+
+def _require_passing_summary(output: str) -> None:
+    if output.count(SUMMARY_MARKER) != 1:
+        raise AssertionError(
+            "The production ADK evaluation did not pass exactly one case"
+        )
+    summary = output.rsplit(SUMMARY_MARKER, maxsplit=1)[1].strip()
+    if summary != EXPECTED_SUMMARY:
+        raise AssertionError(
+            "The production ADK evaluation did not pass exactly one case"
+        )
+
+
+def _require_passing_metrics(metrics: list[EvalMetricResult]) -> None:
+    metrics_by_name = {metric.metric_name: metric for metric in metrics}
+    if len(metrics) != len(EXPECTED_METRIC_THRESHOLDS) or set(metrics_by_name) != set(
+        EXPECTED_METRIC_THRESHOLDS
+    ):
+        raise AssertionError("The production ADK structured result is invalid")
+
+    for name, threshold in EXPECTED_METRIC_THRESHOLDS.items():
+        metric = metrics_by_name[name]
+        if (
+            metric.eval_status != EvalStatus.PASSED
+            or metric.threshold != threshold
+            or metric.score is None
+            or not math.isfinite(metric.score)
+            or metric.score < threshold
+            or metric.score > 1.0
+        ):
+            raise AssertionError("The production ADK structured result is invalid")
+
+
+def _require_passing_structured_result(isolated_agent: Path) -> None:
+    result_paths = sorted(
+        (isolated_agent / ".adk" / "eval_history").glob("*.evalset_result.json")
+    )
+    if len(result_paths) != 1:
+        raise AssertionError("The production ADK structured result is invalid")
+
+    try:
+        eval_set_result = EvalSetResult.model_validate_json(
+            result_paths[0].read_text(encoding="utf-8")
+        )
+    except (OSError, ValueError):
+        raise AssertionError(
+            "The production ADK structured result is invalid"
+        ) from None
+
+    if (
+        eval_set_result.eval_set_id != "adk_compatibility"
+        or len(eval_set_result.eval_case_results) != 1
+    ):
+        raise AssertionError("The production ADK structured result is invalid")
+
+    case_result = eval_set_result.eval_case_results[0]
+    if (
+        case_result.eval_set_id != "adk_compatibility"
+        or case_result.eval_id != "example_tool_once"
+        or case_result.final_eval_status != EvalStatus.PASSED
+        or not case_result.session_id.strip()
+        or len(case_result.eval_metric_result_per_invocation) != 1
+    ):
+        raise AssertionError("The production ADK structured result is invalid")
+
+    invocation_result = case_result.eval_metric_result_per_invocation[0]
+    expected_invocation = invocation_result.expected_invocation
+    if (
+        expected_invocation is None
+        or expected_invocation.model_dump(
+            mode="json",
+            exclude_none=True,
+            exclude_defaults=True,
+        )
+        != EXPECTED_INVOCATION
+        or invocation_result.actual_invocation.user_content.model_dump(
+            mode="json",
+            exclude_none=True,
+            exclude_defaults=True,
+        )
+        != EXPECTED_INVOCATION["user_content"]
+    ):
+        raise AssertionError("The production ADK structured result is invalid")
+
+    final_response = invocation_result.actual_invocation.final_response
+    if final_response is None or not any(
+        part.text and part.text.strip() for part in final_response.parts or []
+    ):
+        raise AssertionError("The production ADK structured result is invalid")
+
+    actual_tools = [
+        {"args": tool.args, "name": tool.name}
+        for tool in get_all_tool_calls(
+            invocation_result.actual_invocation.intermediate_data
+        )
+    ]
+    if actual_tools != [EXPECTED_TOOL_CALL]:
+        raise AssertionError("The production ADK structured result is invalid")
+
+    _require_passing_metrics(case_result.overall_eval_metric_results)
+    _require_passing_metrics(invocation_result.eval_metric_results)
+    overall_metrics = {
+        metric.metric_name: (
+            metric.eval_status,
+            metric.threshold,
+            metric.score,
+        )
+        for metric in case_result.overall_eval_metric_results
+    }
+    invocation_metrics = {
+        metric.metric_name: (
+            metric.eval_status,
+            metric.threshold,
+            metric.score,
+        )
+        for metric in invocation_result.eval_metric_results
+    }
+    if overall_metrics != invocation_metrics:
+        raise AssertionError("The production ADK structured result is invalid")
+
+
+def test_production_adk_compatibility() -> None:
+    """Require one real ADK pass without exposing captured model output."""
+    provider_key = _require_runtime_contract()
+    _require_committed_eval_contract()
+
+    with tempfile.TemporaryDirectory(prefix="adk-production-eval-") as temp:
+        isolated_agent = Path(temp) / "agent"
+        shutil.copytree(
+            REPOSITORY_ROOT / "src" / "agent",
+            isolated_agent,
+            ignore=shutil.ignore_patterns(
+                ".adk",
+                ".env",
+                ".env.*",
+                "__pycache__",
+                "*.pyc",
+            ),
+        )
+        previous_logging_disable = logging.root.manager.disable
+        try:
+            logging.disable(logging.CRITICAL)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                result = CliRunner().invoke(
+                    adk_cli,
+                    [
+                        "eval",
+                        str(isolated_agent),
+                        str(EVAL_SET_PATH),
+                        "--config_file_path",
+                        str(EVAL_CONFIG_PATH),
+                    ],
+                )
+        finally:
+            logging.disable(previous_logging_disable)
+
+        if provider_key in result.output:
+            raise AssertionError("The production evaluation exposed its credential")
+        if result.exit_code != 0:
+            raise AssertionError("The production ADK evaluation command failed")
+        _require_passing_structured_result(isolated_agent)
+
+    _require_passing_summary(result.output)

--- a/tests/test_adk_compatibility.py
+++ b/tests/test_adk_compatibility.py
@@ -1,11 +1,31 @@
 """Compatibility contracts for the pinned Google ADK runtime stack."""
 
+import ast
+import json
+import os
+import runpy
+import subprocess
+import sys
+from collections.abc import Callable
 from pathlib import Path
+from types import FunctionType
+from typing import cast
 
 import pytest
 from google.adk.artifacts import FileArtifactService
 from google.adk.errors.input_validation_error import InputValidationError
+from google.adk.evaluation.eval_case import (
+    IntermediateData,
+    Invocation,
+    get_all_tool_calls,
+)
 from google.adk.evaluation.eval_config import EvalConfig
+from google.adk.evaluation.eval_metrics import (
+    EvalMetricResult,
+    EvalMetricResultPerInvocation,
+    EvalStatus,
+)
+from google.adk.evaluation.eval_result import EvalCaseResult, EvalSetResult
 from google.adk.evaluation.eval_set import EvalSet
 from google.genai import types
 from openinference.instrumentation.google_adk import GoogleADKInstrumentor
@@ -15,6 +35,115 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 EVAL_SET_PATH = REPOSITORY_ROOT / "tests" / "eval" / "adk_compatibility.evalset.json"
 EVAL_CONFIG_PATH = REPOSITORY_ROOT / "tests" / "eval" / "adk_compatibility.config.json"
 EVAL_README_PATH = REPOSITORY_ROOT / "tests" / "eval" / "README.md"
+PRODUCTION_EVAL_PATH = REPOSITORY_ROOT / "tests" / "eval" / "production_adk_eval.py"
+EVAL_ISOLATION_ENVIRONMENT = {
+    "ADK_DISABLE_LOAD_DOTENV": "true",
+    "GOOGLE_API_KEY": "",
+    "MEM0_EMBEDDER_DIMS": "",
+    "MEM0_EMBEDDER_MODEL": "__disabled_for_adk_compatibility_eval__",
+    "OTEL_SDK_DISABLED": "true",
+    "PYTEST_ADDOPTS": "",
+    "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
+    "PYTEST_PLUGINS": "",
+    "ROOT_AGENT_MODEL": "google/gemini-2.5-flash",
+}
+
+
+def _make_metric_results(
+    *,
+    response_status: EvalStatus = EvalStatus.PASSED,
+    response_score: float | None = 0.9,
+) -> list[EvalMetricResult]:
+    return [
+        EvalMetricResult(
+            metric_name="tool_trajectory_avg_score",
+            threshold=1.0,
+            score=1.0,
+            eval_status=EvalStatus.PASSED,
+        ),
+        EvalMetricResult(
+            metric_name="response_match_score",
+            threshold=0.8,
+            score=response_score,
+            eval_status=response_status,
+        ),
+    ]
+
+
+def _make_structured_result(
+    *,
+    overall_response_status: EvalStatus = EvalStatus.PASSED,
+    invocation_response_status: EvalStatus = EvalStatus.PASSED,
+    response_score: float | None = 0.9,
+    tool_name: str = "example_tool",
+    tool_call_id: str | None = None,
+) -> EvalSetResult:
+    prompt = types.Content(
+        role="user",
+        parts=[
+            types.Part(
+                text=(
+                    "Call example_tool exactly once. Then reply with exactly: "
+                    "Successfully used example_tool."
+                )
+            )
+        ],
+    )
+    expected_invocation = Invocation(
+        invocation_id="example_tool_once_invocation",
+        user_content=prompt,
+        final_response=types.Content(
+            role="model",
+            parts=[types.Part(text="Successfully used example_tool.")],
+        ),
+        intermediate_data=IntermediateData(
+            tool_uses=[types.FunctionCall(name="example_tool", args={})]
+        ),
+    )
+    actual_invocation = Invocation(
+        user_content=types.Content(
+            role=prompt.role,
+            parts=prompt.parts,
+        ),
+        final_response=types.Content(
+            role="model",
+            parts=[types.Part(text="Successfully used example_tool.")],
+        ),
+        intermediate_data=IntermediateData(
+            tool_uses=[
+                types.FunctionCall(
+                    id=tool_call_id,
+                    name=tool_name,
+                    args={},
+                )
+            ]
+        ),
+    )
+    case_result = EvalCaseResult(
+        eval_set_id="adk_compatibility",
+        eval_id="example_tool_once",
+        final_eval_status=EvalStatus.PASSED,
+        overall_eval_metric_results=_make_metric_results(
+            response_status=overall_response_status,
+            response_score=response_score,
+        ),
+        eval_metric_result_per_invocation=[
+            EvalMetricResultPerInvocation(
+                actual_invocation=actual_invocation,
+                expected_invocation=expected_invocation,
+                eval_metric_results=_make_metric_results(
+                    response_status=invocation_response_status,
+                    response_score=response_score,
+                ),
+            )
+        ],
+        session_id="synthetic-session",
+    )
+    return EvalSetResult(
+        eval_set_result_id="synthetic-result",
+        eval_set_id="adk_compatibility",
+        eval_case_results=[case_result],
+    )
 
 
 async def test_file_artifacts_reject_identity_path_traversal(
@@ -75,6 +204,13 @@ def test_adk_compatibility_eval_files_use_supported_schema() -> None:
 
     assert eval_set.eval_set_id == "adk_compatibility"
     assert [case.eval_id for case in eval_set.eval_cases] == ["example_tool_once"]
+    conversation = eval_set.eval_cases[0].conversation
+    assert conversation is not None
+    assert len(conversation) == 1
+    assert [
+        tool.model_dump(mode="json", exclude_none=True)
+        for tool in get_all_tool_calls(conversation[0].intermediate_data)
+    ] == [{"args": {}, "name": "example_tool"}]
     assert eval_config.model_dump(mode="json")["criteria"] == {
         "tool_trajectory_avg_score": {
             "threshold": 1.0,
@@ -87,8 +223,424 @@ def test_adk_compatibility_eval_files_use_supported_schema() -> None:
     assert "OPENROUTER_API_KEY" in instructions
     assert "google-adk[eval]==1.36.2" in instructions
     assert "MEM0_EMBEDDER_DIMS=" in instructions
-    assert "src/agent tests/eval/adk_compatibility.evalset.json" in instructions
-    assert "--print_detailed_results" in instructions
+    assert "uv sync --locked --no-default-groups --group eval" in instructions
+    assert "pytest --noconftest --confcutdir=tests/eval" in instructions
+    assert "tests/eval/production_adk_eval.py" in instructions
+    assert "--show-capture=no" in instructions
+    assert "--with" not in instructions
+    assert "--print_detailed_results" not in instructions
+
+
+def test_production_eval_is_explicit_synchronous_and_non_skipping() -> None:
+    """Keep the paid gate outside normal collection and impossible to skip."""
+    source = PRODUCTION_EVAL_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(PRODUCTION_EVAL_PATH))
+    synchronous_tests = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name.startswith("test_")
+    ]
+    asynchronous_tests = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.AsyncFunctionDef) and node.name.startswith("test_")
+    ]
+
+    assert PRODUCTION_EVAL_PATH.name == "production_adk_eval.py"
+    assert len(synchronous_tests) == 1
+    assert synchronous_tests[0].name == "test_production_adk_compatibility"
+    assert synchronous_tests[0].decorator_list == []
+    assert asynchronous_tests == []
+    assert "pytest.skip" not in source
+    assert "skipif" not in source
+    assert "xfail" not in source
+    assert "--print_detailed_results" not in source
+    assert "CliRunner().invoke" in source
+    assert "logging.disable(logging.CRITICAL)" in source
+    assert 'warnings.simplefilter("ignore")' in source
+    assert "TemporaryDirectory" in source
+    assert "ignore_patterns(" in source
+    assert '".adk",' in source
+    assert "_require_passing_summary(result.output)" in source
+    assert "_require_passing_structured_result(isolated_agent)" in source
+
+
+def test_production_eval_summary_is_exact_and_non_vacuous() -> None:
+    """Reject empty, failed, duplicated, and over-counted ADK summaries."""
+    namespace = runpy.run_path(str(PRODUCTION_EVAL_PATH))
+    require_passing_summary = cast(
+        Callable[[str], None],
+        namespace["_require_passing_summary"],
+    )
+    passing = (
+        "Eval Run Summary\nadk_compatibility:\n  Tests passed: 1\n  Tests failed: 0\n"
+    )
+    spoofed_before_marker = (
+        "model output\n"
+        "adk_compatibility:\n"
+        "  Tests passed: 1\n"
+        "  Tests failed: 0\n"
+        "Eval Run Summary\n"
+    )
+
+    require_passing_summary(passing)
+    for invalid in (
+        "",
+        passing.replace("Tests passed: 1", "Tests passed: 0"),
+        passing.replace("Tests failed: 0", "Tests failed: 1"),
+        passing.replace("Tests passed: 1", "Tests passed: 2"),
+        passing + passing,
+        passing + "another_eval:\n" + "  Tests passed: 1\n" + "  Tests failed: 0\n",
+        spoofed_before_marker,
+        passing + "unexpected terminal output\n",
+    ):
+        with pytest.raises(
+            AssertionError,
+            match="did not pass exactly one case",
+        ):
+            require_passing_summary(invalid)
+
+
+def test_production_eval_rejects_drifted_eval_case(tmp_path: Path) -> None:
+    """Pin the prompt, golden response, and session input used for promotion."""
+    namespace = runpy.run_path(str(PRODUCTION_EVAL_PATH))
+    require_committed_contract = cast(
+        FunctionType,
+        namespace["_require_committed_eval_contract"],
+    )
+    function_globals = cast(
+        dict[str, object],
+        require_committed_contract.__globals__,
+    )
+    drifted_eval_set = json.loads(EVAL_SET_PATH.read_text(encoding="utf-8"))
+    invocation = drifted_eval_set["eval_cases"][0]["conversation"][0]
+    invocation["user_content"]["parts"][0]["text"] = "Use any tool."
+    invocation["final_response"]["parts"][0]["text"] = "Any response."
+    drifted_eval_set["eval_cases"][0]["session_input"] = {
+        "app_name": "agent",
+        "user_id": "different-user",
+        "state": {"weakened": True},
+    }
+    drifted_path = tmp_path / "drifted.evalset.json"
+    drifted_path.write_text(json.dumps(drifted_eval_set), encoding="utf-8")
+    function_globals["EVAL_SET_PATH"] = drifted_path
+
+    with pytest.raises(
+        AssertionError,
+        match="evaluation assets are invalid",
+    ):
+        require_committed_contract()
+
+
+def test_production_eval_rejects_custom_metric_override(tmp_path: Path) -> None:
+    """Keep ADK's pinned built-in response matcher authoritative."""
+    namespace = runpy.run_path(str(PRODUCTION_EVAL_PATH))
+    require_committed_contract = cast(
+        FunctionType,
+        namespace["_require_committed_eval_contract"],
+    )
+    function_globals = cast(
+        dict[str, object],
+        require_committed_contract.__globals__,
+    )
+    drifted_config = json.loads(EVAL_CONFIG_PATH.read_text(encoding="utf-8"))
+    drifted_config["custom_metrics"] = {
+        "response_match_score": {"code_config": {"name": "agent.tools.example_tool"}}
+    }
+    drifted_path = tmp_path / "drifted.config.json"
+    drifted_path.write_text(json.dumps(drifted_config), encoding="utf-8")
+    function_globals["EVAL_CONFIG_PATH"] = drifted_path
+
+    with pytest.raises(
+        AssertionError,
+        match="evaluation assets are invalid",
+    ):
+        require_committed_contract()
+
+
+@pytest.mark.parametrize(
+    ("overall_status", "invocation_status", "response_score"),
+    [
+        (EvalStatus.NOT_EVALUATED, EvalStatus.PASSED, 0.9),
+        (EvalStatus.PASSED, EvalStatus.NOT_EVALUATED, 0.9),
+        (EvalStatus.FAILED, EvalStatus.PASSED, 0.9),
+        (EvalStatus.PASSED, EvalStatus.PASSED, None),
+        (EvalStatus.PASSED, EvalStatus.PASSED, 0.79),
+        (EvalStatus.PASSED, EvalStatus.PASSED, 1.01),
+        (EvalStatus.PASSED, EvalStatus.PASSED, float("nan")),
+        (EvalStatus.PASSED, EvalStatus.PASSED, float("inf")),
+    ],
+)
+def test_production_eval_structured_result_rejects_incomplete_metrics(
+    tmp_path: Path,
+    overall_status: EvalStatus,
+    invocation_status: EvalStatus,
+    response_score: float | None,
+) -> None:
+    """Reject metric failures hidden by ADK's aggregate CLI summary."""
+    namespace = runpy.run_path(str(PRODUCTION_EVAL_PATH))
+    require_passing_result = cast(
+        Callable[[Path], None],
+        namespace["_require_passing_structured_result"],
+    )
+    isolated_agent = tmp_path / "agent"
+    history = isolated_agent / ".adk" / "eval_history"
+    history.mkdir(parents=True)
+    result_path = history / "synthetic.evalset_result.json"
+    result_path.write_text(
+        _make_structured_result(
+            overall_response_status=overall_status,
+            invocation_response_status=invocation_status,
+            response_score=response_score,
+        ).model_dump_json(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        AssertionError,
+        match="structured result is invalid",
+    ):
+        require_passing_result(isolated_agent)
+
+
+def test_production_eval_structured_result_is_exact_and_non_vacuous(
+    tmp_path: Path,
+) -> None:
+    """Require one parseable result with one passing case and invocation."""
+    namespace = runpy.run_path(str(PRODUCTION_EVAL_PATH))
+    require_passing_result = cast(
+        Callable[[Path], None],
+        namespace["_require_passing_structured_result"],
+    )
+    isolated_agent = tmp_path / "agent"
+
+    with pytest.raises(
+        AssertionError,
+        match="structured result is invalid",
+    ):
+        require_passing_result(isolated_agent)
+
+    history = isolated_agent / ".adk" / "eval_history"
+    history.mkdir(parents=True)
+    result_path = history / "synthetic.evalset_result.json"
+    result_path.write_text(
+        _make_structured_result().model_dump_json(),
+        encoding="utf-8",
+    )
+
+    require_passing_result(isolated_agent)
+
+    (history / "unexpected.evalset_result.json").write_text(
+        _make_structured_result().model_dump_json(),
+        encoding="utf-8",
+    )
+    with pytest.raises(
+        AssertionError,
+        match="structured result is invalid",
+    ):
+        require_passing_result(isolated_agent)
+
+
+@pytest.mark.parametrize("corruption", ["metric_mismatch", "missing_expected"])
+def test_production_eval_structured_result_rejects_internal_inconsistency(
+    tmp_path: Path,
+    corruption: str,
+) -> None:
+    """Reject artifacts the pinned one-invocation evaluator cannot produce."""
+    namespace = runpy.run_path(str(PRODUCTION_EVAL_PATH))
+    require_passing_result = cast(
+        Callable[[Path], None],
+        namespace["_require_passing_structured_result"],
+    )
+    structured_result = _make_structured_result()
+    invocation_result = structured_result.eval_case_results[
+        0
+    ].eval_metric_result_per_invocation[0]
+    if corruption == "metric_mismatch":
+        invocation_result.eval_metric_results[1].score = 0.8
+    else:
+        invocation_result.expected_invocation = None
+
+    isolated_agent = tmp_path / "agent"
+    history = isolated_agent / ".adk" / "eval_history"
+    history.mkdir(parents=True)
+    (history / "synthetic.evalset_result.json").write_text(
+        structured_result.model_dump_json(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        AssertionError,
+        match="structured result is invalid",
+    ):
+        require_passing_result(isolated_agent)
+
+
+def test_production_eval_structured_result_rejects_wrong_actual_tool(
+    tmp_path: Path,
+) -> None:
+    """Require the real invocation to match the committed exact trajectory."""
+    namespace = runpy.run_path(str(PRODUCTION_EVAL_PATH))
+    require_passing_result = cast(
+        Callable[[Path], None],
+        namespace["_require_passing_structured_result"],
+    )
+    isolated_agent = tmp_path / "agent"
+    history = isolated_agent / ".adk" / "eval_history"
+    history.mkdir(parents=True)
+    (history / "synthetic.evalset_result.json").write_text(
+        _make_structured_result(tool_name="unexpected_tool").model_dump_json(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        AssertionError,
+        match="structured result is invalid",
+    ):
+        require_passing_result(isolated_agent)
+
+
+def test_production_eval_structured_result_allows_provider_tool_call_id(
+    tmp_path: Path,
+) -> None:
+    """Ignore provider transport IDs exactly as ADK's trajectory metric does."""
+    namespace = runpy.run_path(str(PRODUCTION_EVAL_PATH))
+    require_passing_result = cast(
+        Callable[[Path], None],
+        namespace["_require_passing_structured_result"],
+    )
+    isolated_agent = tmp_path / "agent"
+    history = isolated_agent / ".adk" / "eval_history"
+    history.mkdir(parents=True)
+    (history / "synthetic.evalset_result.json").write_text(
+        _make_structured_result(tool_call_id="provider-call-id").model_dump_json(),
+        encoding="utf-8",
+    )
+
+    require_passing_result(isolated_agent)
+
+
+@pytest.mark.parametrize(
+    ("provider_key", "root_model", "expected_error"),
+    [
+        (
+            None,
+            "google/gemini-2.5-flash",
+            "OPENROUTER_API_KEY is required for the production evaluation",
+        ),
+        (
+            "production-eval-provider-secret-canary",
+            "openrouter/provider/not-the-committed-model",
+            "ROOT_AGENT_MODEL does not match the production evaluation contract",
+        ),
+    ],
+)
+def test_production_eval_preflight_fails_closed_without_leaking_credentials(
+    provider_key: str | None,
+    root_model: str,
+    expected_error: str,
+) -> None:
+    """Execute the explicit pytest boundary without reaching a model."""
+    environment = os.environ.copy()
+    for name in (
+        *EVAL_ISOLATION_ENVIRONMENT,
+        "OPENROUTER_API_KEY",
+    ):
+        environment.pop(name, None)
+    environment["PYTEST_ADDOPTS"] = "--collect-only"
+    environment["PYTEST_PLUGINS"] = "untrusted_ambient_plugin"
+    for name in tuple(environment):
+        if name.startswith("COV_CORE_"):
+            environment.pop(name)
+    environment.update(EVAL_ISOLATION_ENVIRONMENT)
+    environment["ROOT_AGENT_MODEL"] = root_model
+    if provider_key is not None:
+        environment["OPENROUTER_API_KEY"] = provider_key
+
+    result = subprocess.run(  # noqa: S603 - fixed interpreter and repository path
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--noconftest",
+            "--confcutdir=tests/eval",
+            "-o",
+            "addopts=",
+            "-p",
+            "no:cacheprovider",
+            str(PRODUCTION_EVAL_PATH),
+            "-q",
+            "--tb=line",
+            "--disable-warnings",
+            "--show-capture=no",
+        ],
+        cwd=REPOSITORY_ROOT,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    output = result.stdout + result.stderr
+
+    assert result.returncode == 1
+    assert expected_error in output
+    if provider_key is not None:
+        assert provider_key not in output
+
+
+def test_production_eval_ignores_external_skip_conftest(tmp_path: Path) -> None:
+    """Prevent a neighboring conftest from skipping the paid gate."""
+    eval_directory = tmp_path / "tests" / "eval"
+    eval_directory.mkdir(parents=True)
+    copied_gate = eval_directory / PRODUCTION_EVAL_PATH.name
+    copied_gate.write_text(
+        PRODUCTION_EVAL_PATH.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    (eval_directory / "conftest.py").write_text(
+        "def pytest_collection_modifyitems(items):\n"
+        "    for item in items:\n"
+        "        item.add_marker('skip')\n",
+        encoding="utf-8",
+    )
+    environment = os.environ.copy()
+    for name in (*EVAL_ISOLATION_ENVIRONMENT, "OPENROUTER_API_KEY"):
+        environment.pop(name, None)
+    for name in tuple(environment):
+        if name.startswith("COV_CORE_"):
+            environment.pop(name)
+    environment.update(EVAL_ISOLATION_ENVIRONMENT)
+
+    result = subprocess.run(  # noqa: S603 - fixed interpreter and temp path
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--noconftest",
+            "--confcutdir=tests/eval",
+            "-o",
+            "addopts=",
+            "-p",
+            "no:cacheprovider",
+            str(copied_gate),
+            "-q",
+            "--tb=line",
+            "--disable-warnings",
+            "--show-capture=no",
+        ],
+        cwd=tmp_path,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    output = result.stdout + result.stderr
+
+    assert result.returncode == 1
+    assert "OPENROUTER_API_KEY is required for the production evaluation" in output
+    assert "skipped" not in output
 
 
 def test_adk_and_genai_instrumentors_support_resolved_stack(

--- a/tests/test_deployment_workflow.py
+++ b/tests/test_deployment_workflow.py
@@ -8,6 +8,7 @@ import shutil
 import stat
 import subprocess
 import sys
+import tomllib
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import cast
@@ -19,6 +20,9 @@ ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_PATH = ROOT / ".github" / "workflows" / "docker-publish.yml"
 BOOTSTRAP_PATH = ROOT / "scripts" / "deployment_bootstrap.sh"
 CLEANUP_PATH = ROOT / "scripts" / "deployment_cleanup.sh"
+EVAL_GATE_PATH = ROOT / "tests" / "eval" / "production_adk_eval.py"
+PYPROJECT_PATH = ROOT / "pyproject.toml"
+LOCK_PATH = ROOT / "uv.lock"
 REVISION = "a" * 40
 DIGEST = f"sha256:{'b' * 64}"
 REPOSITORY = "MixedOwner/Mixed-Repository"
@@ -46,6 +50,7 @@ EXPECTED_PINS = {
     "docker/login-action": "c94ce9fb468520275223c153574b00df6fe4bcc9",
     "docker/metadata-action": "c299e40c65443455700f0fdfc63efafe5b349051",
     "docker/build-push-action": "ca052bb54ab0790a636c9b5f226502c73d547a25",
+    "astral-sh/setup-uv": "d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86",
 }
 
 
@@ -329,7 +334,7 @@ def _cleanup(harness: GitHarness) -> subprocess.CompletedProcess[str]:
 
 def test_external_actions_are_pinned_to_reviewed_commits() -> None:
     uses: list[str] = []
-    for job in ("build", "deploy"):
+    for job in ("build", "production_eval", "deploy"):
         for step in _steps(job):
             if isinstance(step.get("uses"), str):
                 uses.append(cast(str, step["uses"]))
@@ -347,7 +352,9 @@ def test_deploy_is_manual_bounded_read_only_and_serialized() -> None:
 
     assert condition == (
         "github.event_name == 'workflow_dispatch' && "
-        "github.ref == 'refs/heads/main' && inputs.deploy"
+        "github.ref == 'refs/heads/main' && inputs.deploy && "
+        "needs.build.result == 'success' && "
+        "needs.production_eval.result == 'success'"
     )
     assert deploy["permissions"] == {"contents": "read"}
     assert deploy["timeout-minutes"] == 50
@@ -355,12 +362,105 @@ def test_deploy_is_manual_bounded_read_only_and_serialized() -> None:
         "group": "production-deployment",
         "cancel-in-progress": False,
     }
+    assert deploy["needs"] == ["build", "production_eval"]
     assert deploy["env"] == {
         "DEPLOY_SHA": "${{ github.sha }}",
         "IMAGE_DIGEST": "${{ needs.build.outputs.digest }}",
         "DEPLOY_RUN_ID": "${{ github.run_id }}",
         "DEPLOY_RUN_ATTEMPT": "${{ github.run_attempt }}",
     }
+
+
+def test_production_eval_is_manual_locked_exact_and_fail_closed() -> None:
+    job = _job("production_eval")
+    condition = " ".join(str(job["if"]).split())
+    steps = _steps("production_eval")
+
+    assert condition == (
+        "github.event_name == 'workflow_dispatch' && "
+        "github.ref == 'refs/heads/main' && inputs.deploy"
+    )
+    assert job["needs"] == "quality"
+    assert job["permissions"] == {"contents": "read"}
+    assert job["timeout-minutes"] == 10
+    assert "env" not in job
+    assert "outputs" not in job
+    assert "continue-on-error" not in job
+    assert "always()" not in condition
+
+    checkout = _step("production_eval", "Checkout evaluation revision")
+    assert checkout["with"] == {
+        "ref": "${{ github.sha }}",
+        "fetch-depth": 1,
+        "persist-credentials": False,
+    }
+    verification = _step("production_eval", "Verify evaluation revision")
+    assert verification["env"] == {"EVALUATION_SHA": "${{ github.sha }}"}
+    assert "git rev-parse --verify HEAD" in _run_text(verification)
+
+    install = _step("production_eval", "Install locked evaluation dependencies")
+    assert _run_text(install) == ("uv sync --locked --no-default-groups --group eval")
+    assert "env" not in install
+
+    evaluation = _step("production_eval", "Run committed ADK compatibility evaluation")
+    assert "if" not in evaluation
+    assert "continue-on-error" not in evaluation
+    assert evaluation["env"] == {
+        "ADK_DISABLE_LOAD_DOTENV": "true",
+        "GOOGLE_API_KEY": "",
+        "MEM0_EMBEDDER_DIMS": "",
+        "MEM0_EMBEDDER_MODEL": "__disabled_for_adk_compatibility_eval__",
+        "OPENROUTER_API_KEY": "${{ secrets.OPENROUTER_API_KEY }}",
+        "OTEL_SDK_DISABLED": "true",
+        "PYTEST_ADDOPTS": "",
+        "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
+        "PYTEST_PLUGINS": "",
+        "ROOT_AGENT_MODEL": "google/gemini-2.5-flash",
+    }
+    assert " ".join(_run_text(evaluation).split()) == (
+        "uv run --locked --no-sync --no-default-groups --group eval "
+        "pytest --noconftest --confcutdir=tests/eval "
+        "-o addopts= -p no:cacheprovider "
+        "tests/eval/production_adk_eval.py "
+        "-q --tb=line --disable-warnings --show-capture=no"
+    )
+
+    for step in steps:
+        if step.get("name") == "Run committed ADK compatibility evaluation":
+            continue
+        assert "${{ secrets." not in str(step)
+    assert (
+        sum(str(step).count("${{ secrets.OPENROUTER_API_KEY }}") for step in steps) == 1
+    )
+
+    project = tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
+    assert project["dependency-groups"]["eval"] == [
+        "google-adk[eval]==1.36.2",
+        "pytest>=8.3.4,<9.0.0",
+    ]
+    lock = tomllib.loads(LOCK_PATH.read_text(encoding="utf-8"))
+    locked_project = next(
+        package
+        for package in lock["package"]
+        if package["name"] == "google-adk-on-bare-metal"
+    )
+    assert locked_project["dev-dependencies"]["eval"] == [
+        {"name": "google-adk", "extra": ["eval"]},
+        {"name": "pytest"},
+    ]
+    assert locked_project["metadata"]["requires-dev"]["eval"] == [
+        {"name": "google-adk", "extras": ["eval"], "specifier": "==1.36.2"},
+        {"name": "pytest", "specifier": ">=8.3.4,<9.0.0"},
+    ]
+    rendered = WORKFLOW_PATH.read_text(encoding="utf-8")
+    evaluation_job = rendered[
+        rendered.index("  production_eval:") : rendered.index("\n  deploy:")
+    ]
+    for forbidden in (" --with ", "pip install", "uv add", "uv lock", "always()"):
+        assert forbidden not in evaluation_job
+    assert EVAL_GATE_PATH.name == "production_adk_eval.py"
+    assert not EVAL_GATE_PATH.name.startswith("test_")
+    assert not EVAL_GATE_PATH.name.endswith("_test.py")
 
 
 def test_production_secrets_are_scoped_only_to_isolated_serializer() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,20 @@
 version = 1
 revision = 3
 requires-python = "==3.13.*"
+resolution-markers = [
+    "sys_platform == 'win32'",
+    "sys_platform == 'emscripten'",
+    "sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+
+[[package]]
+name = "absl-py"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/4f/d79676ab82f2e42fc3611618139f13a9c4c31d0cff4b486982047679a802/absl_py-2.5.0.tar.gz", hash = "sha256:0c996f25c0490700fadabe6351630f6111534fa0ae252cc6d2014ea3b141135f", size = 118119, upload-time = "2026-07-03T10:57:48.157Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/0a/a10b45aab35b175aded078a462dc8d0c698f5b13946e7cb0869097b78bb6/absl_py-2.5.0-py3-none-any.whl", hash = "sha256:0f17b89f2a4eaaedc4f28c622998aa690564b3012a396a4ffad0821007fe03ba", size = 137410, upload-time = "2026-07-03T10:57:46.735Z" },
+]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -369,6 +383,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -519,6 +542,15 @@ wheels = [
 ]
 
 [[package]]
+name = "gepa"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/56/925779e5690971f1b022f7d107caf015c33ec09560261273ec137e23a8f2/gepa-0.1.4.tar.gz", hash = "sha256:6dd153a676ae5481764860d19286a9c0e8ddb5ef70d7f13044faf24978bdb6b8", size = 351343, upload-time = "2026-07-15T14:53:59.929Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/77/5b3a281cfd9caaa9e68349b434cf27f1ca448003ee0067a1ae2184dc52d1/gepa-0.1.4-py3-none-any.whl", hash = "sha256:12b971039599625c156d2231f6d72a29c31a22e9c237689459b5f1a3c353f532", size = 290167, upload-time = "2026-07-15T14:53:58.422Z" },
+]
+
+[[package]]
 name = "google-adk"
 version = "1.36.2"
 source = { registry = "https://pypi.org/simple" }
@@ -574,6 +606,16 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/fc/270f6ece5f118848fed53aae29150d6fd338c1072b8ae4ccd3db22f7ed0a/google_adk-1.36.2-py3-none-any.whl", hash = "sha256:6f96aab3e011e58ac8275541245a3a2e76ced789d95a559521f86978eb3c9d35", size = 2877715, upload-time = "2026-07-21T21:37:03.84Z" },
 ]
 
+[package.optional-dependencies]
+eval = [
+    { name = "gepa" },
+    { name = "google-cloud-aiplatform", extra = ["evaluation"] },
+    { name = "jinja2" },
+    { name = "pandas" },
+    { name = "rouge-score" },
+    { name = "tabulate" },
+]
+
 [[package]]
 name = "google-adk-on-bare-metal"
 version = "0.2.0"
@@ -608,6 +650,10 @@ dev = [
     { name = "pyyaml" },
     { name = "ruff" },
 ]
+eval = [
+    { name = "google-adk", extra = ["eval"] },
+    { name = "pytest" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -639,6 +685,10 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.0.0,<8.0.0" },
     { name = "pyyaml", specifier = ">=6.0.3,<7.0.0" },
     { name = "ruff", specifier = ">=0.12.7,<1.0.0" },
+]
+eval = [
+    { name = "google-adk", extras = ["eval"], specifier = "==1.36.2" },
+    { name = "pytest", specifier = ">=8.3.4,<9.0.0" },
 ]
 
 [[package]]
@@ -751,6 +801,15 @@ agent-engines = [
     { name = "packaging" },
     { name = "pydantic" },
     { name = "typing-extensions" },
+]
+evaluation = [
+    { name = "jsonschema" },
+    { name = "litellm" },
+    { name = "pandas" },
+    { name = "pyyaml" },
+    { name = "ruamel-yaml" },
+    { name = "scikit-learn" },
+    { name = "tqdm" },
 ]
 
 [[package]]
@@ -1484,6 +1543,15 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.23.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1826,12 +1894,37 @@ wheels = [
 ]
 
 [[package]]
+name = "narwhals"
+version = "2.24.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/1d/58946e5aab18393e793bd4add6985b95d0e01c3a2d832f38f54468b10dcd/narwhals-2.24.0.tar.gz", hash = "sha256:b5c0f684ccd9d7475b564111e319a4964abcf2baf79d3cf6b1003d06ac9b828d", size = 661143, upload-time = "2026-07-13T10:49:19.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/85/a5bfaebfd305ac18b57b0854d74e37e586809061a91fda62f0bd50c8518e/narwhals-2.24.0-py3-none-any.whl", hash = "sha256:42fdedf44e5b2ca7505630d45b4ac3058f38d8485cba9fe1652ca23152df7489", size = 461030, upload-time = "2026-07-13T10:49:17.571Z" },
+]
+
+[[package]]
 name = "nest-asyncio"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
+name = "nltk"
+version = "3.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "defusedxml" },
+    { name = "joblib" },
+    { name = "regex" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/02/df4f105b28a7c16b0e41423bc09cf0f1b8a305df4ef0b10ca74a2e4c648c/nltk-3.10.0.tar.gz", hash = "sha256:4fbac1d98203cbcd1b5d94a2877fb822300072d80604a5e7fae49d2c5f84e8c1", size = 3089244, upload-time = "2026-07-08T02:39:13.562Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/89/a0b0f35e2820d6a99d75ea1c11977ee6d5c9e6658eceb45b0c7620881faa/nltk-3.10.0-py3-none-any.whl", hash = "sha256:54ff84d4916d3ef127e8953bee0023f6a6b320b75d634a19e06ef056d3d244bf", size = 1716144, upload-time = "2026-07-08T02:39:09.753Z" },
 ]
 
 [[package]]
@@ -2154,6 +2247,27 @@ wheels = [
 ]
 
 [[package]]
+name = "pandas"
+version = "3.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/4f/5f3422a2afec5ffc46308b79e53291365a93748b498ac2e58bead0197916/pandas-3.0.5.tar.gz", hash = "sha256:dca3734d6ab7c906e6730f0788b0a1dbb9f2467731f9711f77995c8e9d62d712", size = 4658219, upload-time = "2026-07-22T22:19:28.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/09/7b95c4a0025227d6f118c4039b423412ac6a982db02864166185d812fbc7/pandas-3.0.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c1c05a767fe8e5b4fe9e1c29806829c582052eaedb9120a3da83ba3f69e24a5b", size = 10385742, upload-time = "2026-07-22T22:18:29.346Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/0c/dc78fd8c4da477b4b5e8ad37295af352190d21ef63a9ee1bc071753074cc/pandas-3.0.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b86765f268b56f7e665b93bce9d5df69dee7f99e595cf8fb839483ab315942a3", size = 9932067, upload-time = "2026-07-22T22:18:31.833Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/71/3592c055cf44df9808550f9368ceda80ff2b224d355ef73fe251dcda1802/pandas-3.0.5-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c597ecf5616b5c420372c1d4d4c00dbbfba7398bea857dcc984347e1ea48417b", size = 10466756, upload-time = "2026-07-22T22:18:34.195Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/70/4363150359f95b4cb4bcbb34ca23572bb5495749a621a8f3d5a1ddfd293c/pandas-3.0.5-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b11c36e218331d0387cbe3a0a5f75162357a1d92d57b2b08a336ff94b19b2be", size = 10938525, upload-time = "2026-07-22T22:18:36.81Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/d0/317e7a0c67c0e69fa905a0161409397a7dc2d46ff611f6ca4803352c042b/pandas-3.0.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cf52e1f61d229496da17dc7ab54acdee627357e7008fd4fecba3d0ba2937fa58", size = 11489303, upload-time = "2026-07-22T22:18:39.287Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/8d/36dade89b49e4f9d5cbdbe863772581f98c0c6d78fc39ad4c557f6f2e17e/pandas-3.0.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:db172144bb56422bd157812f3b021eacc255451470b31e2c633c349490a1cfee", size = 11989004, upload-time = "2026-07-22T22:18:42.208Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ba/18c4ec8a746e177da05a9e7a7963781d8ea195780724f854601b6ebd6b78/pandas-3.0.5-cp313-cp313-win_amd64.whl", hash = "sha256:0d298e951f23016ce4699951d044ae6418dbc91bf68cefca0f77666fcbb4e5c6", size = 9826896, upload-time = "2026-07-22T22:18:44.539Z" },
+    { url = "https://files.pythonhosted.org/packages/de/ec/28a57266b753799a87b8bc79e7887ac6fd981b8c6d2978a0b7e7b6bd708c/pandas-3.0.5-cp313-cp313-win_arm64.whl", hash = "sha256:66266d3442a5e8b3c90274c2b8b230bee42dd1c286bc822cc2f9f2c7e12b883e", size = 9094790, upload-time = "2026-07-22T22:18:47.468Z" },
+]
+
+[[package]]
 name = "parso"
 version = "0.8.5"
 source = { registry = "https://pypi.org/simple" }
@@ -2176,7 +2290,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -2766,6 +2880,18 @@ wheels = [
 ]
 
 [[package]]
+name = "rouge-score"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "nltk" },
+    { name = "numpy" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/c5/9136736c37022a6ad27fea38f3111eb8f02fe75d067f9a985cc358653102/rouge_score-0.1.2.tar.gz", hash = "sha256:c7d4da2683e68c9abf0135ef915d63a46643666f848e558a1b9f7ead17ff0f04", size = 17400, upload-time = "2022-07-22T22:46:22.909Z" }
+
+[[package]]
 name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2803,6 +2929,15 @@ wheels = [
 ]
 
 [[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.14.14"
 source = { registry = "https://pypi.org/simple" }
@@ -2826,6 +2961,48 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/aa/9f89c719c467dfaf8ad799b9bae0df494513fb21d31a6059cb5870e57e74/ruff-0.14.14-py3-none-win32.whl", hash = "sha256:b530c191970b143375b6a68e6f743800b2b786bbcf03a7965b06c4bf04568167", size = 10502442, upload-time = "2026-01-22T22:30:38.93Z" },
     { url = "https://files.pythonhosted.org/packages/87/44/90fa543014c45560cae1fffc63ea059fb3575ee6e1cb654562197e5d16fb/ruff-0.14.14-py3-none-win_amd64.whl", hash = "sha256:3dde1435e6b6fe5b66506c1dff67a421d0b7f6488d466f651c07f4cab3bf20fd", size = 11630486, upload-time = "2026-01-22T22:30:10.852Z" },
     { url = "https://files.pythonhosted.org/packages/9e/6a/40fee331a52339926a92e17ae748827270b288a35ef4a15c9c8f2ec54715/ruff-0.14.14-py3-none-win_arm64.whl", hash = "sha256:56e6981a98b13a32236a72a8da421d7839221fa308b223b9283312312e5ac76c", size = 10920448, upload-time = "2026-01-22T22:30:15.417Z" },
+]
+
+[[package]]
+name = "scikit-learn"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "narwhals" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/01/cf3310626b6d48d3e9be69a1223f9180360b5e6edb045f50fade723ce494/scikit_learn-1.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:80746d63bd4b6eaca54d36fe5feaf4d28bb38dc6f9470f81c7cad7c40155f119", size = 8705188, upload-time = "2026-06-02T11:53:41.964Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/04/5acd7ae280c5f93b6ac5ef6cdec14eef4c8d1cd91d85b3292989c94d96b1/scikit_learn-1.9.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5b934c45c252844a91d69fda3a34cff5e7307e1db10d77cb10a3980312c74713", size = 8228299, upload-time = "2026-06-02T11:53:44.817Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/39/ffe829a5b8ecb40a518724a997794657fdc354ada5e8fe8e64d998c0bac9/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:38c3dcb9a1ffb85505ec53d54c7b4aea0cff70050425a7760c2af661ac85df05", size = 8789690, upload-time = "2026-06-02T11:53:47.461Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/88/8dab5de10c638c083772a6be83a3d8106ced492f74a928c8693638e5bb50/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da76d09304a4706db7cc1e3ebaa3b6b98a67365cc11d2996c4f1e58ba47df714", size = 9087723, upload-time = "2026-06-02T11:53:50.702Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3f/7917ca72464038f6240ec70c29f94862d08a34a74291ae4d4ec5eb8186a0/scikit_learn-1.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:5808d98f15c6bf6d9d96d2348c1997392a5888ce7097e664105f930c4bca1277", size = 8184330, upload-time = "2026-06-02T11:53:53.396Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c7/15739eb2f61fda3c54639e9942414e5a19ad8a8d1f5a3266afad7cb7df80/scikit_learn-1.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:d77f54c017633791bc0225a43e2f8d03745fdcfe4880268fcc4df15f505dec2e", size = 7840653, upload-time = "2026-06-02T11:53:56.035Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/52/9c0136c2de7ae0779b7b366447766cec6d9f0702c56bb8ffeb04c8fd3af4/scipy-1.18.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:09143f676d157d9f546d663504ef9c1becb819824f1afc018814176411942446", size = 31036107, upload-time = "2026-06-19T15:00:14.03Z" },
+    { url = "https://files.pythonhosted.org/packages/02/73/0291a64843270f4efb86cdcf2ee0f2048631b65ec6b405398b2b4dbf11bf/scipy-1.18.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5efe260f69417b97ddae455bfb5a95e8359f7f66ad7fa9522a60feb66f169520", size = 28663303, upload-time = "2026-06-19T15:00:16.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0f/10ffa0b697a572f4e0d48b92a88895d366422f019f723e7e14a84c050dac/scipy-1.18.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:68363b7eaacd8b5dd426df56d782cc156468ac79a127a1b87ca597d6e2e82197", size = 20404960, upload-time = "2026-06-19T15:00:19.635Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/d2/e896cea21ba8edd6c81d4c55b1ffcc717e79698dcbebf9641b4cfb4c6622/scipy-1.18.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:c5557d8be5da8e41353fcd4d21491fdbab83b062fc579e94dc09a7c8ab4f669b", size = 23034074, upload-time = "2026-06-19T15:00:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/b2/e83ea34279a52c03374477c74006256ec78df65fc877baa4617d6de1d202/scipy-1.18.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0d13bca67c096d89fb95ced0d8921807300fce0275643aef9533cc63a0773468", size = 33942038, upload-time = "2026-06-19T15:00:24.964Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/af/e8fe5fb136f51e2b01678b92cb4106d10d8cd68ec147ead2e7cb0ac75398/scipy-1.18.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a46f9273dbd0eb1cefba61c9b8648b4dfe3cbc14a080176f9a73e44b8336dc7f", size = 35266390, upload-time = "2026-06-19T15:00:28.059Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/49/2c5cbb907b56695fc67517811d1db234dfd83381a84814ec220aded2794d/scipy-1.18.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5aba46108853ddfc77906b6557aac839d2b52e900c1d72a1180adaaab58d265f", size = 35551324, upload-time = "2026-06-19T15:00:31.014Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/73/eda39f7a2d306ff0ffc574afd13c0bbb6d10a603d9a413998ee269487a80/scipy-1.18.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b6f758e35f12757b5d95c00bc6de2438e229c2664b7a92e96f205959d9f2dfa4", size = 37404785, upload-time = "2026-06-19T15:00:34.072Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/d2/ae881ee28d014f38e0ccbfd974a06a919ba9af34f1f74bf42b5301891d63/scipy-1.18.0-cp313-cp313-win_amd64.whl", hash = "sha256:1afac4a847207c7ff8efd321734a50b06d0280b3b2a2c0fc2f413101747ad7c7", size = 36554943, upload-time = "2026-06-19T15:00:36.903Z" },
+    { url = "https://files.pythonhosted.org/packages/70/3a/21154e2d54eb3639c6bf4dbae2e531c68356bfe95990daa30df33b30d556/scipy-1.18.0-cp313-cp313-win_arm64.whl", hash = "sha256:c5dbddf60e58c2312316d097271a8e73d40eaf2eabfa4d95ed7d3695bbf2ce7b", size = 24350911, upload-time = "2026-06-19T15:00:40.062Z" },
 ]
 
 [[package]]
@@ -2954,12 +3131,30 @@ wheels = [
 ]
 
 [[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
+]
+
+[[package]]
 name = "tenacity"
 version = "9.1.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036, upload-time = "2025-04-02T08:25:09.966Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248, upload-time = "2025-04-02T08:25:07.678Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Add a real-model Google ADK compatibility gate before any manual production VM
deployment can start.

## Why

The committed compatibility EvalSet existed only as a local command, and the
pinned ADK 1.36.2 CLI reports failed metric counts without returning a failing
process status. Its aggregate status can also remain passed when one metric is
not evaluated. A deployment could therefore bypass behavioral verification or
treat a failed, partial, or empty evaluation as successful.

## How

- Add a lockfile-resolved `eval` dependency group for the pinned ADK extras.
- Run one explicitly targeted synchronous pytest only for manual `main`
  deployments.
- Validate the exact one-case `example_tool` trajectory and committed
  thresholds before inference.
- Parse the ephemeral ADK result and require both overall and per-invocation
  metrics to be explicitly passed at their committed thresholds.
- Cross-check the captured CLI result for exactly one pass and zero failures.
- Evaluate a temporary source copy so prompts, results, and history do not
  persist in the checkout.
- Suppress captured provider output and keep the OpenRouter key scoped to the
  evaluation step.
- Require both the immutable image build and evaluation job to succeed before
  `deploy` can run.
- Add fail-closed workflow, lockfile, cardinality, structured-result,
  collection, and credential contracts.

## Tests

- [x] `uv sync --locked`
- [x] `uv run ruff format --check`
- [x] `uv run ruff check --no-fix --output-format=github`
- [x] `uv run mypy .`
- [x] `uv run pytest --cov=src --cov-report=xml --cov-report=term-missing`
      (`1,088 passed`, `9 skipped`, 100% statement and branch coverage)
- [x] Authorized real OpenRouter evaluation: exact actual tool trajectory, two
      explicitly passed metrics, one passed case, and zero failed cases
- [x] Synthetic provider failure: fixed secret-free error, no captured provider
      details, and no checkout eval-history mutation
- [x] Adversarial result/parser/pytest bypass audit: merge-ready

## Related Issues

Closes #123

Part of #111
