### PR TITLE
feat: bound VM image retention

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -75,6 +75,7 @@ jobs:
             ${{ steps.meta.outputs.labels }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
+            io.queryplanner.adk.repository=${{ github.repository }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -227,7 +228,8 @@ jobs:
           for SOURCE_PATH in \
             scripts/deployment_bootstrap.sh \
             scripts/deployment_cleanup.sh \
-            src/agent/compose_env.py
+            src/agent/compose_env.py \
+            src/agent/deployment_retention.py
           do
             if [ ! -f "$SOURCE_PATH" ] || [ -L "$SOURCE_PATH" ]; then
               echo "ERROR: Deployment source file is unavailable."
@@ -485,6 +487,44 @@ jobs:
             printf '%s' "ghcr.io/${{ github.repository }}" \
               | tr '[:upper:]' '[:lower:]'
           )"
+          RETENTION_COMMAND="set -eu
+          PHYSICAL_HOME=\"\$(cd \"\$HOME\" && pwd -P)\"
+          exec flock -n \
+          \"\$PHYSICAL_HOME/$PROJECT_NAME.release-$DEPLOY_RUN_ID-$DEPLOY_RUN_ATTEMPT.lease/lock\" \
+          env -i \
+          \"HOME=\$PHYSICAL_HOME\" \
+          \"PATH=\$PATH\" \
+          LANG=C \
+          LC_ALL=C \
+          \"DOCKER_CONFIG=\${DOCKER_CONFIG-}\" \
+          \"DOCKER_HOST=\${DOCKER_HOST-}\" \
+          \"XDG_RUNTIME_DIR=\${XDG_RUNTIME_DIR-}\" \
+          python3 -I -S -B \
+          -c 'import runpy, sys; source = sys.argv.pop(1); sys.path.insert(0, source); runpy.run_module(\"agent.deployment_retention\", run_name=\"__main__\", alter_sys=True)' \
+          \"\$PHYSICAL_HOME/$PROJECT_NAME.release-$DEPLOY_RUN_ID-$DEPLOY_RUN_ATTEMPT/src\" \
+          enforce \
+          --state-dir \"\$PHYSICAL_HOME/.local/state/$PROJECT_SLUG/deployment\" \
+          --repository \"${{ github.repository }}\" \
+          --target-reference \"$IMAGE_REPOSITORY@$IMAGE_DIGEST\" \
+          --apply"
+          set +e
+          timeout --signal=TERM --kill-after=30s 10m \
+            ssh "${SSH_OPTIONS[@]}" "$SERVER_USER@$SERVER_HOST" \
+            "$RETENTION_COMMAND" < /dev/null
+          RETENTION_STATUS=$?
+          set -e
+          if [ "$RETENTION_STATUS" -ne 0 ]; then
+            case "$RETENTION_STATUS" in
+              124|137|143|255)
+                echo "ERROR: Retention transport ended ambiguously; checking the lease."
+                ;;
+              *)
+                echo "ERROR: Retention or its release lease did not complete."
+                ;;
+            esac
+            exit "$RETENTION_STATUS"
+          fi
+
           CONTROLLER_COMMAND="set -eu
           PHYSICAL_HOME=\"\$(cd \"\$HOME\" && pwd -P)\"
           exec env -i \
@@ -506,6 +546,7 @@ jobs:
           --expected-origin \"https://github.com/${{ github.repository }}\" \
           --compose-project \"adk-$PROJECT_SLUG\" \
           --compose-service agent \
+          --repository \"${{ github.repository }}\" \
           --source-revision \"$DEPLOY_SHA\" \
           --image-reference \"$IMAGE_REPOSITORY@$IMAGE_DIGEST\" \
           --adopt-existing \

--- a/.github/workflows/test-docker-compose.yml
+++ b/.github/workflows/test-docker-compose.yml
@@ -430,6 +430,46 @@ jobs:
           tests/test_deployment_promotion_runtime.py::test_real_docker_promotes_then_restores_exact_verified_baseline
           -q --tb=line --disable-warnings --show-capture=no
 
+  deployment-retention:
+    name: Validate bounded VM image retention
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      RUN_DEPLOYMENT_RETENTION_INTEGRATION: "1"
+      DEPLOYMENT_RETENTION_TEST_PREFIX: >-
+        adk-retention-${{ github.run_id }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Install Python
+        run: uv python install 3.13
+
+      - name: Install locked dependencies
+        run: uv sync --locked
+
+      - name: Run bounded VM image-retention proof
+        env:
+          PYTEST_ADDOPTS: ""
+          PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
+          PYTEST_PLUGINS: ""
+          PYTHONDONTWRITEBYTECODE: "1"
+        run: >-
+          uv run --locked --no-sync pytest
+          --noconftest --confcutdir=tests
+          -o addopts= -p no:cacheprovider
+          tests/test_deployment_retention_runtime.py::test_real_docker_retention_reserves_one_exact_pull_slot
+          -q --tb=line --disable-warnings --show-capture=no
+
   trace-gateway:
     name: Validate trace-redaction gateway
     runs-on: ubuntu-latest

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -89,6 +89,54 @@ a free lease permits removal only after the ownership marker, detached commit,
 and exact-clean worktree all match. Inspect the VM process and deployment
 journal before removing any residual release manually.
 
+### Bounded production image retention
+
+Published images carry the stable
+`io.queryplanner.adk.repository=<owner>/<repository>` ownership label in
+addition to the OCI source and revision labels. After release bootstrap and
+before the deployment controller can pull a candidate, the workflow runs the
+retention policy from that exact detached release under the deployment-state
+lock. The controller repeats the read-only capacity admission check under the
+same lock immediately before its pull, then repeats the strict ownership and
+capacity proof after the pull and before any candidate starts.
+
+The VM cache has a hard maximum of eight managed digest references. When the
+requested digest is not local, retention first reduces the cache to seven and
+reserves the eighth slot for that pull. An already-local, fully verified target
+uses the normal eight-reference limit. The keep set always includes the
+requested target, the current deployment, the two newest distinct prior
+`promoted` or `adopted` generations, and images used by any container. This
+provides a three-generation local rollback cache. There is no age-based
+deletion: aliases, malformed ownership evidence, unresolved recovery state,
+and other ambiguity are retained and can block admission.
+
+One invocation removes at most five exact, eligible digest references. The
+fixed batch has no override. If more safe deletions remain, the command reports
+an incomplete nonzero result after that batch, and the workflow stops before
+the target pull or any production Compose command. Rerun the reviewed workflow
+to process the next batch. An unreachable plan fails without deleting
+anything. Every removal uses the exact digest with `--no-prune`; retention
+never prunes or deletes containers, networks, volumes, builder cache,
+deployment evidence, or application data. A retention failure does not roll
+back or misclassify the existing healthy deployment because promotion has not
+started.
+
+To inspect the plan from a trusted checkout, run the same CLI without
+`--apply`. Replace each placeholder, including the lowercase project slug used
+under `.local/state`:
+
+```bash
+cd "$HOME/<repository>/src"
+python3 -S -B -m agent.deployment_retention enforce \
+  --state-dir "$HOME/.local/state/<lowercase-project-slug>/deployment" \
+  --repository "<owner>/<repository>" \
+  --target-reference "ghcr.io/<lowercase-owner>/<lowercase-repository>@sha256:<64-lowercase-hex>"
+```
+
+Dry-run output contains image identities and keep/delete reasons, not
+production environment values. Do not add `--apply` until the plan and any
+reported ambiguity have been reviewed.
+
 ### Using GHCR Images
 
 Instead of building locally, you can run the image published by your

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
 server = "agent.server:main"
 deployment-state = "agent.deployment_state_cli:main"
 deployment-promote = "agent.deployment_promotion:main"
+deployment-retention = "agent.deployment_retention:main"
 
 [dependency-groups]
 dev = [

--- a/scripts/deployment_bootstrap.sh
+++ b/scripts/deployment_bootstrap.sh
@@ -343,6 +343,7 @@ for TARGET_PATH in \
   src/agent/compose_env.py \
   src/agent/deployment_adoption.py \
   src/agent/deployment_promotion.py \
+  src/agent/deployment_retention.py \
   src/agent/deployment_state.py
 do
   TARGET_ENTRY="$(git_safe -C "$PROJECT_DIR" ls-tree "$DEPLOY_SHA" -- "$TARGET_PATH")"
@@ -431,6 +432,7 @@ for TARGET_PATH in \
   src/agent/compose_env.py \
   src/agent/deployment_adoption.py \
   src/agent/deployment_promotion.py \
+  src/agent/deployment_retention.py \
   src/agent/deployment_state.py
 do
   if [ ! -f "$RELEASE_DIR/$TARGET_PATH" ] \

--- a/src/agent/deployment_promotion.py
+++ b/src/agent/deployment_promotion.py
@@ -33,6 +33,10 @@ from agent.deployment_adoption import (
     DeploymentObservation,
     observe_legacy_deployment,
 )
+from agent.deployment_retention import (
+    ImageRetentionError,
+    enforce_pull_admission,
+)
 from agent.deployment_state import (
     CandidateReceipt,
     CurrentDeployment,
@@ -93,6 +97,7 @@ _IMAGE_REFERENCE = re.compile(
     r"@sha256:[0-9a-f]{64}\Z"
 )
 _EXPECTED_ORIGIN = re.compile(r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\Z")
+_GITHUB_REPOSITORY = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\Z")
 _VOLUME_CREATED_AT = re.compile(
     r"[0-9]{4}-[0-9]{2}-[0-9]{2}T"
     r"[0-9]{2}:[0-9]{2}:[0-9]{2}"
@@ -148,11 +153,13 @@ class PromotionConfig:
     checkout: Path
     release_checkout: Path
     expected_origin: str
+    repository: str
     compose_project: str
     compose_service: str
     source_revision: str
     image_reference: str
     adopt_existing: bool
+    image_repository: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -230,6 +237,11 @@ def _validated_config(config: PromotionConfig) -> PromotionConfig:
         config.expected_origin
     ) is None or config.expected_origin.endswith(".git"):
         raise PromotionError("expected origin is invalid")
+    if (
+        _GITHUB_REPOSITORY.fullmatch(config.repository) is None
+        or config.expected_origin != f"https://github.com/{config.repository}"
+    ):
+        raise PromotionError("GitHub repository identity is invalid")
     for value, field in (
         (config.compose_project, "Compose project"),
         (config.compose_service, "Compose service"),
@@ -240,6 +252,15 @@ def _validated_config(config: PromotionConfig) -> PromotionConfig:
         raise PromotionError("source revision is invalid")
     if _IMAGE_REFERENCE.fullmatch(config.image_reference) is None:
         raise PromotionError("image reference is not an immutable digest")
+    image_repository = (
+        f"ghcr.io/{config.repository.lower()}"
+        if config.image_repository is None
+        else config.image_repository
+    )
+    if _IMAGE_REFERENCE.fullmatch(f"{image_repository}@sha256:{'0' * 64}") is None:
+        raise PromotionError("image repository identity is invalid")
+    if not config.image_reference.startswith(f"{image_repository}@sha256:"):
+        raise PromotionError("image reference repository does not match")
     return config
 
 
@@ -661,6 +682,27 @@ def _pull_and_prove_image(
         executables=executables,
         environment=environment,
     )
+
+
+def _enforce_image_retention_admission(
+    *,
+    transaction: DeploymentStateTransaction,
+    config: PromotionConfig,
+    executables: Executables,
+    environment: Mapping[str, str],
+) -> None:
+    """Require one read-only, exact project-image capacity proof."""
+    try:
+        enforce_pull_admission(
+            transaction,
+            docker=executables.docker,
+            environment=environment,
+            repository=config.repository,
+            target_reference=config.image_reference,
+            image_repository=config.image_repository,
+        )
+    except ImageRetentionError as error:
+        raise PromotionError(f"image-retention admission failed: {error}") from None
 
 
 def _container_ids(
@@ -1634,10 +1676,22 @@ def _promote_locked(
         executables=executables,
         environment=command_environment,
     )
+    _enforce_image_retention_admission(
+        transaction=transaction,
+        config=config,
+        executables=executables,
+        environment=command_environment,
+    )
     image = _pull_and_prove_image(
         config,
         executables,
         command_environment,
+    )
+    _enforce_image_retention_admission(
+        transaction=transaction,
+        config=config,
+        executables=executables,
+        environment=command_environment,
     )
     transaction_id = _new_transaction_id(original_revision)
     receipt = _run_candidate(
@@ -1804,6 +1858,7 @@ def _parser() -> argparse.ArgumentParser:
     promote_parser.add_argument("--checkout", required=True, type=Path)
     promote_parser.add_argument("--release-checkout", required=True, type=Path)
     promote_parser.add_argument("--expected-origin", required=True)
+    promote_parser.add_argument("--repository", required=True)
     promote_parser.add_argument("--compose-project", required=True)
     promote_parser.add_argument("--compose-service", required=True)
     promote_parser.add_argument("--source-revision", required=True)
@@ -1882,6 +1937,8 @@ def main(
     argv: Sequence[str] | None = None,
     environment: Mapping[str, str] | None = None,
     input_stream: BinaryIO | None = None,
+    *,
+    _image_repository: str | None = None,
 ) -> int:
     """Run the promotion CLI and return a stable process status."""
     arguments = _parser().parse_args(sys.argv[1:] if argv is None else argv)
@@ -1890,11 +1947,13 @@ def main(
         checkout=arguments.checkout,
         release_checkout=arguments.release_checkout,
         expected_origin=arguments.expected_origin,
+        repository=arguments.repository,
         compose_project=arguments.compose_project,
         compose_service=arguments.compose_service,
         source_revision=arguments.source_revision,
         image_reference=arguments.image_reference,
         adopt_existing=arguments.adopt_existing,
+        image_repository=_image_repository,
     )
     try:
         if (arguments.release_lease is None) != (not arguments.environment_stdin):

--- a/src/agent/deployment_retention.py
+++ b/src/agent/deployment_retention.py
@@ -1,0 +1,960 @@
+"""Bound exact project-owned Docker image references before a VM pull."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import stat
+import subprocess
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+from agent.deployment_state import (
+    DeploymentLockBusyError,
+    DeploymentState,
+    DeploymentStateError,
+    DeploymentStateStore,
+    DeploymentStateTransaction,
+)
+
+MAX_MANAGED_REFERENCES: Final = 8
+MAX_DELETIONS_PER_INVOCATION: Final = 5
+INCOMPLETE_EXIT_STATUS: Final = 3
+_MAX_COMMAND_OUTPUT_BYTES: Final = 256 * 1024
+_MAX_INVENTORY_IDENTITIES: Final = 512
+_COMMAND_TIMEOUT_SECONDS: Final = 60
+_HOST_ENVIRONMENT_NAMES: Final = (
+    "HOME",
+    "PATH",
+    "DOCKER_CONFIG",
+    "DOCKER_HOST",
+    "XDG_RUNTIME_DIR",
+)
+_GITHUB_REPOSITORY = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\Z")
+_IMAGE_ID = re.compile(r"sha256:[0-9a-f]{64}\Z")
+_CONTAINER_ID = re.compile(r"[0-9a-f]{64}\Z")
+_REVISION = re.compile(r"[0-9a-f]{40}\Z")
+_REPOSITORY_COMPONENT = r"[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*"
+_IMAGE_REPOSITORY = re.compile(
+    rf"(?=.{{1,255}}\Z)"
+    rf"(?:[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?(?::[0-9]{{1,5}})?/)?"
+    rf"{_REPOSITORY_COMPONENT}(?:/{_REPOSITORY_COMPONENT})*\Z"
+)
+
+
+class ImageRetentionError(RuntimeError):
+    """Report a deterministic, secret-free image-retention failure."""
+
+
+@dataclass(frozen=True, slots=True)
+class ManagedImage:
+    """One locally proven, alias-free project image reference."""
+
+    reference: str
+    image_id: str
+    oci_revision: str
+
+    def as_document(self) -> dict[str, str]:
+        """Return bounded secret-free image identity."""
+        return {
+            "reference": self.reference,
+            "image_id": self.image_id,
+            "oci_revision": self.oci_revision,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ReferenceDecision:
+    """One deterministic keep/delete decision for an occupied project digest."""
+
+    reference: str
+    action: str
+    reasons: tuple[str, ...]
+    image_id: str | None
+
+    def as_document(self) -> dict[str, object]:
+        """Return the decision without inventing an unproven image identity."""
+        document: dict[str, object] = {
+            "reference": self.reference,
+            "action": self.action,
+            "reasons": list(self.reasons),
+        }
+        if self.image_id is not None:
+            document["image_id"] = self.image_id
+        return document
+
+
+@dataclass(frozen=True, slots=True)
+class RetentionPlan:
+    """One immutable capacity plan computed from verified state and Docker."""
+
+    repository: str
+    target_reference: str
+    target_present: bool
+    reserved_references: int
+    occupied_references: tuple[str, ...]
+    ambiguous_references: tuple[str, ...]
+    managed_references: tuple[ManagedImage, ...]
+    protected_references: tuple[str, ...]
+    missing_generation_references: tuple[str, ...]
+    delete_references: tuple[str, ...]
+    reference_decisions: tuple[ReferenceDecision, ...]
+
+    @property
+    def admitted_count(self) -> int:
+        """Return occupied references including an absent target reservation."""
+        return len(self.occupied_references) + self.reserved_references
+
+    @property
+    def required_deletions(self) -> int:
+        """Return deletions needed before the requested target can be pulled."""
+        return len(self.delete_references)
+
+    @property
+    def admitted(self) -> bool:
+        """Return whether a target pull stays within the fixed ceiling."""
+        return self.admitted_count <= MAX_MANAGED_REFERENCES
+
+    def as_document(self, *, status: str) -> dict[str, object]:
+        """Return a bounded, secret-free plan or result document."""
+        return {
+            "status": status,
+            "repository": self.repository,
+            "target_reference": self.target_reference,
+            "target_present": self.target_present,
+            "reserved_references": self.reserved_references,
+            "occupied_reference_count": len(self.occupied_references),
+            "managed_reference_count": len(self.managed_references),
+            "managed_references": [
+                image.as_document() for image in self.managed_references
+            ],
+            "admitted_reference_count": self.admitted_count,
+            "managed_reference_limit": MAX_MANAGED_REFERENCES,
+            "maximum_deletions": MAX_DELETIONS_PER_INVOCATION,
+            "protected_references": list(self.protected_references),
+            "ambiguous_references": list(self.ambiguous_references),
+            "missing_generation_references": list(self.missing_generation_references),
+            "delete_references": list(self.delete_references),
+            "reference_decisions": [
+                decision.as_document() for decision in self.reference_decisions
+            ],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class _RecordedGeneration:
+    state: DeploymentState
+    last_sequence: int
+
+
+@dataclass(frozen=True, slots=True)
+class _ImageDocument:
+    image_id: str
+    repo_digests: tuple[str, ...]
+    repo_tags: tuple[str, ...]
+    labels: Mapping[str, str]
+
+
+def _validated_identity(
+    repository: str,
+    target_reference: str,
+    image_repository: str | None,
+) -> tuple[str, str]:
+    if _GITHUB_REPOSITORY.fullmatch(repository) is None:
+        raise ImageRetentionError("GitHub repository identity is invalid")
+    selected_repository = (
+        f"ghcr.io/{repository.lower()}"
+        if image_repository is None
+        else image_repository
+    )
+    if _IMAGE_REPOSITORY.fullmatch(selected_repository) is None:
+        raise ImageRetentionError("image repository identity is invalid")
+    target_pattern = re.compile(
+        rf"{re.escape(selected_repository)}@sha256:[0-9a-f]{{64}}\Z"
+    )
+    if target_pattern.fullmatch(target_reference) is None:
+        raise ImageRetentionError("target image reference is invalid")
+    return selected_repository, f"https://github.com/{repository}"
+
+
+def _validated_docker(path: Path) -> Path:
+    try:
+        canonical = path.resolve(strict=True)
+        metadata = canonical.stat()
+    except OSError:
+        raise ImageRetentionError("Docker executable is unavailable") from None
+    if (
+        not canonical.is_absolute()
+        or canonical != path
+        or not stat.S_ISREG(metadata.st_mode)
+    ):
+        raise ImageRetentionError("Docker executable is invalid")
+    return canonical
+
+
+def _run(
+    docker: Path,
+    arguments: Sequence[str],
+    *,
+    environment: Mapping[str, str],
+    accepted_returncodes: frozenset[int] = frozenset({0}),
+) -> subprocess.CompletedProcess[str]:
+    try:
+        result = subprocess.run(  # noqa: S603 - resolved executable, fixed arguments
+            [str(docker), *arguments],
+            env=environment,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=_COMMAND_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        raise ImageRetentionError("Docker image-retention command timed out") from None
+    except OSError:
+        raise ImageRetentionError(
+            "Docker image-retention command could not start"
+        ) from None
+    if result.returncode not in accepted_returncodes:
+        raise ImageRetentionError(
+            f"Docker image-retention command failed (exit {result.returncode})"
+        )
+    if (
+        len(result.stdout.encode()) > _MAX_COMMAND_OUTPUT_BYTES
+        or len(result.stderr.encode()) > _MAX_COMMAND_OUTPUT_BYTES
+    ):
+        raise ImageRetentionError("Docker image-retention output is too large")
+    return result
+
+
+def _identity_lines(
+    value: str,
+    pattern: re.Pattern[str],
+    field: str,
+) -> tuple[str, ...]:
+    if "\0" in value or "\r" in value:
+        raise ImageRetentionError(f"Docker {field} inventory is invalid")
+    lines = tuple(line for line in value.splitlines() if line)
+    if len(lines) > _MAX_INVENTORY_IDENTITIES or any(
+        pattern.fullmatch(line) is None for line in lines
+    ):
+        raise ImageRetentionError(f"Docker {field} inventory is invalid")
+    return tuple(sorted(set(lines)))
+
+
+def _decode_single_document(value: str, field: str) -> Mapping[str, object]:
+    try:
+        decoded = json.loads(value)
+    except json.JSONDecodeError:
+        raise ImageRetentionError(f"Docker {field} inspection is invalid") from None
+    if (
+        not isinstance(decoded, list)
+        or len(decoded) != 1
+        or not isinstance(decoded[0], dict)
+    ):
+        raise ImageRetentionError(f"Docker {field} inspection is invalid")
+    return decoded[0]
+
+
+def _string_sequence(value: object, field: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ImageRetentionError(f"Docker image {field} is invalid")
+    return tuple(value)
+
+
+def _image_mount_selector(value: object) -> str:
+    if not isinstance(value, str):
+        raise ImageRetentionError(
+            "Docker image mount selector is not an immutable digest"
+        )
+    repository, separator, digest = value.rpartition("@")
+    if (
+        separator != "@"
+        or _IMAGE_REPOSITORY.fullmatch(repository) is None
+        or _IMAGE_ID.fullmatch(digest) is None
+    ):
+        raise ImageRetentionError(
+            "Docker image mount selector is not an immutable digest"
+        )
+    return value
+
+
+def _image_document(value: str) -> _ImageDocument:
+    document = _decode_single_document(value, "image")
+    image_id = document.get("Id")
+    if not isinstance(image_id, str) or _IMAGE_ID.fullmatch(image_id) is None:
+        raise ImageRetentionError("Docker image identity is invalid")
+    config = document.get("Config")
+    if not isinstance(config, dict):
+        raise ImageRetentionError("Docker image configuration is invalid")
+    raw_labels = config.get("Labels")
+    if raw_labels is None:
+        labels: Mapping[str, str] = {}
+    elif isinstance(raw_labels, dict) and all(
+        isinstance(key, str) and isinstance(item, str)
+        for key, item in raw_labels.items()
+    ):
+        labels = raw_labels
+    else:
+        raise ImageRetentionError("Docker image labels are invalid")
+    return _ImageDocument(
+        image_id=image_id,
+        repo_digests=_string_sequence(document.get("RepoDigests"), "digests"),
+        repo_tags=_string_sequence(document.get("RepoTags"), "tags"),
+        labels=labels,
+    )
+
+
+def _inspect_image(
+    docker: Path,
+    identifier: str,
+    environment: Mapping[str, str],
+) -> _ImageDocument | None:
+    result = _run(
+        docker,
+        ["image", "inspect", identifier],
+        environment=environment,
+        accepted_returncodes=frozenset({0, 1}),
+    )
+    if result.returncode == 1:
+        expected_error = f"Error response from daemon: No such image: {identifier}\n"
+        if result.stdout not in {"[]", "[]\n"} or result.stderr != expected_error:
+            raise ImageRetentionError("Docker image absence could not be proven")
+        return None
+    return _image_document(result.stdout)
+
+
+def _managed_image(
+    document: _ImageDocument,
+    *,
+    repository: str,
+    image_repository: str,
+    expected_source: str,
+) -> ManagedImage | None:
+    prefix = f"{image_repository}@sha256:"
+    project_digests = tuple(
+        reference for reference in document.repo_digests if reference.startswith(prefix)
+    )
+    if (
+        len(document.repo_digests) != 1
+        or len(project_digests) != 1
+        or document.repo_tags
+        or document.labels.get("io.queryplanner.adk.repository") != repository
+        or document.labels.get("org.opencontainers.image.source") != expected_source
+    ):
+        return None
+    revision = document.labels.get("org.opencontainers.image.revision")
+    if revision is None or _REVISION.fullmatch(revision) is None:
+        return None
+    return ManagedImage(
+        reference=project_digests[0],
+        image_id=document.image_id,
+        oci_revision=revision,
+    )
+
+
+def _local_inventory(
+    *,
+    docker: Path,
+    environment: Mapping[str, str],
+    repository: str,
+    image_repository: str,
+    expected_source: str,
+) -> tuple[
+    dict[str, ManagedImage],
+    frozenset[str],
+    frozenset[str],
+    frozenset[str],
+]:
+    image_ids = _identity_lines(
+        _run(
+            docker,
+            ["image", "ls", "--all", "--no-trunc", "--quiet"],
+            environment=environment,
+        ).stdout,
+        _IMAGE_ID,
+        "image",
+    )
+    managed: dict[str, ManagedImage] = {}
+    observed_images: dict[str, _ImageDocument] = {}
+    local_digest_references: set[str] = set()
+    occupied_image_ids: dict[str, set[str]] = {}
+    ambiguous_references: set[str] = set()
+    exact_reference = re.compile(
+        rf"{re.escape(image_repository)}@sha256:[0-9a-f]{{64}}\Z"
+    )
+    project_prefix = f"{image_repository}@"
+    for image_id in image_ids:
+        document = _inspect_image(docker, image_id, environment)
+        if document is None or document.image_id != image_id:
+            raise ImageRetentionError(
+                "Docker image inventory changed during inspection"
+            )
+        observed_images[image_id] = document
+        local_digest_references.update(document.repo_digests)
+        project_references: list[str] = []
+        for reference in document.repo_digests:
+            if not reference.startswith(project_prefix):
+                continue
+            if exact_reference.fullmatch(reference) is None:
+                raise ImageRetentionError(
+                    "Docker project image digest reference is malformed"
+                )
+            project_references.append(reference)
+            occupied_image_ids.setdefault(reference, set()).add(image_id)
+        has_project_tag = any(
+            reference.startswith(f"{image_repository}:")
+            for reference in document.repo_tags
+        )
+        if has_project_tag and not project_references:
+            raise ImageRetentionError(
+                "project image tag lacks a canonical digest reference"
+            )
+        if (
+            document.labels.get("io.queryplanner.adk.repository") == repository
+            and not project_references
+        ):
+            raise ImageRetentionError(
+                "labeled project image lacks a canonical digest reference"
+            )
+        selected = _managed_image(
+            document,
+            repository=repository,
+            image_repository=image_repository,
+            expected_source=expected_source,
+        )
+        if selected is None:
+            ambiguous_references.update(project_references)
+            continue
+        by_reference = _inspect_image(docker, selected.reference, environment)
+        if by_reference is None:
+            raise ImageRetentionError("managed image reference disappeared")
+        confirmed = _managed_image(
+            by_reference,
+            repository=repository,
+            image_repository=image_repository,
+            expected_source=expected_source,
+        )
+        if confirmed != selected:
+            raise ImageRetentionError(
+                "managed image identity changed during inspection"
+            )
+        existing = managed.get(selected.reference)
+        if existing is not None and existing != selected:
+            raise ImageRetentionError("managed image reference is ambiguous")
+        managed[selected.reference] = selected
+    for reference, owners in occupied_image_ids.items():
+        if len(owners) != 1:
+            ambiguous_references.add(reference)
+            managed.pop(reference, None)
+    ambiguous_references.update(set(occupied_image_ids) - set(managed))
+
+    container_ids = _identity_lines(
+        _run(
+            docker,
+            ["container", "ls", "--all", "--no-trunc", "--quiet"],
+            environment=environment,
+        ).stdout,
+        _CONTAINER_ID,
+        "container",
+    )
+    used_image_ids: set[str] = set()
+    for container_id in container_ids:
+        result = _run(
+            docker,
+            ["container", "inspect", container_id],
+            environment=environment,
+        )
+        container_document = _decode_single_document(result.stdout, "container")
+        full_id = container_document.get("Id")
+        container_image_id = container_document.get("Image")
+        mounts = container_document.get("Mounts")
+        if (
+            not isinstance(full_id, str)
+            or full_id != container_id
+            or _CONTAINER_ID.fullmatch(full_id) is None
+            or not isinstance(container_image_id, str)
+            or _IMAGE_ID.fullmatch(container_image_id) is None
+            or not isinstance(mounts, list)
+        ):
+            raise ImageRetentionError("Docker container identity is invalid")
+        used_image_ids.add(container_image_id)
+        image_mount_selectors: list[str] = []
+        for mount in mounts:
+            if not isinstance(mount, dict):
+                raise ImageRetentionError("Docker container mount is invalid")
+            if mount.get("Type") != "image":
+                continue
+            image_mount_selectors.append(_image_mount_selector(mount.get("Name")))
+        for selector in sorted(set(image_mount_selectors)):
+            mounted = _inspect_image(docker, selector, environment)
+            if mounted is None:
+                raise ImageRetentionError("Docker image mount is unavailable")
+            if (
+                selector not in mounted.repo_digests
+                or observed_images.get(mounted.image_id) != mounted
+            ):
+                raise ImageRetentionError("Docker image mount identity is ambiguous")
+            used_image_ids.add(mounted.image_id)
+    return (
+        managed,
+        frozenset(used_image_ids),
+        frozenset(local_digest_references),
+        frozenset(ambiguous_references),
+    )
+
+
+def _recorded_generations(
+    transaction: DeploymentStateTransaction,
+) -> tuple[
+    dict[str, _RecordedGeneration],
+    tuple[str, ...],
+]:
+    if transaction.pending() is not None:
+        raise ImageRetentionError("image retention is blocked by pending recovery")
+    if transaction.recovered_terminal() is not None:
+        raise ImageRetentionError("image retention requires a fresh recovery check")
+
+    journal = transaction.journal()
+    current = transaction.current()
+    recorded: dict[str, _RecordedGeneration] = {}
+    for entry in journal:
+        if entry.event not in {"adopted", "promoted"}:
+            continue
+        if entry.state is None:  # pragma: no cover - state loader invariant
+            raise ImageRetentionError("deployment generation state is unavailable")
+        reference = entry.state.image_reference
+        existing = recorded.get(reference)
+        if existing is not None and (
+            existing.state.image_id != entry.state.image_id
+            or existing.state.oci_revision != entry.state.oci_revision
+            or existing.state.source_revision != entry.state.source_revision
+        ):
+            raise ImageRetentionError("recorded image generation identity conflicts")
+        recorded[reference] = _RecordedGeneration(
+            state=entry.state,
+            last_sequence=entry.sequence,
+        )
+
+    if current is None:
+        if recorded:  # pragma: no cover - current is reconciled from this journal
+            raise ImageRetentionError("deployment current state is unavailable")
+        return recorded, ()
+
+    index = current.journal_sequence - 1
+    if index < 0 or index >= len(journal):  # pragma: no cover - state invariant
+        raise ImageRetentionError("deployment current journal anchor is invalid")
+    anchor = journal[index]
+    if (  # pragma: no cover - current is reconciled from this exact entry
+        anchor.event not in {"adopted", "promoted"}
+        or anchor.sha256 != current.journal_sha256
+        or anchor.state != current.state
+    ):
+        raise ImageRetentionError("deployment current journal anchor does not match")
+
+    selected = [current.state.image_reference]
+    seen = set(selected)
+    for entry in reversed(journal[:index]):
+        if entry.event not in {"adopted", "promoted"}:
+            continue
+        if entry.state is None:  # pragma: no cover - state loader invariant
+            raise ImageRetentionError("deployment generation state is unavailable")
+        reference = entry.state.image_reference
+        if reference in seen:
+            continue
+        selected.append(reference)
+        seen.add(reference)
+        if len(selected) == 3:
+            break
+    return recorded, tuple(selected)
+
+
+def plan_image_retention(
+    transaction: DeploymentStateTransaction,
+    *,
+    docker: Path,
+    environment: Mapping[str, str],
+    repository: str,
+    target_reference: str,
+    image_repository: str | None = None,
+) -> RetentionPlan:
+    """Plan exact deletions while an existing state transaction holds its lock."""
+    image_repository, expected_source = _validated_identity(
+        repository,
+        target_reference,
+        image_repository,
+    )
+    selected_docker = _validated_docker(docker)
+    recorded, generations = _recorded_generations(transaction)
+    (
+        managed,
+        used_image_ids,
+        local_digest_references,
+        ambiguous_references,
+    ) = _local_inventory(
+        docker=selected_docker,
+        environment=environment,
+        repository=repository,
+        image_repository=image_repository,
+        expected_source=expected_source,
+    )
+    for reference, generation in recorded.items():
+        image = managed.get(reference)
+        if image is not None and (
+            image.image_id != generation.state.image_id
+            or image.oci_revision != generation.state.oci_revision
+        ):
+            raise ImageRetentionError(
+                "local image does not match its recorded generation"
+            )
+
+    target_document = _inspect_image(selected_docker, target_reference, environment)
+    target_present = target_document is not None
+    if target_document is not None:
+        target = _managed_image(
+            target_document,
+            repository=repository,
+            image_repository=image_repository,
+            expected_source=expected_source,
+        )
+        if target is None or managed.get(target_reference) != target:
+            raise ImageRetentionError("local target image is not exactly managed")
+
+    protected = set(generations)
+    protected.add(target_reference)
+    protected.update(ambiguous_references)
+    protected.update(
+        image.reference
+        for image in managed.values()
+        if image.image_id in used_image_ids
+    )
+    missing_generations = tuple(
+        reference
+        for reference in generations
+        if reference not in local_digest_references
+    )
+    reserved = 0 if target_present else 1
+    occupied_references = frozenset(
+        reference
+        for reference in local_digest_references
+        if reference.startswith(f"{image_repository}@")
+    )
+    required = max(
+        0,
+        len(occupied_references) + reserved - MAX_MANAGED_REFERENCES,
+    )
+
+    unrecorded = sorted(
+        (
+            image
+            for image in managed.values()
+            if image.reference not in recorded and image.reference not in protected
+        ),
+        key=lambda image: image.reference,
+    )
+    historical = sorted(
+        (
+            image
+            for image in managed.values()
+            if image.reference in recorded and image.reference not in protected
+        ),
+        key=lambda image: (
+            recorded[image.reference].last_sequence,
+            image.reference,
+        ),
+    )
+    candidates = (*unrecorded, *historical)
+    if required > len(candidates):
+        raise ImageRetentionError(
+            "managed image ceiling is unreachable without protected references"
+        )
+    deletions = tuple(image.reference for image in candidates[:required])
+    deletion_set = set(deletions)
+    current_reference = None if not generations else generations[0]
+    prior_references = set(generations[1:])
+    container_references = {
+        image.reference
+        for image in managed.values()
+        if image.image_id in used_image_ids
+    }
+    decisions: list[ReferenceDecision] = []
+    for reference in sorted(occupied_references):
+        image = managed.get(reference)
+        if reference in deletion_set:
+            reason = (
+                "planned_historical_deletion"
+                if reference in recorded
+                else "planned_unrecorded_deletion"
+            )
+            decisions.append(
+                ReferenceDecision(
+                    reference=reference,
+                    action="delete",
+                    reasons=(reason,),
+                    image_id=None if image is None else image.image_id,
+                )
+            )
+            continue
+        reasons: list[str] = []
+        if reference == target_reference:
+            reasons.append("requested_target")
+        if reference == current_reference:
+            reasons.append("current_generation")
+        elif reference in prior_references:
+            reasons.append("prior_generation")
+        if reference in container_references:
+            reasons.append("container_use")
+        if reference in ambiguous_references:
+            reasons.append("ambiguous_ownership")
+        if not reasons:
+            reasons.append("available_capacity")
+        decisions.append(
+            ReferenceDecision(
+                reference=reference,
+                action="keep",
+                reasons=tuple(reasons),
+                image_id=None if image is None else image.image_id,
+            )
+        )
+    return RetentionPlan(
+        repository=repository,
+        target_reference=target_reference,
+        target_present=target_present,
+        reserved_references=reserved,
+        occupied_references=tuple(sorted(occupied_references)),
+        ambiguous_references=tuple(sorted(ambiguous_references)),
+        managed_references=tuple(
+            sorted(managed.values(), key=lambda image: image.reference)
+        ),
+        protected_references=tuple(sorted(protected)),
+        missing_generation_references=missing_generations,
+        delete_references=deletions,
+        reference_decisions=tuple(decisions),
+    )
+
+
+def enforce_pull_admission(
+    transaction: DeploymentStateTransaction,
+    *,
+    docker: Path,
+    environment: Mapping[str, str],
+    repository: str,
+    target_reference: str,
+    image_repository: str | None = None,
+) -> RetentionPlan:
+    """Repeat read-only pull admission while the promotion lock is held."""
+    plan = plan_image_retention(
+        transaction,
+        docker=docker,
+        environment=environment,
+        repository=repository,
+        target_reference=target_reference,
+        image_repository=image_repository,
+    )
+    if not plan.admitted:
+        raise ImageRetentionError("managed image capacity is not admitted")
+    return plan
+
+
+def _delete_image(
+    image: ManagedImage,
+    *,
+    docker: Path,
+    environment: Mapping[str, str],
+    repository: str,
+    image_repository: str,
+    expected_source: str,
+) -> None:
+    current = _inspect_image(docker, image.reference, environment)
+    confirmed = (
+        None
+        if current is None
+        else _managed_image(
+            current,
+            repository=repository,
+            image_repository=image_repository,
+            expected_source=expected_source,
+        )
+    )
+    if confirmed != image:
+        raise ImageRetentionError("managed image changed before exact removal")
+    _run(
+        docker,
+        ["image", "rm", "--no-prune", image.reference],
+        environment=environment,
+    )
+    remaining_reference = _inspect_image(docker, image.reference, environment)
+    remaining_image = _inspect_image(docker, image.image_id, environment)
+    if remaining_reference is not None or remaining_image is not None:
+        raise ImageRetentionError("managed image remained after exact removal")
+
+
+def apply_image_retention(
+    transaction: DeploymentStateTransaction,
+    *,
+    docker: Path,
+    environment: Mapping[str, str],
+    repository: str,
+    target_reference: str,
+    image_repository: str | None = None,
+) -> tuple[RetentionPlan, bool, tuple[ReferenceDecision, ...]]:
+    """Apply at most one deterministic five-reference retention batch."""
+    initial = plan_image_retention(
+        transaction,
+        docker=docker,
+        environment=environment,
+        repository=repository,
+        target_reference=target_reference,
+        image_repository=image_repository,
+    )
+    if initial.admitted:
+        return initial, True, ()
+    image_repository, expected_source = _validated_identity(
+        repository,
+        target_reference,
+        image_repository,
+    )
+    selected_docker = _validated_docker(docker)
+    removed_decisions: list[ReferenceDecision] = []
+    for delete_index in range(MAX_DELETIONS_PER_INVOCATION):
+        current = plan_image_retention(
+            transaction,
+            docker=selected_docker,
+            environment=environment,
+            repository=repository,
+            target_reference=target_reference,
+            image_repository=image_repository,
+        )
+        if current.admitted:
+            return current, True, tuple(removed_decisions)
+        expected = initial.delete_references[delete_index : delete_index + 1]
+        if current.delete_references[:1] != expected:
+            raise ImageRetentionError(
+                "managed image deletion order changed before exact removal"
+            )
+        indexed = {image.reference: image for image in current.managed_references}
+        reference = current.delete_references[0]
+        decision = next(
+            decision
+            for decision in current.reference_decisions
+            if decision.reference == reference
+        )
+        _delete_image(
+            indexed[reference],
+            docker=selected_docker,
+            environment=environment,
+            repository=repository,
+            image_repository=image_repository,
+            expected_source=expected_source,
+        )
+        removed_decisions.append(decision)
+    final = plan_image_retention(
+        transaction,
+        docker=selected_docker,
+        environment=environment,
+        repository=repository,
+        target_reference=target_reference,
+        image_repository=image_repository,
+    )
+    return final, final.admitted, tuple(removed_decisions)
+
+
+def _command_environment(source: Mapping[str, str]) -> dict[str, str]:
+    selected = {
+        name: source[name] for name in _HOST_ENVIRONMENT_NAMES if name in source
+    }
+    selected.update({"LANG": "C", "LC_ALL": "C"})
+    return selected
+
+
+def _resolved_docker(environment: Mapping[str, str]) -> Path:
+    selected = shutil.which("docker", path=environment.get("PATH"))
+    if selected is None:
+        raise ImageRetentionError("Docker executable is unavailable")
+    return _validated_docker(Path(selected).resolve(strict=True))
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="deployment-retention",
+        description="Plan or enforce exact VM image-reference retention.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    enforce = subparsers.add_parser("enforce")
+    enforce.add_argument("--state-dir", type=Path, required=True)
+    enforce.add_argument("--repository", required=True)
+    enforce.add_argument("--target-reference", required=True)
+    enforce.add_argument("--apply", action="store_true")
+    return parser
+
+
+def _emit(document: Mapping[str, object]) -> None:
+    print(
+        json.dumps(
+            document,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    )
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    environment: Mapping[str, str] | None = None,
+) -> int:
+    """Run the image-retention CLI and return a stable process status."""
+    arguments = _parser().parse_args(argv)
+    source = os.environ if environment is None else environment
+    command_environment = _command_environment(source)
+    try:
+        docker = _resolved_docker(command_environment)
+        store = DeploymentStateStore(arguments.state_dir)
+        with store.transaction() as transaction:
+            if not arguments.apply:
+                plan = plan_image_retention(
+                    transaction,
+                    docker=docker,
+                    environment=command_environment,
+                    repository=arguments.repository,
+                    target_reference=arguments.target_reference,
+                    image_repository=None,
+                )
+                _emit(plan.as_document(status="dry-run"))
+                return 0
+            plan, admitted, removed_decisions = apply_image_retention(
+                transaction,
+                docker=docker,
+                environment=command_environment,
+                repository=arguments.repository,
+                target_reference=arguments.target_reference,
+                image_repository=None,
+            )
+            document = plan.as_document(
+                status="admitted" if admitted else "incomplete",
+            )
+            document["removed_reference_decisions"] = [
+                decision.as_document() for decision in removed_decisions
+            ]
+            _emit(document)
+            return 0 if admitted else INCOMPLETE_EXIT_STATUS
+    except DeploymentLockBusyError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 75
+    except (DeploymentStateError, ImageRetentionError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    except OSError:
+        print("ERROR: image-retention host operation failed", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/deployment_promotion_runtime_driver.py
+++ b/tests/deployment_promotion_runtime_driver.py
@@ -1,0 +1,56 @@
+"""Test-only clean-process driver for the private Docker registry proof."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Sequence
+
+from agent.deployment_promotion import main as promotion_main
+
+REPOSITORY = "QueryPlanner/google-adk-on-bare-metal"
+EXPECTED_ORIGIN = "https://github.com/QueryPlanner/google-adk-on-bare-metal"
+_LOCAL_IMAGE_REPOSITORY = re.compile(
+    r"127\.0\.0\.1:(?P<port>[0-9]{1,5})/"
+    r"adk-promotion-[a-z0-9][a-z0-9-]{0,23}-[0-9a-f]{16}/agent\Z"
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Drive promotion against one loopback-only test registry.",
+    )
+    parser.add_argument("--image-repository", required=True)
+    parser.add_argument("--expected-origin", required=True, choices=(EXPECTED_ORIGIN,))
+    parser.add_argument("--repository", required=True, choices=(REPOSITORY,))
+    parser.add_argument("promotion_arguments", nargs=argparse.REMAINDER)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Validate the isolated test seam and preserve production status handling."""
+    arguments = _parser().parse_args(sys.argv[1:] if argv is None else argv)
+    match = _LOCAL_IMAGE_REPOSITORY.fullmatch(arguments.image_repository)
+    if match is None or not 1 <= int(match.group("port")) <= 65535:
+        raise SystemExit("image repository must use the isolated loopback registry")
+    if (
+        not arguments.promotion_arguments
+        or arguments.promotion_arguments[0] != "promote"
+    ):
+        raise SystemExit("the runtime driver only supports promotion")
+    return promotion_main(
+        [
+            "promote",
+            "--expected-origin",
+            arguments.expected_origin,
+            "--repository",
+            arguments.repository,
+            *arguments.promotion_arguments[1:],
+        ],
+        _image_repository=arguments.image_repository,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_compose_workflow.py
+++ b/tests/test_compose_workflow.py
@@ -245,7 +245,7 @@ def test_workflow_checkout_is_immutable_and_drops_credentials() -> None:
     document = WORKFLOW_PATH.read_text(encoding="utf-8")
     checkout_uses = list(CHECKOUT_USES_PATTERN.finditer(document))
 
-    assert len(checkout_uses) == 5
+    assert len(checkout_uses) == 6
     for checkout_use in checkout_uses:
         checkout_reference = checkout_use.group("reference")
         assert re.fullmatch(r"[0-9a-f]{40}", checkout_reference)
@@ -254,7 +254,7 @@ def test_workflow_checkout_is_immutable_and_drops_credentials() -> None:
     assert {match.group("reference") for match in checkout_uses} == {
         "3d3c42e5aac5ba805825da76410c181273ba90b1"
     }
-    assert document.count("persist-credentials: false") == 5
+    assert document.count("persist-credentials: false") == 6
     assert "secrets." not in document
     assert "packages: write" not in document
     assert "docker/login-action" not in document

--- a/tests/test_deployment_promotion.py
+++ b/tests/test_deployment_promotion.py
@@ -39,9 +39,11 @@ TARGET_REVISION = "b" * 40
 OLD_IMAGE_ID = f"sha256:{'c' * 64}"
 TARGET_IMAGE_ID = f"sha256:{'d' * 64}"
 MANUAL_IMAGE_ID = f"sha256:{'9' * 64}"
-OLD_IMAGE = f"ghcr.io/queryplanner/agent@sha256:{'e' * 64}"
-TARGET_IMAGE = f"ghcr.io/queryplanner/agent@sha256:{'f' * 64}"
-MANUAL_IMAGE = f"ghcr.io/queryplanner/agent@sha256:{'8' * 64}"
+REPOSITORY = "QueryPlanner/google-adk-on-bare-metal"
+IMAGE_REPOSITORY = "ghcr.io/queryplanner/google-adk-on-bare-metal"
+OLD_IMAGE = f"{IMAGE_REPOSITORY}@sha256:{'e' * 64}"
+TARGET_IMAGE = f"{IMAGE_REPOSITORY}@sha256:{'f' * 64}"
+MANUAL_IMAGE = f"{IMAGE_REPOSITORY}@sha256:{'8' * 64}"
 OLD_CONTAINER = "1" * 64
 TARGET_CONTAINER = "2" * 64
 CANDIDATE_CONTAINER = "3" * 64
@@ -85,6 +87,30 @@ def _private(path: Path, payload: bytes) -> Path:
     return path
 
 
+def _retention_image(seed: str) -> dict[str, object]:
+    reference = f"{IMAGE_REPOSITORY}@sha256:{seed * 64}"
+    return {
+        "Id": f"sha256:{seed * 64}",
+        "RepoDigests": [reference],
+        "RepoTags": [],
+        "Config": {
+            "Labels": {
+                "io.queryplanner.adk.repository": REPOSITORY,
+                "org.opencontainers.image.revision": seed * 40,
+                "org.opencontainers.image.source": ORIGIN,
+            }
+        },
+    }
+
+
+def _file_snapshot(root: Path) -> dict[str, bytes]:
+    return {
+        str(path.relative_to(root)): path.read_bytes()
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
 @dataclass
 class Host:
     """Stateful fake for only the Git and Docker process boundaries."""
@@ -110,6 +136,9 @@ class Host:
     log: list[tuple[str, ...]] = field(default_factory=list)
     pending_seen_before_mutation: bool = False
     lease_probe: Path | None = None
+    target_local: bool = False
+    target_repository_label: str = REPOSITORY
+    retention_images: dict[str, dict[str, object]] = field(default_factory=dict)
 
     def executable(self, name: str) -> str:
         return str(self.bin_dir / name)
@@ -198,21 +227,41 @@ class Host:
 
     def _image_document(self, selector: str) -> dict[str, object]:
         if selector in {TARGET_IMAGE, TARGET_IMAGE_ID}:
+            if not self.target_local:
+                raise KeyError(selector)
             return {
                 "Id": TARGET_IMAGE_ID,
                 "RepoDigests": [TARGET_IMAGE],
+                "RepoTags": [],
                 "Config": {
-                    "Labels": {"org.opencontainers.image.revision": TARGET_REVISION}
+                    "Labels": {
+                        "io.queryplanner.adk.repository": (
+                            self.target_repository_label
+                        ),
+                        "org.opencontainers.image.revision": TARGET_REVISION,
+                        "org.opencontainers.image.source": ORIGIN,
+                    }
                 },
             }
         if selector in {OLD_IMAGE, OLD_IMAGE_ID}:
             return {
                 "Id": OLD_IMAGE_ID,
                 "RepoDigests": [OLD_IMAGE],
+                "RepoTags": [],
                 "Config": {
-                    "Labels": {"org.opencontainers.image.revision": OLD_REVISION}
+                    "Labels": {
+                        "io.queryplanner.adk.repository": REPOSITORY,
+                        "org.opencontainers.image.revision": OLD_REVISION,
+                        "org.opencontainers.image.source": ORIGIN,
+                    }
                 },
             }
+        for document in self.retention_images.values():
+            repo_digests = document.get("RepoDigests")
+            if selector == document.get("Id") or (
+                isinstance(repo_digests, list) and selector in repo_digests
+            ):
+                return document
         raise AssertionError(selector)
 
     def _container_document(
@@ -289,12 +338,40 @@ class Host:
         environment: dict[str, str],
     ) -> subprocess.CompletedProcess[str]:
         tail = args[1:]
+        if tail == ["image", "ls", "--all", "--no-trunc", "--quiet"]:
+            image_ids = [OLD_IMAGE_ID, *sorted(self.retention_images)]
+            if self.target_local:
+                image_ids.append(TARGET_IMAGE_ID)
+            return self.completed(
+                args, stdout="".join(f"{item}\n" for item in image_ids)
+            )
         if tail[:2] == ["image", "pull"]:
+            self.target_local = True
             return self.completed(args, stdout=f"{tail[2]}\n")
         if tail[:2] == ["image", "inspect"]:
+            try:
+                document = self._image_document(tail[2])
+            except KeyError:
+                return self.completed(
+                    args,
+                    returncode=1,
+                    stdout="[]\n",
+                    stderr=(f"Error response from daemon: No such image: {tail[2]}\n"),
+                )
+            return self.completed(args, stdout=json.dumps([document]))
+        if tail == ["container", "ls", "--all", "--no-trunc", "--quiet"]:
+            container_ids: list[str] = []
+            if self.production_exists:
+                container_ids.append(
+                    TARGET_CONTAINER
+                    if self.production_image == TARGET_IMAGE
+                    else OLD_CONTAINER
+                )
+            if self.candidate_exists:
+                container_ids.append(CANDIDATE_CONTAINER)
             return self.completed(
                 args,
-                stdout=json.dumps([self._image_document(tail[2])]),
+                stdout="".join(f"{item}\n" for item in container_ids),
             )
         if tail[:2] == ["container", "ls"]:
             project_filter = next(
@@ -426,6 +503,7 @@ def setup(
         checkout=checkout,
         release_checkout=release,
         expected_origin=ORIGIN,
+        repository=REPOSITORY,
         compose_project=PROJECT,
         compose_service=SERVICE,
         source_revision=TARGET_REVISION,
@@ -461,6 +539,8 @@ def _argv(config: PromotionConfig) -> list[str]:
         str(config.release_checkout),
         "--expected-origin",
         config.expected_origin,
+        "--repository",
+        config.repository,
         "--compose-project",
         config.compose_project,
         "--compose-service",
@@ -496,6 +576,7 @@ def _pending(
     cutover_started: bool = True,
 ) -> None:
     _initialize(host, config)
+    host.target_local = True
     target_env = _private(
         config.state_dir.parent / "target-input.env",
         b'TARGET="yes"\n',
@@ -547,6 +628,7 @@ def _fresh_pending(
 ) -> None:
     host.production_exists = False
     host.volume_exists = False
+    host.target_local = True
     (host.checkout / ".env").unlink()
     target_env = _private(
         config.state_dir.parent / "fresh-target-input.env",
@@ -636,6 +718,74 @@ def test_candidate_failure_leaves_every_production_identity_untouched(
     assert DeploymentStateStore(config.state_dir).read_journal() == before_journal
     assert not config.state_dir.joinpath("pending.json").exists()
     assert not host.candidate_exists
+
+
+def test_capacity_race_blocks_before_pull_or_deployment_mutation(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    host, config, environment = setup
+    _initialize(host, config)
+    host.retention_images.update(
+        {f"sha256:{seed * 64}": _retention_image(seed) for seed in "0123456"}
+    )
+    state_before = _file_snapshot(config.state_dir)
+    environment_before = (host.checkout / ".env").read_bytes()
+    runtime_before = host._container_document(candidate=False)
+    production_revision_before = host.production_revision
+    commands_before = len(host.log)
+
+    assert main(_argv(config), environment) == 1
+
+    assert "image-retention admission failed" in capsys.readouterr().err
+    assert _file_snapshot(config.state_dir) == state_before
+    assert (host.checkout / ".env").read_bytes() == environment_before
+    assert host._container_document(candidate=False) == runtime_before
+    assert host.production_revision == production_revision_before
+    assert not host.candidate_exists
+    later = host.log[commands_before:]
+    assert any(command[1:3] == ("image", "ls") for command in later)
+    assert not any(
+        command[1:3]
+        in {
+            ("image", "pull"),
+            ("image", "rm"),
+            ("container", "rm"),
+        }
+        or "compose" in command
+        or "checkout" in command
+        for command in later
+    )
+
+
+def test_post_pull_retention_proof_rejects_unmanaged_target(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    host, config, environment = setup
+    _initialize(host, config)
+    host.target_repository_label = "Other/repository"
+    state_before = _file_snapshot(config.state_dir)
+    environment_before = (host.checkout / ".env").read_bytes()
+    runtime_before = host._container_document(candidate=False)
+    commands_before = len(host.log)
+
+    assert main(_argv(config), environment) == 1
+
+    assert "local target image is not exactly managed" in capsys.readouterr().err
+    assert host.target_local
+    assert _file_snapshot(config.state_dir) == state_before
+    assert (host.checkout / ".env").read_bytes() == environment_before
+    assert host._container_document(candidate=False) == runtime_before
+    assert not host.candidate_exists
+    later = host.log[commands_before:]
+    assert sum(command[1:3] == ("image", "pull") for command in later) == 1
+    assert not any(
+        command[1:3] in {("image", "rm"), ("container", "rm")}
+        or "compose" in command
+        or "checkout" in command
+        for command in later
+    )
 
 
 def test_post_cutover_failure_restores_and_records_rollback(
@@ -960,6 +1110,7 @@ def test_pending_fresh_install_is_aborted_and_requires_rerun(
     host, config, environment = setup
     host.production_exists = False
     host.volume_exists = False
+    host.target_local = True
     (host.checkout / ".env").unlink()
     target_env = _private(
         config.state_dir.parent / "fresh-target-input.env",
@@ -1279,6 +1430,31 @@ def test_cli_surface_and_fixed_environment_allowlist(
 
     assert tuple(SECRETS) == PRODUCTION_ENVIRONMENT_NAMES
     assert main(_argv(config), environment) == 0
+
+
+def test_internal_image_repository_override_is_not_a_cli_option(
+    setup: tuple[Host, PromotionConfig, dict[str, str]],
+) -> None:
+    """Exercise the test seam while keeping it absent from production argv."""
+    host, config, environment = setup
+    _initialize(host, config)
+    image_repository = f"ghcr.io/{config.repository.lower()}"
+
+    assert (
+        main(
+            _argv(config),
+            environment,
+            _image_repository=image_repository,
+        )
+        == 0
+    )
+
+    with pytest.raises(SystemExit) as error:
+        main(
+            [*_argv(config), "--image-repository", image_repository],
+            environment,
+        )
+    assert error.value.code == 2
 
 
 def test_cli_reads_exact_production_environment_from_bounded_stdin(
@@ -1610,10 +1786,23 @@ def test_explicit_adoption_happens_before_promotion(
     [
         ("state_dir", Path("relative"), "absolute normalized"),
         ("expected_origin", f"{ORIGIN}.git", "expected origin"),
+        ("repository", "invalid", "GitHub repository"),
+        ("repository", "Other/repository", "GitHub repository"),
+        ("image_repository", "invalid repository", "image repository identity"),
+        (
+            "image_repository",
+            "registry.example/other/agent",
+            "repository does not match",
+        ),
         ("compose_project", "UPPER", "Compose project"),
         ("compose_service", "bad.name", "Compose service"),
         ("source_revision", "a" * 39, "source revision"),
         ("image_reference", "agent:latest", "immutable digest"),
+        (
+            "image_reference",
+            f"ghcr.io/queryplanner/other@sha256:{'7' * 64}",
+            "repository does not match",
+        ),
     ],
 )
 def test_invalid_controller_inputs_fail_before_external_mutation(
@@ -1630,6 +1819,10 @@ def test_invalid_controller_inputs_fail_before_external_mutation(
         assert isinstance(value, str)
         if field == "expected_origin":
             changed = replace(config, expected_origin=value)
+        elif field == "repository":
+            changed = replace(config, repository=value)
+        elif field == "image_repository":
+            changed = replace(config, image_repository=value)
         elif field == "compose_project":
             changed = replace(config, compose_project=value)
         elif field == "compose_service":

--- a/tests/test_deployment_promotion_runtime.py
+++ b/tests/test_deployment_promotion_runtime.py
@@ -1157,6 +1157,11 @@ def _push_exact_image(
         environment=environment,
         timeout=30,
     )
+    _run(
+        [docker, "image", "pull", exact_reference],
+        environment=environment,
+        timeout=180,
+    )
     exact_document = _image_identity(docker, environment, exact_reference)
     assert exact_document.get("Id") == source_image_id
     assert exact_document.get("RepoDigests") == [exact_reference]
@@ -2001,6 +2006,87 @@ def _assert_safe_output(result: subprocess.CompletedProcess[str]) -> None:
             for stream in (result.stdout, result.stderr)
         ):
             raise AssertionError("promotion output exposed a private canary")
+
+
+def test_pushed_fixture_is_rehydrated_by_immutable_digest() -> None:
+    """Pull the digest after removing the fixture's final mutable tags."""
+    source_image_id = f"sha256:{'a' * 64}"
+    source_tag = "fixture-source:phase"
+    image_repository = "127.0.0.1:49152/adk-promotion-proof-0123456789abcdef/agent"
+    repository_tag = f"{image_repository}:phase"
+    exact_reference = f"{image_repository}@sha256:{'b' * 64}"
+    cleanup_targets: list[CleanupTarget] = []
+    runner = create_autospec(
+        _run,
+        spec_set=True,
+        side_effect=[
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+            subprocess.CompletedProcess(
+                [],
+                0,
+                stdout=json.dumps(
+                    [
+                        {
+                            "Id": source_image_id,
+                            "RepoDigests": [exact_reference],
+                            "RepoTags": [source_tag, repository_tag],
+                        }
+                    ]
+                ),
+                stderr="",
+            ),
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+            subprocess.CompletedProcess(
+                [],
+                0,
+                stdout=json.dumps(
+                    [
+                        {
+                            "Id": source_image_id,
+                            "RepoDigests": [exact_reference],
+                            "RepoTags": [],
+                        }
+                    ]
+                ),
+                stderr="",
+            ),
+        ],
+    )
+
+    with patch(f"{__name__}._run", runner):
+        result = _push_exact_image(
+            "docker",
+            {},
+            cleanup_targets,
+            source_image_id=source_image_id,
+            source_tag=source_tag,
+            repository_tag=repository_tag,
+        )
+
+    assert result == exact_reference
+    assert cleanup_targets == [
+        CleanupTarget(
+            kind="image",
+            reference=repository_tag,
+            expected_id=source_image_id,
+        ),
+        CleanupTarget(
+            kind="image",
+            reference=exact_reference,
+            expected_id=source_image_id,
+        ),
+    ]
+    commands = [call.args[0] for call in runner.call_args_list]
+    assert commands[4:] == [
+        ["docker", "image", "rm", repository_tag],
+        ["docker", "image", "rm", source_tag],
+        ["docker", "image", "pull", exact_reference],
+        ["docker", "image", "inspect", exact_reference],
+    ]
 
 
 def test_runtime_redaction_covers_embedded_byte_representations() -> None:

--- a/tests/test_deployment_promotion_runtime.py
+++ b/tests/test_deployment_promotion_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import importlib.util
 import json
 import os
 import re
@@ -18,6 +19,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from functools import partial
 from pathlib import Path
+from types import ModuleType
 from typing import Literal
 from unittest.mock import create_autospec, patch
 from urllib.error import URLError
@@ -35,6 +37,9 @@ from agent.deployment_state import DeploymentStateStore
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 CANDIDATE_COMPOSE_PATH = REPOSITORY_ROOT / "compose.candidate.yaml"
 PROMOTION_MODULE_PATH = REPOSITORY_ROOT / "src" / "agent" / "deployment_promotion.py"
+PROMOTION_RUNTIME_DRIVER_PATH = (
+    REPOSITORY_ROOT / "tests" / "deployment_promotion_runtime_driver.py"
+)
 RUN_ENVIRONMENT_NAME = "RUN_DEPLOYMENT_PROMOTION_INTEGRATION"
 PREFIX_ENVIRONMENT_NAME = "DEPLOYMENT_PROMOTION_TEST_PREFIX"
 PREFIX_PATTERN = re.compile(r"adk-promotion-[a-z0-9][a-z0-9-]{0,23}\Z")
@@ -44,7 +49,8 @@ IMAGE_REFERENCE_PATTERN = re.compile(
     r"127\.0\.0\.1:[0-9]+/[a-z0-9-]+/agent@sha256:[0-9a-f]{64}\Z"
 )
 CONTAINER_ID_PATTERN = re.compile(r"[0-9a-f]{64}\Z")
-EXPECTED_ORIGIN = "https://github.com/QueryPlanner/google-adk-on-bare-metal"
+GITHUB_REPOSITORY = "QueryPlanner/google-adk-on-bare-metal"
+EXPECTED_ORIGIN = f"https://github.com/{GITHUB_REPOSITORY}"
 REGISTRY_IMAGE_REFERENCE = (
     "registry@sha256:1be55279f18a2fe1a74edf2664cac61c1bea305b7b4642dab412e7affdcb3e33"
 )
@@ -67,6 +73,21 @@ CANDIDATE_FAILURE_BOUND_SECONDS = 180
 OWNER_LABEL = "io.queryplanner.adk.promotion-test.owner"
 
 type DockerResourceKind = Literal["container", "image", "network", "volume"]
+
+
+def _load_runtime_driver() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "deployment_promotion_runtime_driver",
+        PROMOTION_RUNTIME_DRIVER_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise AssertionError("runtime driver could not be loaded")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+PROMOTION_RUNTIME_DRIVER = _load_runtime_driver()
 
 
 @dataclass
@@ -144,6 +165,8 @@ USER root
 COPY promotion-wrapper.sh /usr/local/bin/promotion-wrapper
 RUN chmod 0755 /usr/local/bin/promotion-wrapper
 LABEL org.opencontainers.image.revision="${SOURCE_REVISION}"
+LABEL org.opencontainers.image.source="https://github.com/QueryPlanner/google-adk-on-bare-metal"
+LABEL io.queryplanner.adk.repository="QueryPlanner/google-adk-on-bare-metal"
 USER app
 ENTRYPOINT ["/usr/local/bin/promotion-wrapper"]
 # Docker clears an inherited CMD when a child image sets ENTRYPOINT.
@@ -1079,6 +1102,7 @@ def _push_exact_image(
     cleanup_targets: list[CleanupTarget],
     *,
     source_image_id: str,
+    source_tag: str,
     repository_tag: str,
 ) -> str:
     _assert_image_reference_absent(
@@ -1123,6 +1147,20 @@ def _push_exact_image(
     exact_reference = matching[0]
     assert IMAGE_REFERENCE_PATTERN.fullmatch(exact_reference)
     exact_cleanup.reference = exact_reference
+    _run(
+        [docker, "image", "rm", repository_tag],
+        environment=environment,
+        timeout=30,
+    )
+    _run(
+        [docker, "image", "rm", source_tag],
+        environment=environment,
+        timeout=30,
+    )
+    exact_document = _image_identity(docker, environment, exact_reference)
+    assert exact_document.get("Id") == source_image_id
+    assert exact_document.get("RepoDigests") == [exact_reference]
+    assert exact_document.get("RepoTags") == []
     return exact_reference
 
 
@@ -1239,13 +1277,19 @@ def _promotion_cli(
     project: str,
     revision: str,
     image_reference: str,
+    image_repository: str,
     adopt_existing: bool,
     check: bool = True,
 ) -> subprocess.CompletedProcess[str]:
     command = [
         sys.executable,
-        "-m",
-        "agent.deployment_promotion",
+        str(PROMOTION_RUNTIME_DRIVER_PATH),
+        "--image-repository",
+        image_repository,
+        "--expected-origin",
+        EXPECTED_ORIGIN,
+        "--repository",
+        GITHUB_REPOSITORY,
         "promote",
         "--state-dir",
         str(state_directory),
@@ -1253,8 +1297,6 @@ def _promotion_cli(
         str(checkout),
         "--release-checkout",
         str(release_checkout),
-        "--expected-origin",
-        EXPECTED_ORIGIN,
         "--compose-project",
         project,
         "--compose-service",
@@ -1272,6 +1314,133 @@ def _promotion_cli(
         check=check,
         timeout=360,
     )
+
+
+def test_runtime_driver_receives_exact_test_identity_and_repository(
+    tmp_path: Path,
+) -> None:
+    """Keep the non-GHCR seam confined to the loopback-only test driver."""
+    image_repository = (
+        "127.0.0.1:49152/adk-promotion-123456789012345678901234-0123456789abcdef/agent"
+    )
+    image_reference = f"{image_repository}@sha256:{'a' * 64}"
+    completed = subprocess.CompletedProcess([], 0, stdout="PROMOTED\n", stderr="")
+    runner = create_autospec(_run, spec_set=True, return_value=completed)
+
+    with patch(f"{__name__}._run", runner):
+        result = _promotion_cli(
+            {},
+            state_directory=tmp_path / "state",
+            checkout=tmp_path / "checkout",
+            release_checkout=tmp_path / "release",
+            project="adk-promotion-proof-prod",
+            revision="b" * 40,
+            image_reference=image_reference,
+            image_repository=image_repository,
+            adopt_existing=True,
+        )
+
+    assert result is completed
+    command = runner.call_args.args[0]
+    assert command[:2] == [sys.executable, str(PROMOTION_RUNTIME_DRIVER_PATH)]
+    assert command[2:8] == [
+        "--image-repository",
+        image_repository,
+        "--expected-origin",
+        EXPECTED_ORIGIN,
+        "--repository",
+        GITHUB_REPOSITORY,
+    ]
+    assert command[8] == "promote"
+    assert "--adopt-existing" in command
+    assert "-m" not in command
+
+
+def test_runtime_driver_accepts_maximum_generated_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Accept a long run ID plus the exact generated UUID suffix."""
+    image_repository = (
+        "127.0.0.1:49152/adk-promotion-123456789012345678901234-0123456789abcdef/agent"
+    )
+    promoter = create_autospec(
+        PROMOTION_RUNTIME_DRIVER.promotion_main,
+        spec_set=True,
+        return_value=0,
+    )
+    monkeypatch.setattr(
+        PROMOTION_RUNTIME_DRIVER,
+        "promotion_main",
+        promoter,
+    )
+
+    result = PROMOTION_RUNTIME_DRIVER.main(
+        [
+            "--image-repository",
+            image_repository,
+            "--expected-origin",
+            EXPECTED_ORIGIN,
+            "--repository",
+            GITHUB_REPOSITORY,
+            "promote",
+            "--state-dir",
+            "/private/test-state",
+        ]
+    )
+
+    assert result == 0
+    promoter.assert_called_once_with(
+        [
+            "promote",
+            "--expected-origin",
+            EXPECTED_ORIGIN,
+            "--repository",
+            GITHUB_REPOSITORY,
+            "--state-dir",
+            "/private/test-state",
+        ],
+        _image_repository=image_repository,
+    )
+
+
+@pytest.mark.parametrize(
+    "image_repository",
+    [
+        "registry.example/adk-promotion-proof-0123456789abcdef/agent",
+        "127.0.0.1:0/adk-promotion-proof-0123456789abcdef/agent",
+        "127.0.0.1:65536/adk-promotion-proof-0123456789abcdef/agent",
+        "127.0.0.1:49152/adk-promotion-proof/agent",
+    ],
+)
+def test_runtime_driver_rejects_nonisolated_repository(
+    monkeypatch: pytest.MonkeyPatch,
+    image_repository: str,
+) -> None:
+    """Reject any override outside the exact loopback fixture shape."""
+    promoter = create_autospec(
+        PROMOTION_RUNTIME_DRIVER.promotion_main,
+        spec_set=True,
+    )
+    monkeypatch.setattr(
+        PROMOTION_RUNTIME_DRIVER,
+        "promotion_main",
+        promoter,
+    )
+
+    with pytest.raises(SystemExit, match="isolated loopback registry"):
+        PROMOTION_RUNTIME_DRIVER.main(
+            [
+                "--image-repository",
+                image_repository,
+                "--expected-origin",
+                EXPECTED_ORIGIN,
+                "--repository",
+                GITHUB_REPOSITORY,
+                "promote",
+            ]
+        )
+
+    promoter.assert_not_called()
 
 
 def _container_document(
@@ -2332,15 +2501,22 @@ def test_real_docker_promotes_then_restores_exact_verified_baseline(
             base_environment,
             name=registry_name,
         )
+        image_repository = f"{registry_endpoint}/{repository_name}"
 
         references: dict[str, str] = {}
-        for phase in ("old", "good", "unhealthy", "failing"):
+        for phase, source_tag in (
+            ("old", old_tag),
+            ("good", good_tag),
+            ("unhealthy", unhealthy_tag),
+            ("failing", failing_tag),
+        ):
             references[phase] = _push_exact_image(
                 docker,
                 base_environment,
                 cleanup_targets,
                 source_image_id=release_images[phase],
-                repository_tag=(f"{registry_endpoint}/{repository_name}:{phase}"),
+                source_tag=source_tag,
+                repository_tag=f"{image_repository}:{phase}",
             )
         revisions = {
             "old": old_revision,
@@ -2349,16 +2525,24 @@ def test_real_docker_promotes_then_restores_exact_verified_baseline(
             "failing": failing_revision,
         }
         for phase, revision in revisions.items():
-            image_id, oci_revision, repo_digests = _release_image_identity(
-                _image_identity(
-                    docker,
-                    base_environment,
-                    references[phase],
-                )
+            image_document = _image_identity(
+                docker,
+                base_environment,
+                references[phase],
             )
+            image_id, oci_revision, repo_digests = _release_image_identity(
+                image_document
+            )
+            image_config = image_document.get("Config")
+            assert isinstance(image_config, dict)
+            labels = image_config.get("Labels")
+            assert isinstance(labels, dict)
             assert image_id == release_images[phase]
             assert oci_revision == revision
-            assert references[phase] in repo_digests
+            assert repo_digests == (references[phase],)
+            assert image_document.get("RepoTags") == []
+            assert labels["io.queryplanner.adk.repository"] == GITHUB_REPOSITORY
+            assert labels["org.opencontainers.image.source"] == EXPECTED_ORIGIN
         assert len(set(revisions.values())) == 4
         assert len(set(release_images.values())) == 4
         assert len(set(references.values())) == 4
@@ -2594,6 +2778,7 @@ def test_real_docker_promotes_then_restores_exact_verified_baseline(
             project=production_project,
             revision=good_revision,
             image_reference=references["good"],
+            image_repository=image_repository,
             adopt_existing=True,
         )
         _assert_safe_output(good_result)
@@ -2722,6 +2907,7 @@ def test_real_docker_promotes_then_restores_exact_verified_baseline(
             project=production_project,
             revision=unhealthy_revision,
             image_reference=references["unhealthy"],
+            image_repository=image_repository,
             adopt_existing=False,
             check=False,
         )
@@ -2868,6 +3054,7 @@ def test_real_docker_promotes_then_restores_exact_verified_baseline(
             project=production_project,
             revision=failing_revision,
             image_reference=references["failing"],
+            image_repository=image_repository,
             adopt_existing=False,
             check=False,
         )

--- a/tests/test_deployment_retention.py
+++ b/tests/test_deployment_retention.py
@@ -1,0 +1,2043 @@
+"""Bounded VM image retention with real deployment state."""
+
+from __future__ import annotations
+
+import json
+import runpy
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from unittest.mock import create_autospec, patch
+
+import pytest
+
+from agent import deployment_retention as retention
+from agent.deployment_retention import (
+    ImageRetentionError,
+    apply_image_retention,
+    enforce_pull_admission,
+    main,
+    plan_image_retention,
+)
+from agent.deployment_state import (
+    CandidateReceipt,
+    DeploymentStateStore,
+    DeploymentTerminalCommittedError,
+)
+
+REPOSITORY = "QueryPlanner/google-adk-on-bare-metal"
+IMAGE_REPOSITORY = "ghcr.io/queryplanner/google-adk-on-bare-metal"
+SOURCE = f"https://github.com/{REPOSITORY}"
+ENVIRONMENT = {"PATH": "/usr/bin", "HOME": "/home/agent"}
+
+
+def _reference(index: int) -> str:
+    return f"{IMAGE_REPOSITORY}@sha256:{index:064x}"
+
+
+def _image_id(index: int) -> str:
+    return f"sha256:{index + 1000:064x}"
+
+
+def _revision(index: int) -> str:
+    return f"{index + 2000:040x}"
+
+
+def _private_environment(tmp_path: Path, name: str) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    path = tmp_path / f"{name}.env"
+    path.write_bytes(f'SECRET="{name}"\n'.encode())
+    path.chmod(0o600)
+    return path
+
+
+def _managed_document(
+    index: int,
+    *,
+    reference: str | None = None,
+    image_id: str | None = None,
+    repository_label: str = REPOSITORY,
+    source: str = SOURCE,
+    revision: str | None = None,
+    extra_digests: tuple[str, ...] = (),
+    tags: tuple[str, ...] = (),
+) -> dict[str, object]:
+    selected_reference = _reference(index) if reference is None else reference
+    return {
+        "Id": _image_id(index) if image_id is None else image_id,
+        "RepoDigests": [selected_reference, *extra_digests],
+        "RepoTags": list(tags),
+        "Config": {
+            "Labels": {
+                "io.queryplanner.adk.repository": repository_label,
+                "org.opencontainers.image.source": source,
+                "org.opencontainers.image.revision": (
+                    _revision(index) if revision is None else revision
+                ),
+            }
+        },
+    }
+
+
+def _completed(
+    command: list[str],
+    *,
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        command,
+        returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+@dataclass(slots=True)
+class DockerBoundary:
+    """Stateful Docker CLI boundary; application state and planning stay real."""
+
+    images: dict[str, dict[str, object]]
+    containers: dict[str, str] = field(default_factory=dict)
+    calls: list[tuple[str, ...]] = field(default_factory=list)
+    fail_remove_at: int | None = None
+    retain_id_after_remove: bool = False
+    remove_count: int = 0
+    container_mounts: dict[str, list[object]] = field(default_factory=dict)
+    container_host_mounts: dict[str, list[object] | None] = field(default_factory=dict)
+    scripted: dict[
+        tuple[str, ...],
+        list[subprocess.CompletedProcess[str] | BaseException],
+    ] = field(default_factory=dict)
+    late_container: tuple[str, str] | None = None
+    container_list_count: int = 0
+    remove_images_before_list: dict[int, tuple[str, ...]] = field(default_factory=dict)
+    image_list_count: int = 0
+
+    def _image_for(self, identifier: str) -> dict[str, object] | None:
+        selected = self.images.get(identifier)
+        if selected is not None:
+            return selected
+        for document in self.images.values():
+            digests = document.get("RepoDigests")
+            tags = document.get("RepoTags")
+            if (
+                isinstance(digests, list)
+                and identifier in digests
+                or isinstance(tags, list)
+                and identifier in tags
+            ):
+                return document
+        return None
+
+    def run(
+        self,
+        command: list[str],
+        *,
+        env: dict[str, str],
+        text: bool,
+        capture_output: bool,
+        check: bool,
+        timeout: int,
+    ) -> subprocess.CompletedProcess[str]:
+        """Return deterministic Docker observations and exact removals."""
+        assert env["PATH"]
+        assert text is True
+        assert capture_output is True
+        assert check is False
+        assert timeout == 60
+        selected = tuple(command)
+        self.calls.append(selected)
+        arguments = command[1:]
+        scripted = self.scripted.get(tuple(arguments))
+        if scripted:
+            response = scripted.pop(0)
+            if isinstance(response, BaseException):
+                raise response
+            return subprocess.CompletedProcess(
+                command,
+                response.returncode,
+                stdout=response.stdout,
+                stderr=response.stderr,
+            )
+        if arguments == ["image", "ls", "--all", "--no-trunc", "--quiet"]:
+            self.image_list_count += 1
+            for image_id in self.remove_images_before_list.get(
+                self.image_list_count, ()
+            ):
+                self.images.pop(image_id, None)
+            return _completed(
+                command,
+                stdout="".join(f"{image_id}\n" for image_id in sorted(self.images)),
+            )
+        if arguments == ["container", "ls", "--all", "--no-trunc", "--quiet"]:
+            self.container_list_count += 1
+            if self.container_list_count >= 2 and self.late_container is not None:
+                container_id, image_id = self.late_container
+                self.containers[container_id] = image_id
+            return _completed(
+                command,
+                stdout="".join(
+                    f"{container_id}\n" for container_id in sorted(self.containers)
+                ),
+            )
+        if arguments[:2] == ["image", "inspect"] and len(arguments) == 3:
+            document = self._image_for(arguments[2])
+            if document is None:
+                return _completed(
+                    command,
+                    returncode=1,
+                    stdout="[]\n",
+                    stderr=(
+                        f"Error response from daemon: No such image: {arguments[2]}\n"
+                    ),
+                )
+            return _completed(command, stdout=json.dumps([document]))
+        if arguments[:2] == ["container", "inspect"] and len(arguments) == 3:
+            container_id = arguments[2]
+            container_image_id = self.containers.get(container_id)
+            if container_image_id is None:
+                return _completed(command, returncode=1, stderr="not found")
+            return _completed(
+                command,
+                stdout=json.dumps(
+                    [
+                        {
+                            "Id": container_id,
+                            "Image": container_image_id,
+                            "Mounts": self.container_mounts.get(container_id, []),
+                            "HostConfig": {
+                                "Mounts": self.container_host_mounts.get(container_id)
+                            },
+                        }
+                    ]
+                ),
+            )
+        if arguments[:3] == ["image", "rm", "--no-prune"] and len(arguments) == 4:
+            self.remove_count += 1
+            if self.fail_remove_at == self.remove_count:
+                return _completed(command, returncode=1, stderr="injected")
+            reference = arguments[3]
+            document = self._image_for(reference)
+            if document is None:
+                return _completed(command, returncode=1, stderr="not found")
+            removed_image_id = document["Id"]
+            assert isinstance(removed_image_id, str)
+            if self.retain_id_after_remove:
+                document["RepoDigests"] = []
+            else:
+                self.images.pop(removed_image_id)
+            return _completed(command, stdout=f"Untagged: {reference}\n")
+        return _completed(command, returncode=99, stderr="unexpected")
+
+
+def _docker(tmp_path: Path) -> Path:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    path = (tmp_path / "docker").resolve()
+    path.write_text("#!/bin/sh\n", encoding="utf-8")
+    path.chmod(0o700)
+    return path
+
+
+def _mock_run(boundary: DockerBoundary) -> Any:
+    return create_autospec(
+        subprocess.run,
+        spec_set=True,
+        side_effect=boundary.run,
+    )
+
+
+def _adopt(
+    store: DeploymentStateStore,
+    tmp_path: Path,
+    index: int,
+) -> None:
+    with store.transaction() as transaction:
+        transaction.adopt(
+            compose_project="adk-template",
+            compose_service="agent",
+            source_revision=_revision(index),
+            image_reference=_reference(index),
+            image_id=_image_id(index),
+            oci_revision=_revision(index),
+            environment_source=_private_environment(tmp_path, f"adopt-{index}"),
+            deployment_id=f"adopt-{index}",
+            recorded_at=f"2026-07-29T00:00:{index:02d}.000000Z",
+        )
+
+
+def _begin(
+    store: DeploymentStateStore,
+    tmp_path: Path,
+    index: int,
+) -> str:
+    with store.transaction() as transaction:
+        journal = transaction.journal()
+        tail = None if not journal else journal[-1]
+        sequence = len(journal) + 1
+        transaction_id = f"promote-{index}-{sequence}"
+        pending = transaction.begin_promotion(
+            compose_project="adk-template",
+            compose_service="agent",
+            source_revision=_revision(index),
+            image_reference=_reference(index),
+            image_id=_image_id(index),
+            oci_revision=_revision(index),
+            environment_source=_private_environment(tmp_path, transaction_id),
+            candidate=CandidateReceipt(
+                observed_at=f"2026-07-29T00:00:{sequence:02d}.000000Z",
+                compose_project=f"candidate-{index}-{sequence}",
+                compose_service="agent",
+                container_id=f"{index * 100 + sequence:064x}",
+                image_reference=_reference(index),
+                image_id=_image_id(index),
+                oci_revision=_revision(index),
+                baseline_journal_sequence=None if tail is None else tail.sequence,
+                baseline_journal_sha256=None if tail is None else tail.sha256,
+            ),
+            persistent_volumes=(),
+            transaction_id=transaction_id,
+            recorded_at=f"2026-07-29T00:00:{sequence:02d}.000000Z",
+        )
+        return pending.transaction_id
+
+
+def _terminal(
+    store: DeploymentStateStore,
+    transaction_id: str,
+    event: str,
+) -> None:
+    with store.transaction() as transaction:
+        method = {
+            "promoted": transaction.commit_promotion,
+            "rolled_back": transaction.record_rollback,
+            "aborted": transaction.record_abort,
+        }[event]
+        method(transaction_id, persistent_volumes=())
+
+
+def _promote(store: DeploymentStateStore, tmp_path: Path, index: int) -> None:
+    _terminal(store, _begin(store, tmp_path, index), "promoted")
+
+
+def _plan(
+    store: DeploymentStateStore,
+    docker: Path,
+    boundary: DockerBoundary,
+    target: str,
+) -> retention.RetentionPlan:
+    run = _mock_run(boundary)
+    with (
+        patch("agent.deployment_retention.subprocess.run", new=run),
+        store.transaction() as transaction,
+    ):
+        return plan_image_retention(
+            transaction,
+            docker=docker,
+            environment=ENVIRONMENT,
+            repository=REPOSITORY,
+            target_reference=target,
+        )
+
+
+def test_fresh_state_reserves_absent_target_and_orders_unrecorded_digests(
+    tmp_path: Path,
+) -> None:
+    """Allow fresh state while reducing eight local references to seven."""
+    store = DeploymentStateStore((tmp_path / "state").resolve())
+    images = {_image_id(index): _managed_document(index) for index in range(1, 9)}
+    boundary = DockerBoundary(images)
+
+    plan = _plan(store, _docker(tmp_path), boundary, _reference(99))
+
+    assert plan.reserved_references == 1
+    assert plan.admitted_count == 9
+    assert plan.delete_references == (_reference(1),)
+    assert plan.protected_references == (_reference(99),)
+    assert plan.missing_generation_references == ()
+    assert plan.required_deletions == 1
+    assert plan.admitted is False
+    document = plan.as_document(status="dry-run")
+    assert document["managed_reference_limit"] == 8
+    assert document["maximum_deletions"] == 5
+    decisions = document["reference_decisions"]
+    assert isinstance(decisions, list)
+    assert [decision["reference"] for decision in decisions] == [
+        _reference(index) for index in range(1, 9)
+    ]
+    assert decisions[0] == {
+        "reference": _reference(1),
+        "action": "delete",
+        "reasons": ["planned_unrecorded_deletion"],
+        "image_id": _image_id(1),
+    }
+    assert decisions[1] == {
+        "reference": _reference(2),
+        "action": "keep",
+        "reasons": ["available_capacity"],
+        "image_id": _image_id(2),
+    }
+
+
+def test_present_exact_target_uses_all_eight_slots_and_admits(
+    tmp_path: Path,
+) -> None:
+    """Count a fully proven local target instead of reserving another slot."""
+    store = DeploymentStateStore((tmp_path / "state").resolve())
+    boundary = DockerBoundary(
+        {_image_id(index): _managed_document(index) for index in range(1, 9)}
+    )
+    docker = _docker(tmp_path)
+    run = _mock_run(boundary)
+
+    with (
+        patch("agent.deployment_retention.subprocess.run", new=run),
+        store.transaction() as transaction,
+    ):
+        plan = enforce_pull_admission(
+            transaction,
+            docker=docker,
+            environment=ENVIRONMENT,
+            repository=REPOSITORY,
+            target_reference=_reference(8),
+        )
+
+    assert plan.target_present is True
+    assert plan.reserved_references == 0
+    assert plan.admitted is True
+    assert plan.delete_references == ()
+    target_decision = next(
+        decision
+        for decision in plan.reference_decisions
+        if decision.reference == _reference(8)
+    )
+    assert target_decision.action == "keep"
+    assert target_decision.reasons == ("requested_target",)
+
+
+def test_generation_keep_set_ignores_rollback_abort_and_repeated_reference(
+    tmp_path: Path,
+) -> None:
+    """Protect current plus two prior distinct establishing events only."""
+    store = DeploymentStateStore((tmp_path / "state").resolve())
+    _adopt(store, tmp_path, 1)
+    _promote(store, tmp_path, 2)
+    _promote(store, tmp_path, 3)
+    _terminal(store, _begin(store, tmp_path, 4), "rolled_back")
+    _terminal(store, _begin(store, tmp_path, 5), "aborted")
+    _promote(store, tmp_path, 2)
+    images = {_image_id(index): _managed_document(index) for index in range(1, 13)}
+
+    plan = _plan(
+        store,
+        _docker(tmp_path),
+        DockerBoundary(images),
+        _reference(99),
+    )
+
+    assert set(plan.protected_references) == {
+        _reference(2),
+        _reference(3),
+        _reference(1),
+        _reference(99),
+    }
+    assert _reference(4) in plan.delete_references
+    assert _reference(5) in plan.delete_references
+
+
+def test_reference_decisions_explain_generations_containers_and_history(
+    tmp_path: Path,
+) -> None:
+    """Emit ordered, exact reasons for every occupied project digest."""
+    store = DeploymentStateStore((tmp_path / "state").resolve())
+    for index in range(1, 9):
+        if index == 1:
+            _adopt(store, tmp_path, index)
+        else:
+            _promote(store, tmp_path, index)
+    container_id = f"{123:064x}"
+    boundary = DockerBoundary(
+        {_image_id(index): _managed_document(index) for index in range(1, 9)},
+        containers={container_id: _image_id(7)},
+    )
+
+    plan = _plan(store, _docker(tmp_path), boundary, _reference(99))
+
+    assert [decision.reference for decision in plan.reference_decisions] == [
+        _reference(index) for index in range(1, 9)
+    ]
+    decisions = {decision.reference: decision for decision in plan.reference_decisions}
+    assert decisions[_reference(1)].action == "delete"
+    assert decisions[_reference(1)].reasons == ("planned_historical_deletion",)
+    assert decisions[_reference(1)].image_id == _image_id(1)
+    assert decisions[_reference(2)].reasons == ("available_capacity",)
+    assert decisions[_reference(6)].reasons == ("prior_generation",)
+    assert decisions[_reference(7)].reasons == (
+        "prior_generation",
+        "container_use",
+    )
+    assert decisions[_reference(8)].reasons == ("current_generation",)
+
+
+def test_missing_prior_is_reported_without_substituting_older_generation(
+    tmp_path: Path,
+) -> None:
+    """Keep history selection stable when a recent prior is not local."""
+    store = DeploymentStateStore((tmp_path / "state").resolve())
+    for index in range(1, 5):
+        if index == 1:
+            _adopt(store, tmp_path, index)
+        else:
+            _promote(store, tmp_path, index)
+    boundary = DockerBoundary(
+        {_image_id(index): _managed_document(index) for index in (1, 2, 4, 6, 7, 8, 9)}
+    )
+
+    plan = _plan(store, _docker(tmp_path), boundary, _reference(9))
+
+    assert plan.missing_generation_references == (_reference(3),)
+    assert _reference(1) not in plan.protected_references
+    assert _reference(2) in plan.protected_references
+    assert _reference(3) in plan.protected_references
+    assert _reference(4) in plan.protected_references
+
+
+@pytest.mark.parametrize("event", ["rolled_back", "aborted"])
+def test_fresh_terminal_without_current_allows_empty_generation_set(
+    tmp_path: Path,
+    event: str,
+) -> None:
+    """A verified fresh non-install outcome is valid pre-pull state."""
+    store = DeploymentStateStore((tmp_path / event / "state").resolve())
+    _terminal(store, _begin(store, tmp_path / event, 1), event)
+
+    plan = _plan(
+        store,
+        _docker(tmp_path / event),
+        DockerBoundary({}),
+        _reference(2),
+    )
+
+    assert plan.protected_references == (_reference(2),)
+    assert plan.managed_references == ()
+    assert plan.admitted_count == 1
+
+
+def test_pending_and_just_recovered_state_block_before_docker(
+    tmp_path: Path,
+) -> None:
+    """Never inspect or mutate Docker across unresolved/reconciled recovery."""
+    pending_store = DeploymentStateStore((tmp_path / "pending-state").resolve())
+    _begin(pending_store, tmp_path, 1)
+    docker = _docker(tmp_path)
+    boundary = DockerBoundary({})
+    run = _mock_run(boundary)
+    with (
+        patch("agent.deployment_retention.subprocess.run", new=run),
+        pending_store.transaction() as transaction,
+        pytest.raises(ImageRetentionError, match="pending recovery"),
+    ):
+        plan_image_retention(
+            transaction,
+            docker=docker,
+            environment=ENVIRONMENT,
+            repository=REPOSITORY,
+            target_reference=_reference(2),
+        )
+    assert boundary.calls == []
+
+    recovered_store = DeploymentStateStore((tmp_path / "recovered-state").resolve())
+    _adopt(recovered_store, tmp_path, 2)
+    transaction_id = _begin(recovered_store, tmp_path, 3)
+    original_unlink = Path.unlink
+
+    def fail_pending_unlink(path: Path, missing_ok: bool = False) -> None:
+        if path == recovered_store.pending_path:
+            raise OSError("injected")
+        original_unlink(path, missing_ok=missing_ok)
+
+    with (
+        recovered_store.transaction() as transaction,
+        patch.object(Path, "unlink", autospec=True, side_effect=fail_pending_unlink),
+        pytest.raises(DeploymentTerminalCommittedError),
+    ):
+        transaction.record_abort(transaction_id, persistent_volumes=())
+    with (
+        patch("agent.deployment_retention.subprocess.run", new=run),
+        recovered_store.transaction() as transaction,
+        pytest.raises(ImageRetentionError, match="fresh recovery"),
+    ):
+        plan_image_retention(
+            transaction,
+            docker=docker,
+            environment=ENVIRONMENT,
+            repository=REPOSITORY,
+            target_reference=_reference(4),
+        )
+    assert boundary.calls == []
+
+
+def test_container_use_protects_stopped_or_running_image_and_can_block(
+    tmp_path: Path,
+) -> None:
+    """Use inspected image IDs from every container as hard protections."""
+    store = DeploymentStateStore((tmp_path / "state").resolve())
+    images = {_image_id(index): _managed_document(index) for index in range(1, 10)}
+    containers = {f"{index:064x}": _image_id(index) for index in range(1, 9)}
+    boundary = DockerBoundary(images, containers=containers)
+
+    with pytest.raises(ImageRetentionError, match="ceiling is unreachable"):
+        _plan(store, _docker(tmp_path), boundary, _reference(99))
+
+    assert not any(call[1:3] == ("image", "rm") for call in boundary.calls)
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        {"repository_label": "Other/repo"},
+        {"source": "https://github.com/Other/repo"},
+        {"revision": "invalid"},
+        {"extra_digests": ("ghcr.io/other/repo@sha256:" + "f" * 64,)},
+        {"tags": ("ghcr.io/queryplanner/google-adk-on-bare-metal:latest",)},
+    ],
+)
+def test_present_target_must_pass_full_managed_singleton_proof(
+    tmp_path: Path,
+    change: dict[str, object],
+) -> None:
+    """Reject present targets that are unlabeled, aliased, or malformed."""
+    store = DeploymentStateStore((tmp_path / "state").resolve())
+    document = _managed_document(1, **change)  # type: ignore[arg-type]
+    boundary = DockerBoundary({_image_id(1): document})
+
+    with pytest.raises(
+        ImageRetentionError,
+        match="target image is not exactly managed",
+    ):
+        _plan(store, _docker(tmp_path), boundary, _reference(1))
+
+
+def test_recorded_identity_conflict_and_local_replacement_fail_closed(
+    tmp_path: Path,
+) -> None:
+    """Reject one reference associated with conflicting durable or local IDs."""
+    conflict_store = DeploymentStateStore((tmp_path / "conflict").resolve())
+    _adopt(conflict_store, tmp_path, 1)
+    with conflict_store.transaction() as transaction:
+        journal = transaction.journal()
+        tail = journal[-1]
+        pending = transaction.begin_promotion(
+            compose_project="adk-template",
+            compose_service="agent",
+            source_revision=_revision(9),
+            image_reference=_reference(1),
+            image_id=_image_id(9),
+            oci_revision=_revision(9),
+            environment_source=_private_environment(tmp_path, "conflict"),
+            candidate=CandidateReceipt(
+                observed_at="2026-07-29T00:00:09.000000Z",
+                compose_project="candidate-conflict",
+                compose_service="agent",
+                container_id="9" * 64,
+                image_reference=_reference(1),
+                image_id=_image_id(9),
+                oci_revision=_revision(9),
+                baseline_journal_sequence=tail.sequence,
+                baseline_journal_sha256=tail.sha256,
+            ),
+            persistent_volumes=(),
+            transaction_id="promote-conflict",
+            recorded_at="2026-07-29T00:00:09.000000Z",
+        )
+        transaction.commit_promotion(
+            pending.transaction_id,
+            persistent_volumes=(),
+        )
+    with pytest.raises(ImageRetentionError, match="generation identity conflicts"):
+        _plan(
+            conflict_store,
+            _docker(tmp_path),
+            DockerBoundary({_image_id(9): _managed_document(9)}),
+            _reference(10),
+        )
+
+    replacement_store = DeploymentStateStore((tmp_path / "replacement").resolve())
+    _adopt(replacement_store, tmp_path, 2)
+    replacement = _managed_document(
+        2,
+        image_id=_image_id(8),
+        revision=_revision(2),
+    )
+    with pytest.raises(ImageRetentionError, match="recorded generation"):
+        _plan(
+            replacement_store,
+            _docker(tmp_path),
+            DockerBoundary({_image_id(8): replacement}),
+            _reference(10),
+        )
+
+
+def test_apply_deletes_unrecorded_before_oldest_success_and_caps_batch(
+    tmp_path: Path,
+) -> None:
+    """Apply one deterministic five-reference batch and report incomplete."""
+    store = DeploymentStateStore((tmp_path / "state").resolve())
+    for index in range(1, 5):
+        if index == 1:
+            _adopt(store, tmp_path, index)
+        else:
+            _promote(store, tmp_path, index)
+    images = {_image_id(index): _managed_document(index) for index in range(1, 15)}
+    boundary = DockerBoundary(images)
+    docker = _docker(tmp_path)
+    run = _mock_run(boundary)
+
+    with (
+        patch("agent.deployment_retention.subprocess.run", new=run),
+        store.transaction() as transaction,
+    ):
+        final, admitted, removed_decisions = apply_image_retention(
+            transaction,
+            docker=docker,
+            environment=ENVIRONMENT,
+            repository=REPOSITORY,
+            target_reference=_reference(99),
+        )
+
+    removed = [
+        call[-1]
+        for call in boundary.calls
+        if call[1:4] == ("image", "rm", "--no-prune")
+    ]
+    assert removed == [_reference(index) for index in range(5, 10)]
+    assert [decision.reference for decision in removed_decisions] == removed
+    assert all(decision.action == "delete" for decision in removed_decisions)
+    assert all(
+        decision.reasons == ("planned_unrecorded_deletion",)
+        for decision in removed_decisions
+    )
+    assert admitted is False
+    assert final.admitted_count == 10
+
+    boundary.calls.clear()
+    with (
+        patch("agent.deployment_retention.subprocess.run", new=run),
+        store.transaction() as transaction,
+    ):
+        final, admitted, removed_decisions = apply_image_retention(
+            transaction,
+            docker=docker,
+            environment=ENVIRONMENT,
+            repository=REPOSITORY,
+            target_reference=_reference(99),
+        )
+    assert admitted is True
+    assert final.admitted_count == 8
+    assert [decision.reference for decision in removed_decisions] == [
+        _reference(10),
+        _reference(11),
+    ]
+    assert [call[-1] for call in boundary.calls if call[1:3] == ("image", "rm")] == [
+        _reference(10),
+        _reference(11),
+    ]
+
+
+def test_removal_failure_and_reference_only_untagging_stop_batch(
+    tmp_path: Path,
+) -> None:
+    """Never count a failed removal or a remaining image ID as reclaimed."""
+    store = DeploymentStateStore((tmp_path / "state").resolve())
+    docker = _docker(tmp_path)
+    images = {_image_id(index): _managed_document(index) for index in range(1, 10)}
+    failure = DockerBoundary(dict(images), fail_remove_at=1)
+    with (
+        patch(
+            "agent.deployment_retention.subprocess.run",
+            new=_mock_run(failure),
+        ),
+        store.transaction() as transaction,
+        pytest.raises(ImageRetentionError, match="command failed"),
+    ):
+        apply_image_retention(
+            transaction,
+            docker=docker,
+            environment=ENVIRONMENT,
+            repository=REPOSITORY,
+            target_reference=_reference(99),
+        )
+
+    retained = DockerBoundary(dict(images), retain_id_after_remove=True)
+    with (
+        patch(
+            "agent.deployment_retention.subprocess.run",
+            new=_mock_run(retained),
+        ),
+        store.transaction() as transaction,
+        pytest.raises(ImageRetentionError, match="remained after exact removal"),
+    ):
+        apply_image_retention(
+            transaction,
+            docker=docker,
+            environment=ENVIRONMENT,
+            repository=REPOSITORY,
+            target_reference=_reference(99),
+        )
+
+    retained.calls.clear()
+    with (
+        patch(
+            "agent.deployment_retention.subprocess.run",
+            new=_mock_run(retained),
+        ),
+        store.transaction() as transaction,
+        pytest.raises(ImageRetentionError, match="lacks a canonical digest"),
+    ):
+        apply_image_retention(
+            transaction,
+            docker=docker,
+            environment=ENVIRONMENT,
+            repository=REPOSITORY,
+            target_reference=_reference(99),
+        )
+    assert not any(call[1:3] == ("image", "rm") for call in retained.calls)
+
+
+@pytest.mark.parametrize(
+    "unrelated",
+    [
+        _managed_document(
+            1,
+            reference="docker.io/library/alpine@sha256:" + "a" * 64,
+            repository_label="Other/repository",
+            source="https://github.com/Other/repository",
+        ),
+        {
+            "Id": _image_id(1),
+            "RepoDigests": [],
+            "RepoTags": ["docker.io/library/alpine:latest"],
+            "Config": {"Labels": None},
+        },
+    ],
+)
+def test_unrelated_unmanaged_images_do_not_block_admission(
+    tmp_path: Path,
+    unrelated: dict[str, object],
+) -> None:
+    """Ignore images that neither use nor claim the project repository."""
+    store = DeploymentStateStore((tmp_path / "state").resolve())
+
+    plan = _plan(
+        store,
+        _docker(tmp_path),
+        DockerBoundary({_image_id(1): unrelated}),
+        _reference(99),
+    )
+
+    assert plan.admitted is True
+    assert plan.occupied_references == ()
+    assert plan.managed_references == ()
+
+
+@pytest.mark.parametrize(
+    "labels",
+    [
+        None,
+        {
+            "io.queryplanner.adk.repository": "Other/repository",
+            "org.opencontainers.image.source": "https://github.com/Other/repository",
+            "org.opencontainers.image.revision": _revision(1),
+        },
+    ],
+)
+def test_project_tag_without_digest_blocks_regardless_of_labels(
+    tmp_path: Path,
+    labels: dict[str, str] | None,
+) -> None:
+    """Treat a tag-only project image as unreclaimed ownership evidence."""
+    document: dict[str, object] = {
+        "Id": _image_id(1),
+        "RepoDigests": [],
+        "RepoTags": [f"{IMAGE_REPOSITORY}:latest"],
+        "Config": {"Labels": labels},
+    }
+    store = DeploymentStateStore((tmp_path / "state").resolve())
+
+    with pytest.raises(ImageRetentionError, match="tag lacks a canonical digest"):
+        _plan(
+            store,
+            _docker(tmp_path),
+            DockerBoundary({_image_id(1): document}),
+            _reference(99),
+        )
+
+
+def test_project_tag_with_digest_remains_ambiguous_and_protected(
+    tmp_path: Path,
+) -> None:
+    """Retain a tagged canonical digest without treating it as exact-managed."""
+    document = _managed_document(
+        1,
+        tags=(f"{IMAGE_REPOSITORY}:latest",),
+    )
+    store = DeploymentStateStore((tmp_path / "state").resolve())
+
+    plan = _plan(
+        store,
+        _docker(tmp_path),
+        DockerBoundary({_image_id(1): document}),
+        _reference(99),
+    )
+
+    assert plan.ambiguous_references == (_reference(1),)
+    assert _reference(1) in plan.protected_references
+    assert plan.delete_references == ()
+
+
+def test_partial_batch_recomputes_from_docker_without_state_mutation(
+    tmp_path: Path,
+) -> None:
+    """Resume deterministically after deletion three fails in a five-item batch."""
+    store = DeploymentStateStore((tmp_path / "state").resolve())
+    for index in range(1, 5):
+        if index == 1:
+            _adopt(store, tmp_path, index)
+        else:
+            _promote(store, tmp_path, index)
+    state_before = store.current_path.read_bytes()
+    journal_before = {
+        path.name: path.read_bytes() for path in sorted(store.journal_path.iterdir())
+    }
+    boundary = DockerBoundary(
+        {_image_id(index): _managed_document(index) for index in range(1, 15)},
+        fail_remove_at=3,
+    )
+    docker = _docker(tmp_path)
+    run = _mock_run(boundary)
+
+    with (
+        patch("agent.deployment_retention.subprocess.run", new=run),
+        store.transaction() as transaction,
+        pytest.raises(ImageRetentionError, match="command failed"),
+    ):
+        apply_image_retention(
+            transaction,
+            docker=docker,
+            environment=ENVIRONMENT,
+            repository=REPOSITORY,
+            target_reference=_reference(99),
+        )
+
+    first_calls = [
+        call[-1]
+        for call in boundary.calls
+        if call[1:4] == ("image", "rm", "--no-prune")
+    ]
+    assert first_calls == [_reference(5), _reference(6), _reference(7)]
+    assert _image_id(5) not in boundary.images
+    assert _image_id(6) not in boundary.images
+    assert _image_id(7) in boundary.images
+    assert all(_image_id(index) in boundary.images for index in (2, 3, 4))
+
+    boundary.fail_remove_at = None
+    boundary.calls.clear()
+    with (
+        patch("agent.deployment_retention.subprocess.run", new=run),
+        store.transaction() as transaction,
+    ):
+        final, admitted, removed_decisions = apply_image_retention(
+            transaction,
+            docker=docker,
+            environment=ENVIRONMENT,
+            repository=REPOSITORY,
+            target_reference=_reference(99),
+        )
+
+    resumed_calls = [
+        call[-1]
+        for call in boundary.calls
+        if call[1:4] == ("image", "rm", "--no-prune")
+    ]
+    assert resumed_calls == [
+        _reference(7),
+        _reference(8),
+        _reference(9),
+        _reference(10),
+        _reference(11),
+    ]
+    assert [decision.reference for decision in removed_decisions] == resumed_calls
+    assert admitted is True
+    assert final.admitted_count == 8
+    assert all(_image_id(index) in boundary.images for index in (2, 3, 4))
+    assert store.current_path.read_bytes() == state_before
+    assert {
+        path.name: path.read_bytes() for path in sorted(store.journal_path.iterdir())
+    } == journal_before
+
+
+def test_admission_is_read_only_when_capacity_requires_cleanup(
+    tmp_path: Path,
+) -> None:
+    """The in-lock controller guard never converts a plan into mutation."""
+    store = DeploymentStateStore((tmp_path / "state").resolve())
+    boundary = DockerBoundary(
+        {_image_id(index): _managed_document(index) for index in range(1, 9)}
+    )
+    run = _mock_run(boundary)
+    with (
+        patch("agent.deployment_retention.subprocess.run", new=run),
+        store.transaction() as transaction,
+        pytest.raises(ImageRetentionError, match="capacity is not admitted"),
+    ):
+        enforce_pull_admission(
+            transaction,
+            docker=_docker(tmp_path),
+            environment=ENVIRONMENT,
+            repository=REPOSITORY,
+            target_reference=_reference(99),
+        )
+    assert not any(call[1:3] == ("image", "rm") for call in boundary.calls)
+
+
+def test_cli_dry_run_apply_incomplete_and_errors_are_secret_free(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Expose stable CLI modes and statuses without forwarding Docker stderr."""
+    state_dir = (tmp_path / "state").resolve()
+    images = {_image_id(index): _managed_document(index) for index in range(1, 15)}
+    boundary = DockerBoundary(images)
+    docker = _docker(tmp_path)
+    arguments = [
+        "enforce",
+        "--state-dir",
+        str(state_dir),
+        "--repository",
+        REPOSITORY,
+        "--target-reference",
+        _reference(99),
+    ]
+    run = _mock_run(boundary)
+    secret_environment = {
+        **ENVIRONMENT,
+        "OPENROUTER_API_KEY": "SECRET-retention-value",
+    }
+    with (
+        patch("agent.deployment_retention.subprocess.run", new=run),
+        patch("agent.deployment_retention.shutil.which", return_value=str(docker)),
+    ):
+        assert main(arguments, environment=secret_environment) == 0
+        dry_run = json.loads(capsys.readouterr().out)
+        assert "SECRET-retention-value" not in json.dumps(dry_run)
+        assert dry_run["status"] == "dry-run"
+        assert "removed_reference_decisions" not in dry_run
+        assert main([*arguments, "--apply"], environment=secret_environment) == 3
+        incomplete = json.loads(capsys.readouterr().out)
+        assert "SECRET-retention-value" not in json.dumps(incomplete)
+        assert incomplete["status"] == "incomplete"
+        assert incomplete["removed_reference_decisions"] == [
+            {
+                "reference": _reference(index),
+                "action": "delete",
+                "reasons": ["planned_unrecorded_deletion"],
+                "image_id": _image_id(index),
+            }
+            for index in range(1, 6)
+        ]
+
+    failure = DockerBoundary(
+        {_image_id(index): _managed_document(index) for index in range(1, 10)},
+        fail_remove_at=1,
+    )
+    with (
+        patch(
+            "agent.deployment_retention.subprocess.run",
+            new=_mock_run(failure),
+        ),
+        patch("agent.deployment_retention.shutil.which", return_value=str(docker)),
+    ):
+        assert main([*arguments, "--apply"], environment=secret_environment) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "injected" not in captured.err
+    assert "SECRET" not in captured.err
+
+    post_failure = DockerBoundary(
+        {_image_id(index): _managed_document(index) for index in range(1, 10)},
+        retain_id_after_remove=True,
+    )
+    with (
+        patch(
+            "agent.deployment_retention.subprocess.run",
+            new=_mock_run(post_failure),
+        ),
+        patch("agent.deployment_retention.shutil.which", return_value=str(docker)),
+    ):
+        assert main([*arguments, "--apply"], environment=secret_environment) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "remained after exact removal" in captured.err
+
+    ambiguous = DockerBoundary(
+        {
+            _image_id(index): _managed_document(
+                index,
+                repository_label="Other/repository",
+            )
+            for index in range(1, 9)
+        }
+    )
+    with (
+        patch(
+            "agent.deployment_retention.subprocess.run",
+            new=_mock_run(ambiguous),
+        ),
+        patch("agent.deployment_retention.shutil.which", return_value=str(docker)),
+    ):
+        assert main([*arguments, "--apply"], environment=secret_environment) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "ceiling is unreachable" in captured.err
+    assert not any(call[1:3] == ("image", "rm") for call in ambiguous.calls)
+
+
+def test_cli_apply_emits_one_verified_removal_decision(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Audit one successful exact removal separately from the final inventory."""
+    state_dir = (tmp_path / "state").resolve()
+    docker = _docker(tmp_path)
+    boundary = DockerBoundary(
+        {_image_id(index): _managed_document(index) for index in range(1, 9)}
+    )
+    arguments = [
+        "enforce",
+        "--state-dir",
+        str(state_dir),
+        "--repository",
+        REPOSITORY,
+        "--target-reference",
+        _reference(99),
+        "--apply",
+    ]
+
+    with (
+        patch(
+            "agent.deployment_retention.subprocess.run",
+            new=_mock_run(boundary),
+        ),
+        patch("agent.deployment_retention.shutil.which", return_value=str(docker)),
+    ):
+        assert main(arguments, environment=ENVIRONMENT) == 0
+
+    document = json.loads(capsys.readouterr().out)
+    assert document["status"] == "admitted"
+    assert document["removed_reference_decisions"] == [
+        {
+            "reference": _reference(1),
+            "action": "delete",
+            "reasons": ["planned_unrecorded_deletion"],
+            "image_id": _image_id(1),
+        }
+    ]
+    assert _reference(1) not in {
+        decision["reference"] for decision in document["reference_decisions"]
+    }
+
+
+def test_ambiguous_project_references_occupy_capacity_and_are_never_deleted(
+    tmp_path: Path,
+) -> None:
+    """Count alias/wrong-label references while excluding them from deletion."""
+    store = DeploymentStateStore((tmp_path / "state").resolve())
+    images = {
+        _image_id(index): _managed_document(
+            index,
+            repository_label="Other/repository",
+        )
+        for index in range(1, 9)
+    }
+    boundary = DockerBoundary(images)
+    docker = _docker(tmp_path)
+
+    with (
+        patch(
+            "agent.deployment_retention.subprocess.run",
+            new=_mock_run(boundary),
+        ),
+        store.transaction() as transaction,
+        pytest.raises(ImageRetentionError, match="ceiling is unreachable"),
+    ):
+        apply_image_retention(
+            transaction,
+            docker=docker,
+            environment=ENVIRONMENT,
+            repository=REPOSITORY,
+            target_reference=_reference(99),
+        )
+
+    assert not any(call[1:3] == ("image", "rm") for call in boundary.calls)
+
+    images[_image_id(1)] = _managed_document(1)
+    plan = _plan(store, docker, DockerBoundary(images), _reference(99))
+    assert len(plan.occupied_references) == 8
+    assert len(plan.ambiguous_references) == 7
+    assert plan.delete_references == (_reference(1),)
+    assert _reference(2) in plan.protected_references
+    ambiguous = next(
+        decision
+        for decision in plan.reference_decisions
+        if decision.reference == _reference(2)
+    )
+    assert ambiguous.action == "keep"
+    assert ambiguous.reasons == ("ambiguous_ownership",)
+    assert ambiguous.image_id is None
+    assert ambiguous.as_document() == {
+        "reference": _reference(2),
+        "action": "keep",
+        "reasons": ["ambiguous_ownership"],
+    }
+
+
+def test_malformed_project_digest_fails_closed(
+    tmp_path: Path,
+) -> None:
+    """Reject a project-prefixed reference that is not one canonical digest."""
+    store = DeploymentStateStore((tmp_path / "state").resolve())
+    malformed = _managed_document(1, reference=f"{_reference(1)}suffix")
+    with pytest.raises(ImageRetentionError, match="reference is malformed"):
+        _plan(
+            store,
+            _docker(tmp_path),
+            DockerBoundary({_image_id(1): malformed}),
+            _reference(99),
+        )
+
+
+def test_internal_repository_override_supports_local_registry_proofs(
+    tmp_path: Path,
+) -> None:
+    """Use a runtime-only repository override without broadening the CLI."""
+    local_repository = "127.0.0.1:5000/queryplanner/google-adk-on-bare-metal"
+    target = f"{local_repository}@sha256:{1:064x}"
+    document = _managed_document(1, reference=target)
+    store = DeploymentStateStore((tmp_path / "state").resolve())
+    docker = _docker(tmp_path)
+    boundary = DockerBoundary({_image_id(1): document})
+    run = _mock_run(boundary)
+
+    with (
+        patch("agent.deployment_retention.subprocess.run", new=run),
+        store.transaction() as transaction,
+    ):
+        plan = plan_image_retention(
+            transaction,
+            docker=docker,
+            environment=ENVIRONMENT,
+            repository=REPOSITORY,
+            target_reference=target,
+            image_repository=local_repository,
+        )
+
+    assert plan.target_present is True
+    assert plan.occupied_references == (target,)
+
+
+def test_image_mount_and_root_image_ids_are_protected(
+    tmp_path: Path,
+) -> None:
+    """Resolve Moby's immutable mount Name, never its snapshot Source path."""
+    store = DeploymentStateStore((tmp_path / "state").resolve())
+    images = {_image_id(index): _managed_document(index) for index in range(1, 10)}
+    container_id = f"{123:064x}"
+    snapshot_path = "/var/lib/docker/image/mounts/snapshots/8/fs"
+    boundary = DockerBoundary(
+        images,
+        containers={container_id: _image_id(9)},
+        container_mounts={
+            container_id: [
+                {"Type": "bind", "Source": "/operator/data"},
+                {
+                    "Type": "image",
+                    "Name": _reference(8),
+                    "Source": snapshot_path,
+                    "Destination": "/models",
+                },
+            ]
+        },
+        container_host_mounts={
+            container_id: [
+                {
+                    "Type": "image",
+                    "Source": _reference(8),
+                    "Target": "/models",
+                }
+            ]
+        },
+    )
+
+    plan = _plan(store, _docker(tmp_path), boundary, _reference(99))
+
+    assert _reference(8) in plan.protected_references
+    assert _reference(9) in plan.protected_references
+    assert _reference(8) not in plan.delete_references
+    assert _reference(9) not in plan.delete_references
+    assert not any(
+        call[1:] == ("image", "inspect", snapshot_path) for call in boundary.calls
+    )
+
+
+@pytest.mark.parametrize(
+    ("mounts", "message"),
+    [
+        (["invalid"], "container mount is invalid"),
+        (
+            [{"Type": "image", "Source": "/var/lib/docker/snapshot"}],
+            "selector is not an immutable digest",
+        ),
+        (
+            [
+                {
+                    "Type": "image",
+                    "Name": f"{IMAGE_REPOSITORY}:latest",
+                    "Source": "/var/lib/docker/snapshot",
+                }
+            ],
+            "selector is not an immutable digest",
+        ),
+        (
+            [
+                {
+                    "Type": "image",
+                    "Name": _image_id(2),
+                    "Source": "/var/lib/docker/snapshot",
+                }
+            ],
+            "selector is not an immutable digest",
+        ),
+        (
+            [
+                {
+                    "Type": "image",
+                    "Name": _reference(2),
+                    "Source": "/var/lib/docker/snapshot",
+                }
+            ],
+            "mount is unavailable",
+        ),
+    ],
+)
+def test_malformed_or_missing_image_mount_fails_closed(
+    tmp_path: Path,
+    mounts: list[object],
+    message: str,
+) -> None:
+    """Reject image-mount observations that cannot prove an exact image ID."""
+    store = DeploymentStateStore((tmp_path / "state").resolve())
+    container_id = f"{123:064x}"
+    boundary = DockerBoundary(
+        {_image_id(1): _managed_document(1)},
+        containers={container_id: _image_id(1)},
+        container_mounts={container_id: mounts},
+    )
+    with pytest.raises(ImageRetentionError, match=message):
+        _plan(store, _docker(tmp_path), boundary, _reference(99))
+
+
+def test_malformed_container_identity_fails_closed(tmp_path: Path) -> None:
+    """Reject a container inspection that does not match its listed ID."""
+    store = DeploymentStateStore((tmp_path / "state").resolve())
+    container_id = f"{123:064x}"
+    malformed = {
+        "Id": f"{124:064x}",
+        "Image": _image_id(1),
+        "Mounts": [],
+    }
+    boundary = DockerBoundary(
+        {_image_id(1): _managed_document(1)},
+        containers={container_id: _image_id(1)},
+        scripted={
+            ("container", "inspect", container_id): [
+                _completed([], stdout=json.dumps([malformed]))
+            ]
+        },
+    )
+
+    with pytest.raises(ImageRetentionError, match="container identity is invalid"):
+        _plan(store, _docker(tmp_path), boundary, _reference(99))
+
+
+def test_mount_name_is_authoritative_over_legacy_host_config(
+    tmp_path: Path,
+) -> None:
+    """Do not reject an immutable Moby Name because HostConfig is legacy."""
+    store = DeploymentStateStore((tmp_path / "state").resolve())
+    container_id = f"{123:064x}"
+    boundary = DockerBoundary(
+        {_image_id(1): _managed_document(1)},
+        containers={container_id: _image_id(1)},
+        container_mounts={
+            container_id: [
+                {
+                    "Type": "image",
+                    "Name": _reference(1),
+                    "Source": "/var/lib/docker/image/mounts/snapshots/1/fs",
+                }
+            ]
+        },
+        container_host_mounts={
+            container_id: [
+                {
+                    "Type": "image",
+                    "Source": f"{IMAGE_REPOSITORY}:legacy",
+                }
+            ]
+        },
+    )
+
+    plan = _plan(store, _docker(tmp_path), boundary, _reference(99))
+
+    assert _reference(1) in plan.protected_references
+
+
+def test_mount_selector_identity_drift_fails_closed(tmp_path: Path) -> None:
+    """Require the selector inspection to match the inventoried image ID proof."""
+    selector = "docker.io/library/alpine@sha256:" + "a" * 64
+    observed: dict[str, object] = {
+        "Id": _image_id(1),
+        "RepoDigests": [selector],
+        "RepoTags": [],
+        "Config": {"Labels": None},
+    }
+    changed: dict[str, object] = {
+        **observed,
+        "Config": {"Labels": {"drift": "detected"}},
+    }
+    container_id = f"{123:064x}"
+    boundary = DockerBoundary(
+        {_image_id(1): observed},
+        containers={container_id: _image_id(1)},
+        container_mounts={
+            container_id: [
+                {
+                    "Type": "image",
+                    "Name": selector,
+                    "Source": "/var/lib/docker/image/mounts/snapshots/1/fs",
+                }
+            ]
+        },
+        scripted={
+            ("image", "inspect", selector): [
+                _completed([], stdout=json.dumps([changed]))
+            ]
+        },
+    )
+    store = DeploymentStateStore((tmp_path / "state").resolve())
+
+    with pytest.raises(ImageRetentionError, match="mount identity is ambiguous"):
+        _plan(store, _docker(tmp_path), boundary, _reference(99))
+
+
+def test_inventory_disappearance_drift_and_duplicate_ownership_fail_closed(
+    tmp_path: Path,
+) -> None:
+    """Reject races between image listing, ID inspection, and reference proof."""
+    store = DeploymentStateStore((tmp_path / "state").resolve())
+    docker = _docker(tmp_path)
+    absent = _completed(
+        [],
+        returncode=1,
+        stdout="[]\n",
+        stderr=f"Error response from daemon: No such image: {_image_id(1)}\n",
+    )
+    disappeared = DockerBoundary(
+        {_image_id(1): _managed_document(1)},
+        scripted={("image", "inspect", _image_id(1)): [absent]},
+    )
+    with pytest.raises(ImageRetentionError, match="inventory changed"):
+        _plan(store, docker, disappeared, _reference(99))
+
+    reference_absent = _completed(
+        [],
+        returncode=1,
+        stdout="[]\n",
+        stderr=f"Error response from daemon: No such image: {_reference(1)}\n",
+    )
+    missing_reference = DockerBoundary(
+        {_image_id(1): _managed_document(1)},
+        scripted={("image", "inspect", _reference(1)): [reference_absent]},
+    )
+    with pytest.raises(ImageRetentionError, match="reference disappeared"):
+        _plan(store, docker, missing_reference, _reference(99))
+
+    changed = _managed_document(1, image_id=_image_id(2))
+    drift = DockerBoundary(
+        {_image_id(1): _managed_document(1)},
+        scripted={
+            ("image", "inspect", _reference(1)): [
+                _completed([], stdout=json.dumps([changed]))
+            ]
+        },
+    )
+    with pytest.raises(ImageRetentionError, match="identity changed"):
+        _plan(store, docker, drift, _reference(99))
+
+    duplicate_images = {
+        _image_id(1): _managed_document(1),
+        _image_id(2): _managed_document(
+            2,
+            reference=_reference(1),
+            repository_label="Other/repository",
+        ),
+    }
+    duplicate = _plan(
+        store,
+        docker,
+        DockerBoundary(duplicate_images),
+        _reference(99),
+    )
+    assert duplicate.ambiguous_references == (_reference(1),)
+    assert duplicate.managed_references == ()
+
+    second = _managed_document(
+        2,
+        reference=_reference(1),
+        revision=_revision(2),
+    )
+    identity_swap = DockerBoundary(
+        {
+            _image_id(1): _managed_document(1),
+            _image_id(2): second,
+        },
+        scripted={
+            ("image", "inspect", _reference(1)): [
+                _completed([], stdout=json.dumps([_managed_document(1)])),
+                _completed([], stdout=json.dumps([second])),
+            ]
+        },
+    )
+    with pytest.raises(ImageRetentionError, match="reference is ambiguous"):
+        _plan(store, docker, identity_swap, _reference(99))
+
+
+def test_external_disappearance_before_replan_stops_without_removal(
+    tmp_path: Path,
+) -> None:
+    """Stop when the last full inventory already satisfies seven plus one."""
+    store = DeploymentStateStore((tmp_path / "state").resolve())
+    images = {_image_id(index): _managed_document(index) for index in range(1, 9)}
+    boundary = DockerBoundary(
+        images,
+        remove_images_before_list={2: (_image_id(1),)},
+    )
+    run = _mock_run(boundary)
+    with (
+        patch("agent.deployment_retention.subprocess.run", new=run),
+        store.transaction() as transaction,
+    ):
+        final, admitted, removed_decisions = apply_image_retention(
+            transaction,
+            docker=_docker(tmp_path),
+            environment=ENVIRONMENT,
+            repository=REPOSITORY,
+            target_reference=_reference(99),
+        )
+    assert admitted is True
+    assert final.admitted_count == 8
+    assert removed_decisions == ()
+    assert not any(call[1:3] == ("image", "rm") for call in boundary.calls)
+
+
+def test_replan_fails_closed_when_deterministic_order_changes(
+    tmp_path: Path,
+) -> None:
+    """Never substitute a newly ordered candidate for the reviewed sequence."""
+    store = DeploymentStateStore((tmp_path / "state").resolve())
+    boundary = DockerBoundary(
+        {_image_id(index): _managed_document(index) for index in range(1, 10)},
+        remove_images_before_list={2: (_image_id(1),)},
+    )
+    run = _mock_run(boundary)
+    with (
+        patch("agent.deployment_retention.subprocess.run", new=run),
+        store.transaction() as transaction,
+        pytest.raises(ImageRetentionError, match="deletion order changed"),
+    ):
+        apply_image_retention(
+            transaction,
+            docker=_docker(tmp_path),
+            environment=ENVIRONMENT,
+            repository=REPOSITORY,
+            target_reference=_reference(99),
+        )
+
+    removed = [
+        call[-1]
+        for call in boundary.calls
+        if call[1:4] == ("image", "rm", "--no-prune")
+    ]
+    assert removed == []
+    assert _image_id(2) in boundary.images
+
+
+def test_replan_fails_closed_when_container_use_changes_order(tmp_path: Path) -> None:
+    """Never replace a reviewed candidate after a container starts using it."""
+    store = DeploymentStateStore((tmp_path / "state").resolve())
+    boundary = DockerBoundary(
+        {_image_id(index): _managed_document(index) for index in range(1, 9)},
+        late_container=(f"{123:064x}", _image_id(1)),
+    )
+    run = _mock_run(boundary)
+
+    with (
+        patch("agent.deployment_retention.subprocess.run", new=run),
+        store.transaction() as transaction,
+        pytest.raises(ImageRetentionError, match="deletion order changed"),
+    ):
+        apply_image_retention(
+            transaction,
+            docker=_docker(tmp_path),
+            environment=ENVIRONMENT,
+            repository=REPOSITORY,
+            target_reference=_reference(99),
+        )
+
+    removed = [
+        call[-1]
+        for call in boundary.calls
+        if call[1:4] == ("image", "rm", "--no-prune")
+    ]
+    assert removed == []
+    assert _image_id(1) in boundary.images
+    assert _image_id(2) in boundary.images
+
+
+def test_exact_identity_race_after_replan_blocks_removal(tmp_path: Path) -> None:
+    """Retain the current candidate if its exact proof changes after planning."""
+    store = DeploymentStateStore((tmp_path / "state").resolve())
+    images = {_image_id(index): _managed_document(index) for index in range(1, 9)}
+    changed = _managed_document(1, revision=_revision(99))
+    boundary = DockerBoundary(
+        images,
+        scripted={
+            ("image", "inspect", _image_id(1)): [
+                _completed([], stdout=json.dumps([images[_image_id(1)]])),
+                _completed([], stdout=json.dumps([changed])),
+            ],
+            ("image", "inspect", _reference(1)): [
+                _completed([], stdout=json.dumps([images[_image_id(1)]])),
+                _completed([], stdout=json.dumps([changed])),
+            ],
+        },
+    )
+    run = _mock_run(boundary)
+
+    with (
+        patch("agent.deployment_retention.subprocess.run", new=run),
+        store.transaction() as transaction,
+        pytest.raises(ImageRetentionError, match="changed before exact removal"),
+    ):
+        apply_image_retention(
+            transaction,
+            docker=_docker(tmp_path),
+            environment=ENVIRONMENT,
+            repository=REPOSITORY,
+            target_reference=_reference(99),
+        )
+
+    assert not any(call[1:3] == ("image", "rm") for call in boundary.calls)
+
+
+@pytest.mark.parametrize(
+    ("repository", "target", "image_repository", "message"),
+    [
+        ("invalid", _reference(1), None, "GitHub repository"),
+        (REPOSITORY, _reference(1), "INVALID", "image repository"),
+        (REPOSITORY, "ghcr.io/example:latest", None, "target image"),
+    ],
+)
+def test_identity_input_validation(
+    repository: str,
+    target: str,
+    image_repository: str | None,
+    message: str,
+) -> None:
+    """Reject identities before touching state or Docker."""
+    with pytest.raises(ImageRetentionError, match=message):
+        retention._validated_identity(repository, target, image_repository)
+
+
+def test_docker_path_and_command_failures_are_bounded(
+    tmp_path: Path,
+) -> None:
+    """Map path, timeout, spawn, exit, and output failures to safe errors."""
+    missing = (tmp_path / "missing").resolve()
+    with pytest.raises(ImageRetentionError, match="unavailable"):
+        retention._validated_docker(missing)
+    with pytest.raises(ImageRetentionError, match="invalid"):
+        retention._validated_docker(tmp_path.resolve())
+
+    docker = _docker(tmp_path)
+    cases: list[tuple[BaseException | subprocess.CompletedProcess[str], str]] = [
+        (subprocess.TimeoutExpired(["docker"], 60), "timed out"),
+        (OSError("secret"), "could not start"),
+        (_completed([], returncode=2, stderr="secret"), "failed"),
+        (
+            _completed([], stdout="x" * (256 * 1024 + 1)),
+            "output is too large",
+        ),
+    ]
+    for response, message in cases:
+        run = create_autospec(
+            subprocess.run,
+            spec_set=True,
+            side_effect=response if isinstance(response, BaseException) else None,
+            return_value=None if isinstance(response, BaseException) else response,
+        )
+        with (
+            patch("agent.deployment_retention.subprocess.run", new=run),
+            pytest.raises(ImageRetentionError, match=message),
+        ):
+            retention._run(docker, ["image", "ls"], environment=ENVIRONMENT)
+
+
+@pytest.mark.parametrize(
+    ("operation", "message"),
+    [
+        (
+            lambda: retention._identity_lines("bad\r\n", retention._IMAGE_ID, "image"),
+            "inventory",
+        ),
+        (
+            lambda: retention._identity_lines(
+                "invalid\n", retention._IMAGE_ID, "image"
+            ),
+            "inventory",
+        ),
+        (lambda: retention._decode_single_document("{", "image"), "inspection"),
+        (lambda: retention._decode_single_document("{}", "image"), "inspection"),
+        (
+            lambda: retention._image_document(
+                json.dumps(
+                    [{"Id": "bad", "RepoDigests": [], "RepoTags": [], "Config": {}}]
+                )
+            ),
+            "identity",
+        ),
+        (
+            lambda: retention._image_document(
+                json.dumps(
+                    [
+                        {
+                            "Id": _image_id(1),
+                            "RepoDigests": [],
+                            "RepoTags": [],
+                        }
+                    ]
+                )
+            ),
+            "configuration",
+        ),
+        (
+            lambda: retention._image_document(
+                json.dumps(
+                    [
+                        {
+                            "Id": _image_id(1),
+                            "RepoDigests": [],
+                            "RepoTags": [],
+                            "Config": {"Labels": {"bad": 1}},
+                        }
+                    ]
+                )
+            ),
+            "labels",
+        ),
+        (
+            lambda: retention._image_document(
+                json.dumps(
+                    [
+                        {
+                            "Id": _image_id(1),
+                            "RepoDigests": "bad",
+                            "RepoTags": [],
+                            "Config": {"Labels": None},
+                        }
+                    ]
+                )
+            ),
+            "digests",
+        ),
+    ],
+)
+def test_malformed_docker_documents_are_rejected(
+    operation: Any,
+    message: str,
+) -> None:
+    """Fail closed for every malformed Docker JSON boundary."""
+    with pytest.raises(ImageRetentionError, match=message):
+        operation()
+
+
+def test_optional_empty_docker_fields_are_valid_but_unmanaged() -> None:
+    """Accept Docker's null empty-list encoding without claiming ownership."""
+    document = retention._image_document(
+        json.dumps(
+            [
+                {
+                    "Id": _image_id(1),
+                    "RepoDigests": None,
+                    "RepoTags": None,
+                    "Config": {"Labels": None},
+                }
+            ]
+        )
+    )
+    assert document.repo_digests == ()
+    assert document.repo_tags == ()
+    assert document.labels == {}
+
+
+@pytest.mark.parametrize("stdout", ["[]\n", "[]"])
+def test_exact_docker_inspect_absence_is_accepted(
+    tmp_path: Path,
+    stdout: str,
+) -> None:
+    """Accept only Docker's bounded empty-array absence serialization."""
+    docker = _docker(tmp_path)
+    identifier = _reference(1)
+    boundary = DockerBoundary(
+        {},
+        scripted={
+            ("image", "inspect", identifier): [
+                _completed(
+                    [],
+                    returncode=1,
+                    stdout=stdout,
+                    stderr=(
+                        f"Error response from daemon: No such image: {identifier}\n"
+                    ),
+                )
+            ]
+        },
+    )
+
+    with patch(
+        "agent.deployment_retention.subprocess.run",
+        new=_mock_run(boundary),
+    ):
+        assert retention._inspect_image(docker, identifier, ENVIRONMENT) is None
+
+
+@pytest.mark.parametrize(
+    ("returncode", "stdout", "stderr", "message"),
+    [
+        (
+            1,
+            "",
+            f"Error response from daemon: No such image: {_reference(1)}\n",
+            "absence could not be proven",
+        ),
+        (
+            1,
+            "[ ]\n",
+            f"Error response from daemon: No such image: {_reference(1)}\n",
+            "absence could not be proven",
+        ),
+        (
+            1,
+            "[]\n",
+            f"Error response from daemon: No such image: {_reference(1)}",
+            "absence could not be proven",
+        ),
+        (
+            1,
+            "[]\n",
+            f"Error response from daemon: No such image: {_reference(2)}\n",
+            "absence could not be proven",
+        ),
+        (0, "[]\n", "", "inspection is invalid"),
+        (2, "[]\n", "daemon unavailable", "command failed"),
+    ],
+)
+def test_inconsistent_docker_inspect_absence_is_rejected(
+    tmp_path: Path,
+    returncode: int,
+    stdout: str,
+    stderr: str,
+    message: str,
+) -> None:
+    """Reject every return-code/stdout/stderr combination outside the contract."""
+    docker = _docker(tmp_path)
+    identifier = _reference(1)
+    boundary = DockerBoundary(
+        {},
+        scripted={
+            ("image", "inspect", identifier): [
+                _completed(
+                    [],
+                    returncode=returncode,
+                    stdout=stdout,
+                    stderr=stderr,
+                )
+            ]
+        },
+    )
+
+    with (
+        patch(
+            "agent.deployment_retention.subprocess.run",
+            new=_mock_run(boundary),
+        ),
+        pytest.raises(ImageRetentionError, match=message),
+    ):
+        retention._inspect_image(docker, identifier, ENVIRONMENT)
+
+
+def test_unproven_inspect_absence_is_an_error(
+    tmp_path: Path,
+) -> None:
+    """Do not interpret an arbitrary Docker exit one as object absence."""
+    docker = _docker(tmp_path)
+    boundary = DockerBoundary(
+        {},
+        scripted={
+            ("image", "inspect", _reference(1)): [
+                _completed([], returncode=1, stderr="daemon unavailable")
+            ]
+        },
+    )
+    with (
+        patch(
+            "agent.deployment_retention.subprocess.run",
+            new=_mock_run(boundary),
+        ),
+        pytest.raises(ImageRetentionError, match="absence could not be proven"),
+    ):
+        retention._inspect_image(docker, _reference(1), ENVIRONMENT)
+
+
+def test_cli_admitted_busy_missing_docker_oserror_and_module_entry(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Cover stable success and host/state failure process statuses."""
+    state_dir = (tmp_path / "state").resolve()
+    docker = _docker(tmp_path)
+    boundary = DockerBoundary({})
+    arguments = [
+        "enforce",
+        "--state-dir",
+        str(state_dir),
+        "--repository",
+        REPOSITORY,
+        "--target-reference",
+        _reference(99),
+        "--apply",
+    ]
+    with (
+        patch(
+            "agent.deployment_retention.subprocess.run",
+            new=_mock_run(boundary),
+        ),
+        patch("agent.deployment_retention.shutil.which", return_value=str(docker)),
+    ):
+        assert main(arguments, environment=ENVIRONMENT) == 0
+    assert json.loads(capsys.readouterr().out)["status"] == "admitted"
+
+    store = DeploymentStateStore(state_dir)
+    with (
+        store.transaction(),
+        patch("agent.deployment_retention.shutil.which", return_value=str(docker)),
+    ):
+        assert main(arguments, environment=ENVIRONMENT) == 75
+    assert "another deployment transaction" in capsys.readouterr().err
+
+    with patch("agent.deployment_retention.shutil.which", return_value=None):
+        assert main(arguments, environment=ENVIRONMENT) == 1
+    assert "Docker executable is unavailable" in capsys.readouterr().err
+
+    blocking_file = tmp_path / "not-a-directory"
+    blocking_file.write_text("operator-owned", encoding="utf-8")
+    broken_arguments = list(arguments)
+    broken_arguments[broken_arguments.index(str(state_dir))] = str(
+        blocking_file / "state"
+    )
+    with patch("agent.deployment_retention.shutil.which", return_value=str(docker)):
+        assert main(broken_arguments, environment=ENVIRONMENT) == 1
+    assert "host operation failed" in capsys.readouterr().err
+
+    run = _mock_run(DockerBoundary({}))
+    with (
+        patch.object(sys, "argv", ["deployment-retention", *arguments]),
+        patch("subprocess.run", new=run),
+        patch("shutil.which", return_value=str(docker)),
+        pytest.raises(SystemExit) as exited,
+    ):
+        runpy.run_module("agent.deployment_retention", run_name="__main__")
+    assert exited.value.code == 0
+    assert json.loads(capsys.readouterr().out)["status"] == "admitted"
+
+
+def test_cli_busy_lock_is_cross_process_and_never_executes_docker(
+    tmp_path: Path,
+) -> None:
+    """Prove a real competing process exits before any Docker observation."""
+    state_dir = (tmp_path / "state").resolve()
+    store = DeploymentStateStore(state_dir)
+    executable_dir = tmp_path / "bin"
+    executable_dir.mkdir()
+    docker = executable_dir / "docker"
+    sentinel = executable_dir / "docker.log"
+    sentinel.write_bytes(b"")
+    docker.write_text(
+        '#!/bin/sh\nprintf "called\\n" >> "${0}.log"\nexit 99\n',
+        encoding="utf-8",
+    )
+    docker.chmod(0o700)
+    environment = {
+        "HOME": str(tmp_path),
+        "LANG": "C",
+        "LC_ALL": "C",
+        "PATH": str(executable_dir),
+        "PYTHONPATH": str(Path("src").resolve()),
+    }
+    command = [
+        sys.executable,
+        "-m",
+        "agent.deployment_retention",
+        "enforce",
+        "--state-dir",
+        str(state_dir),
+        "--repository",
+        REPOSITORY,
+        "--target-reference",
+        _reference(99),
+        "--apply",
+    ]
+
+    with store.transaction():
+        result = subprocess.run(  # noqa: S603 - fixed interpreter and arguments
+            command,
+            env=environment,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=10,
+        )
+
+    assert result.returncode == 75
+    assert result.stdout == ""
+    assert "another deployment transaction" in result.stderr
+    assert sentinel.read_bytes() == b""
+
+
+def test_pyproject_exposes_retention_entrypoint() -> None:
+    """Keep the operator CLI available without constructing module paths."""
+    document = Path("pyproject.toml").read_text(encoding="utf-8")
+    assert 'deployment-retention = "agent.deployment_retention:main"' in document

--- a/tests/test_deployment_retention_runtime.py
+++ b/tests/test_deployment_retention_runtime.py
@@ -80,7 +80,6 @@ type BuilderCacheIdentity = tuple[
     str,
     str,
     int,
-    str | None,
 ]
 
 
@@ -973,7 +972,6 @@ def _builder_cache_identity(
                 record_type,
                 description,
                 usage_count,
-                last_used_at,
             )
         )
     if len({identity[0] for identity in identities}) != len(identities):
@@ -1088,6 +1086,98 @@ def test_optional_inspection_rejects_ambiguous_absence(
         pytest.raises(AssertionError, match="network inspection failed"),
     ):
         _inspect_optional("docker", {}, "network", "fixture")
+
+
+def test_builder_cache_identity_ignores_relative_last_used_age() -> None:
+    """Compare stable cache records without comparing Docker's relative clock."""
+    document = {
+        "CreatedAt": "2026-07-29 01:07:59.391031871 +0000 UTC",
+        "Description": "local source for context",
+        "ID": "cache-record",
+        "LastUsedAt": "Less than a second ago",
+        "Mutable": False,
+        "Parents": None,
+        "Reclaimable": True,
+        "Shared": False,
+        "Size": "0B",
+        "Type": "source.local",
+        "UsageCount": 1,
+    }
+    later_document = {**document, "LastUsedAt": "2 seconds ago"}
+    runner = create_autospec(
+        _run,
+        spec_set=True,
+        side_effect=[
+            subprocess.CompletedProcess(
+                [],
+                0,
+                stdout=f"{json.dumps(document)}\n",
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                [],
+                0,
+                stdout=f"{json.dumps(later_document)}\n",
+                stderr="",
+            ),
+        ],
+    )
+
+    with patch(f"{__name__}._run", runner):
+        initial = _builder_cache_identity("docker", {})
+        later = _builder_cache_identity("docker", {})
+
+    expected = (
+        (
+            "cache-record",
+            (),
+            "2026-07-29 01:07:59.391031871 +0000 UTC",
+            False,
+            True,
+            "0B",
+            "source.local",
+            "local source for context",
+            1,
+        ),
+    )
+    assert initial == expected
+    assert later == expected
+
+
+@pytest.mark.parametrize("last_used_at", ["", 0, []])
+def test_builder_cache_identity_rejects_invalid_last_used_age(
+    last_used_at: object,
+) -> None:
+    """Keep validating Docker's dynamic field even though it is not compared."""
+    document = {
+        "CreatedAt": "2026-07-29 01:07:59.391031871 +0000 UTC",
+        "Description": "local source for context",
+        "ID": "cache-record",
+        "LastUsedAt": last_used_at,
+        "Mutable": False,
+        "Parents": None,
+        "Reclaimable": True,
+        "Shared": False,
+        "Size": "0B",
+        "Type": "source.local",
+        "UsageCount": 1,
+    }
+    runner = create_autospec(
+        _run,
+        spec_set=True,
+        return_value=subprocess.CompletedProcess(
+            [],
+            0,
+            stdout=f"{json.dumps(document)}\n",
+            stderr="",
+        ),
+    )
+
+    with (
+        patch(f"{__name__}._run", runner),
+        pytest.raises(AssertionError, match="cache identity was invalid"),
+    ):
+        _builder_cache_identity("docker", {})
 
 
 def test_hosted_retention_job_is_exact_and_isolated() -> None:

--- a/tests/test_deployment_retention_runtime.py
+++ b/tests/test_deployment_retention_runtime.py
@@ -1,0 +1,1488 @@
+"""Opt-in real-Docker proof for bounded VM image retention."""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import os
+import re
+import shutil
+import stat
+import subprocess
+import time
+import uuid
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+from urllib.error import URLError
+from urllib.request import ProxyHandler, build_opener
+
+import pytest
+import yaml  # type: ignore[import-untyped]
+
+from agent.deployment_retention import (
+    RetentionPlan,
+    apply_image_retention,
+    enforce_pull_admission,
+    plan_image_retention,
+)
+from agent.deployment_state import (
+    CandidateReceipt,
+    DeploymentStateStore,
+    DeploymentStateTransaction,
+    PersistentVolumeIdentity,
+)
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = REPOSITORY_ROOT / ".github" / "workflows" / "test-docker-compose.yml"
+RUN_ENVIRONMENT_NAME = "RUN_DEPLOYMENT_RETENTION_INTEGRATION"
+PREFIX_ENVIRONMENT_NAME = "DEPLOYMENT_RETENTION_TEST_PREFIX"
+PREFIX_PATTERN = re.compile(r"adk-retention-[a-z0-9][a-z0-9-]{0,30}\Z")
+RESOURCE_NAME_PATTERN = re.compile(r"[a-z0-9][a-z0-9_.-]{0,62}\Z")
+IMAGE_ID_PATTERN = re.compile(r"sha256:[0-9a-f]{64}\Z")
+IMAGE_REFERENCE_PATTERN = re.compile(
+    r"127\.0\.0\.1:[0-9]+/[a-z0-9-]+/agent@sha256:[0-9a-f]{64}\Z"
+)
+CONTAINER_ID_PATTERN = re.compile(r"[0-9a-f]{64}\Z")
+MANAGED_REPOSITORY = "QueryPlanner/google-adk-on-bare-metal"
+MANAGED_SOURCE = f"https://github.com/{MANAGED_REPOSITORY}"
+MANAGED_LABEL = "io.queryplanner.adk.repository"
+OWNER_LABEL = "io.queryplanner.adk.retention-test.owner"
+PRIVATE_CANARY = 'retention-private-$-हॅलो-"-\\-canary'
+VOLUME_SENTINEL = "retention-volume-sentinel"
+REGISTRY_IMAGE_REFERENCE = (
+    "registry@sha256:1be55279f18a2fe1a74edf2664cac61c1bea305b7b4642dab412e7affdcb3e33"
+)
+DERIVATIVE_DOCKERFILE = """\
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+ARG MANAGED_REPOSITORY
+ARG MANAGED_SOURCE
+ARG OWNER
+ARG REVISION
+LABEL io.queryplanner.adk.repository="${MANAGED_REPOSITORY}"
+LABEL org.opencontainers.image.source="${MANAGED_SOURCE}"
+LABEL org.opencontainers.image.revision="${REVISION}"
+LABEL io.queryplanner.adk.retention-test.owner="${OWNER}"
+"""
+
+type ResourceKind = Literal["container", "image", "network", "volume"]
+type BuilderCacheIdentity = tuple[
+    str,
+    tuple[str, ...],
+    str,
+    bool,
+    bool,
+    str,
+    str,
+    str,
+    int,
+    str | None,
+]
+
+
+@dataclass(frozen=True, slots=True)
+class ManagedImage:
+    """One exact managed image identity published to the local registry."""
+
+    reference: str
+    image_id: str
+    revision: str
+
+
+@dataclass(frozen=True, slots=True)
+class CleanupTarget:
+    """One exact Docker resource with an independent ownership proof."""
+
+    kind: ResourceKind
+    reference: str
+    expected_owner: str | None = None
+    expected_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if (self.expected_owner is None) == (self.expected_id is None):
+            raise AssertionError("cleanup target needs exactly one ownership proof")
+
+
+def _secret_representations(secret: str) -> tuple[str, ...]:
+    byte_representation = repr(secret.encode())
+    candidates = {
+        secret,
+        secret.replace("$", "$$"),
+        json.dumps(secret, ensure_ascii=False)[1:-1],
+        json.dumps(secret, ensure_ascii=True)[1:-1],
+        repr(secret),
+        byte_representation,
+        byte_representation[2:-1],
+    }
+    return tuple(sorted(filter(None, candidates), key=len, reverse=True))
+
+
+def _redact(value: str) -> str:
+    redacted = value
+    for representation in _secret_representations(PRIVATE_CANARY):
+        redacted = redacted.replace(representation, "[REDACTED]")
+    return redacted
+
+
+def _run(
+    command: Sequence[str],
+    *,
+    environment: Mapping[str, str],
+    cwd: Path = REPOSITORY_ROOT,
+    check: bool = True,
+    timeout: float = 180,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        result = subprocess.run(  # noqa: S603 - fixed/resolved test executables
+            list(command),
+            cwd=cwd,
+            env=environment,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as error:
+        stdout = _redact(str(error.stdout or "")[-4_000:])
+        stderr = _redact(str(error.stderr or "")[-4_000:])
+        raise AssertionError(
+            f"{' '.join(command[:3])} exceeded {timeout:g} seconds\n"
+            f"stdout:\n{stdout}\nstderr:\n{stderr}"
+        ) from None
+    if check and result.returncode != 0:
+        stdout = _redact(result.stdout[-4_000:])
+        stderr = _redact(result.stderr[-4_000:])
+        raise AssertionError(
+            f"{' '.join(command[:3])} failed with {result.returncode}\n"
+            f"stdout:\n{stdout}\nstderr:\n{stderr}"
+        )
+    return result
+
+
+def _base_environment() -> dict[str, str]:
+    inherited = (
+        "DOCKER_CONFIG",
+        "DOCKER_CONTEXT",
+        "DOCKER_HOST",
+        "HOME",
+        "PATH",
+        "SSL_CERT_DIR",
+        "SSL_CERT_FILE",
+        "XDG_RUNTIME_DIR",
+    )
+    environment = {name: os.environ[name] for name in inherited if name in os.environ}
+    environment.update({"LANG": "C.UTF-8", "LC_ALL": "C.UTF-8"})
+    return environment
+
+
+def _require_docker(environment: Mapping[str, str]) -> str:
+    docker = shutil.which("docker", path=environment.get("PATH"))
+    if docker is None:
+        raise AssertionError("Docker CLI is required for the opted-in proof")
+    selected = Path(docker).resolve(strict=True)
+    if not stat.S_ISREG(selected.stat().st_mode):
+        raise AssertionError("Docker CLI is not a regular file")
+    _run([str(selected), "version"], environment=environment, timeout=30)
+    return str(selected)
+
+
+def _resource_prefix() -> str:
+    configured = os.environ.get(
+        PREFIX_ENVIRONMENT_NAME,
+        f"adk-retention-{os.getpid()}",
+    ).lower()
+    if PREFIX_PATTERN.fullmatch(configured) is None:
+        raise AssertionError("deployment-retention Docker prefix is invalid")
+    selected = f"{configured}-{uuid.uuid4().hex[:12]}"
+    if RESOURCE_NAME_PATTERN.fullmatch(selected) is None:
+        raise AssertionError("deployment-retention resource prefix is invalid")
+    return selected
+
+
+def _inspect_optional(
+    docker: str,
+    environment: Mapping[str, str],
+    kind: ResourceKind,
+    reference: str,
+) -> dict[str, object] | None:
+    result = _run(
+        [docker, kind, "inspect", reference],
+        environment=environment,
+        check=False,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        if any(
+            marker in result.stderr
+            for marker in (
+                "No such image",
+                "No such container",
+                "No such network",
+                "No such object",
+                "No such volume",
+            )
+        ):
+            return None
+        raise AssertionError(f"Docker {kind} inspection failed")
+    documents = json.loads(result.stdout)
+    if not isinstance(documents, list) or len(documents) != 1:
+        raise AssertionError(f"Docker {kind} inspection was ambiguous")
+    document = documents[0]
+    if not isinstance(document, dict):
+        raise AssertionError(f"Docker {kind} inspection was invalid")
+    return document
+
+
+def _resource_identity(kind: ResourceKind, document: Mapping[str, object]) -> str:
+    identity = document.get("Name") if kind == "volume" else document.get("Id")
+    if not isinstance(identity, str):
+        raise AssertionError(f"Docker {kind} identity was invalid")
+    return identity
+
+
+def _resource_labels(
+    kind: ResourceKind,
+    document: Mapping[str, object],
+) -> Mapping[str, object]:
+    if kind in {"container", "image"}:
+        config = document.get("Config")
+        if not isinstance(config, dict):
+            raise AssertionError(f"Docker {kind} configuration was invalid")
+        labels = config.get("Labels")
+    else:
+        labels = document.get("Labels")
+    if not isinstance(labels, dict):
+        raise AssertionError(f"Docker {kind} labels were invalid")
+    return labels
+
+
+def _owned_document(
+    docker: str,
+    environment: Mapping[str, str],
+    target: CleanupTarget,
+) -> dict[str, object] | None:
+    document = _inspect_optional(
+        docker,
+        environment,
+        target.kind,
+        target.reference,
+    )
+    if document is None:
+        return None
+    identity = _resource_identity(target.kind, document)
+    if target.expected_id is not None and identity != target.expected_id:
+        raise AssertionError("cleanup target identity changed")
+    if target.expected_owner is not None:
+        labels = _resource_labels(target.kind, document)
+        if labels.get(OWNER_LABEL) != target.expected_owner:
+            raise AssertionError("cleanup target owner changed")
+    return document
+
+
+def _cleanup_target(
+    docker: str,
+    environment: Mapping[str, str],
+    target: CleanupTarget,
+) -> None:
+    document = _owned_document(docker, environment, target)
+    if document is None:
+        return
+    identity = _resource_identity(target.kind, document)
+    if target.kind == "container":
+        state = document.get("State")
+        if not isinstance(state, dict):
+            raise AssertionError("cleanup container state was invalid")
+        if state.get("Running") is True:
+            _run(
+                [docker, "container", "stop", "--time", "10", identity],
+                environment=environment,
+                timeout=30,
+            )
+        if _owned_document(docker, environment, target) is None:
+            return
+        command = [docker, "container", "rm", "--volumes", identity]
+    elif target.kind == "image":
+        command = [
+            docker,
+            "image",
+            "rm",
+            "--no-prune",
+            target.reference,
+        ]
+    elif target.kind == "network":
+        command = [docker, "network", "rm", identity]
+    else:
+        command = [docker, "volume", "rm", identity]
+    _run(command, environment=environment, timeout=90)
+    if _owned_document(docker, environment, target) is not None:
+        raise AssertionError("exact cleanup left its owned target")
+
+
+def _execute_cleanup(
+    docker: str,
+    environment: Mapping[str, str],
+    targets: Sequence[CleanupTarget],
+) -> list[str]:
+    priorities = {"container": 0, "network": 1, "volume": 2, "image": 3}
+    failures: list[str] = []
+    ordered = sorted(
+        enumerate(targets),
+        key=lambda item: (priorities[item[1].kind], -item[0]),
+    )
+    for _index, target in ordered:
+        try:
+            _cleanup_target(docker, environment, target)
+        except (AssertionError, OSError, TypeError, ValueError) as error:
+            failures.append(_redact(str(error)[-1_000:]))
+    return failures
+
+
+def _report_cleanup_failures(
+    failures: Sequence[str],
+    primary_error: BaseException | None,
+) -> None:
+    if not failures:
+        return
+    message = "deployment-retention cleanup failed: " + " | ".join(failures)
+    if primary_error is None:
+        raise AssertionError(message)
+    primary_error.add_note(message)
+
+
+def _assert_absent(
+    docker: str,
+    environment: Mapping[str, str],
+    kind: ResourceKind,
+    reference: str,
+) -> None:
+    if _inspect_optional(docker, environment, kind, reference) is not None:
+        raise AssertionError(f"generated Docker {kind} already exists")
+
+
+def _ensure_registry_image(
+    docker: str,
+    environment: Mapping[str, str],
+    cleanup_targets: list[CleanupTarget],
+) -> str:
+    document = _inspect_optional(
+        docker,
+        environment,
+        "image",
+        REGISTRY_IMAGE_REFERENCE,
+    )
+    introduced = document is None
+    if introduced:
+        _run(
+            [docker, "image", "pull", REGISTRY_IMAGE_REFERENCE],
+            environment=environment,
+            timeout=180,
+        )
+        document = _inspect_optional(
+            docker,
+            environment,
+            "image",
+            REGISTRY_IMAGE_REFERENCE,
+        )
+    if document is None:
+        raise AssertionError("pinned registry image is unavailable")
+    image_id = _resource_identity("image", document)
+    if IMAGE_ID_PATTERN.fullmatch(image_id) is None:
+        raise AssertionError("pinned registry image ID was invalid")
+    if introduced:
+        cleanup_targets.append(
+            CleanupTarget(
+                kind="image",
+                reference=REGISTRY_IMAGE_REFERENCE,
+                expected_id=image_id,
+            )
+        )
+    return image_id
+
+
+def _start_registry(
+    docker: str,
+    environment: Mapping[str, str],
+    cleanup_targets: list[CleanupTarget],
+    *,
+    name: str,
+    image_id: str,
+    owner: str,
+) -> str:
+    _assert_absent(docker, environment, "container", name)
+    target = CleanupTarget(
+        kind="container",
+        reference=name,
+        expected_owner=owner,
+    )
+    cleanup_targets.append(target)
+    _run(
+        [
+            docker,
+            "container",
+            "create",
+            "--name",
+            name,
+            "--label",
+            f"{OWNER_LABEL}={owner}",
+            "--publish",
+            "127.0.0.1::5000",
+            image_id,
+        ],
+        environment=environment,
+        timeout=30,
+    )
+    _run(
+        [docker, "container", "start", name],
+        environment=environment,
+        timeout=30,
+    )
+    port = _run(
+        [
+            docker,
+            "container",
+            "inspect",
+            "--format",
+            '{{(index (index .NetworkSettings.Ports "5000/tcp") 0).HostPort}}',
+            name,
+        ],
+        environment=environment,
+        timeout=30,
+    ).stdout.strip()
+    if re.fullmatch(r"[0-9]{1,5}", port) is None:
+        raise AssertionError("private registry port was invalid")
+    endpoint = f"127.0.0.1:{port}"
+    opener = build_opener(ProxyHandler({}))
+    deadline = time.monotonic() + 30
+    while True:
+        try:
+            with opener.open(f"http://{endpoint}/v2/", timeout=2) as response:
+                if response.status != 200:
+                    raise AssertionError("private registry response was invalid")
+            return endpoint
+        except URLError:
+            if time.monotonic() >= deadline:
+                raise AssertionError("private registry did not become ready") from None
+            time.sleep(0.25)
+
+
+def _write_derivative_context(context: Path) -> None:
+    context.mkdir(mode=0o700)
+    (context / "Dockerfile").write_text(
+        DERIVATIVE_DOCKERFILE,
+        encoding="utf-8",
+    )
+
+
+def _managed_image_document(
+    docker: str,
+    environment: Mapping[str, str],
+    reference: str,
+    *,
+    owner: str,
+    revision: str,
+) -> dict[str, object]:
+    document = _inspect_optional(docker, environment, "image", reference)
+    if document is None:
+        raise AssertionError("managed image was unavailable")
+    image_id = _resource_identity("image", document)
+    if IMAGE_ID_PATTERN.fullmatch(image_id) is None:
+        raise AssertionError("managed image ID was invalid")
+    config = document.get("Config")
+    if not isinstance(config, dict):
+        raise AssertionError("managed image configuration was invalid")
+    labels = config.get("Labels")
+    expected_labels = {
+        MANAGED_LABEL: MANAGED_REPOSITORY,
+        "org.opencontainers.image.source": MANAGED_SOURCE,
+        "org.opencontainers.image.revision": revision,
+        OWNER_LABEL: owner,
+    }
+    if not isinstance(labels, dict) or any(
+        labels.get(name) != value for name, value in expected_labels.items()
+    ):
+        raise AssertionError("managed image labels did not match")
+    return document
+
+
+def _publish_managed_image(
+    docker: str,
+    environment: Mapping[str, str],
+    cleanup_targets: list[CleanupTarget],
+    *,
+    context: Path,
+    repository: str,
+    phase: int,
+    owner: str,
+    keep_local: bool,
+) -> ManagedImage:
+    revision = hashlib.sha1(  # noqa: S324 - Git-shaped fixture identity
+        f"{owner}-revision-{phase}".encode()
+    ).hexdigest()
+    tag = f"{repository}:fixture-{phase}"
+    _assert_absent(docker, environment, "image", tag)
+    cleanup_targets.append(
+        CleanupTarget(
+            kind="image",
+            reference=tag,
+            expected_owner=owner,
+        )
+    )
+    iid_file = context / f"phase-{phase}.iid"
+    _run(
+        [
+            docker,
+            "build",
+            "--iidfile",
+            str(iid_file),
+            "--tag",
+            tag,
+            "--build-arg",
+            f"BASE_IMAGE={REGISTRY_IMAGE_REFERENCE}",
+            "--build-arg",
+            f"MANAGED_REPOSITORY={MANAGED_REPOSITORY}",
+            "--build-arg",
+            f"MANAGED_SOURCE={MANAGED_SOURCE}",
+            "--build-arg",
+            f"OWNER={owner}",
+            "--build-arg",
+            f"REVISION={revision}",
+            str(context),
+        ],
+        environment=environment,
+        timeout=300,
+    )
+    image_id = iid_file.read_text(encoding="ascii").strip()
+    if IMAGE_ID_PATTERN.fullmatch(image_id) is None:
+        raise AssertionError("Docker build returned an invalid image ID")
+    built = _managed_image_document(
+        docker,
+        environment,
+        tag,
+        owner=owner,
+        revision=revision,
+    )
+    if _resource_identity("image", built) != image_id:
+        raise AssertionError("built image ID changed")
+    _run(
+        [docker, "image", "push", tag],
+        environment=environment,
+        timeout=180,
+    )
+    pushed = _managed_image_document(
+        docker,
+        environment,
+        tag,
+        owner=owner,
+        revision=revision,
+    )
+    digests = pushed.get("RepoDigests")
+    if not isinstance(digests, list):
+        raise AssertionError("pushed image digests were invalid")
+    exact = [
+        value
+        for value in digests
+        if isinstance(value, str) and value.startswith(f"{repository}@sha256:")
+    ]
+    if len(exact) != 1 or IMAGE_REFERENCE_PATTERN.fullmatch(exact[0]) is None:
+        raise AssertionError("pushed image digest was ambiguous")
+    reference = exact[0]
+    cleanup_targets.append(
+        CleanupTarget(
+            kind="image",
+            reference=reference,
+            expected_owner=owner,
+        )
+    )
+    _cleanup_target(
+        docker,
+        environment,
+        CleanupTarget(
+            kind="image",
+            reference=tag,
+            expected_owner=owner,
+        ),
+    )
+    if keep_local:
+        _run(
+            [docker, "image", "pull", reference],
+            environment=environment,
+            timeout=180,
+        )
+        local = _managed_image_document(
+            docker,
+            environment,
+            reference,
+            owner=owner,
+            revision=revision,
+        )
+        if _resource_identity("image", local) != image_id:
+            raise AssertionError("pulled image ID changed")
+        if local.get("RepoTags") not in (None, []):
+            raise AssertionError("managed image retained a mutable tag")
+        if local.get("RepoDigests") != [reference]:
+            raise AssertionError("managed image digest set was ambiguous")
+    elif _inspect_optional(docker, environment, "image", reference) is not None:
+        _cleanup_target(
+            docker,
+            environment,
+            CleanupTarget(
+                kind="image",
+                reference=reference,
+                expected_owner=owner,
+            ),
+        )
+    return ManagedImage(reference=reference, image_id=image_id, revision=revision)
+
+
+def _volume_document(
+    docker: str,
+    environment: Mapping[str, str],
+    name: str,
+) -> dict[str, object]:
+    document = _inspect_optional(docker, environment, "volume", name)
+    if document is None:
+        raise AssertionError("sentinel volume was unavailable")
+    return document
+
+
+def _volume_identity(document: Mapping[str, object]) -> dict[str, object]:
+    return {
+        name: document.get(name)
+        for name in (
+            "Name",
+            "Driver",
+            "Mountpoint",
+            "CreatedAt",
+            "Labels",
+            "Options",
+            "Scope",
+        )
+    }
+
+
+def _recorded_volume(
+    docker: str,
+    environment: Mapping[str, str],
+    name: str,
+) -> PersistentVolumeIdentity:
+    document = _volume_document(docker, environment, name)
+    driver = document.get("Driver")
+    mountpoint = document.get("Mountpoint")
+    created_at = document.get("CreatedAt")
+    if not all(isinstance(value, str) for value in (driver, mountpoint, created_at)):
+        raise AssertionError("sentinel volume identity was invalid")
+    return PersistentVolumeIdentity(
+        name=name,
+        driver=str(driver),
+        mountpoint=str(mountpoint),
+        destination="/sentinel",
+        created_at=str(created_at),
+    )
+
+
+def _container_document(
+    docker: str,
+    environment: Mapping[str, str],
+    name: str,
+) -> dict[str, object]:
+    document = _inspect_optional(docker, environment, "container", name)
+    if document is None:
+        raise AssertionError("sentinel container was unavailable")
+    return document
+
+
+def _container_identity(document: Mapping[str, object]) -> dict[str, object]:
+    state = document.get("State")
+    config = document.get("Config")
+    network = document.get("NetworkSettings")
+    mounts = document.get("Mounts")
+    if not (
+        isinstance(state, dict)
+        and isinstance(config, dict)
+        and isinstance(network, dict)
+        and isinstance(mounts, list)
+    ):
+        raise AssertionError("sentinel container identity was invalid")
+    return {
+        "Id": document.get("Id"),
+        "Name": document.get("Name"),
+        "Image": document.get("Image"),
+        "Created": document.get("Created"),
+        "RestartCount": document.get("RestartCount"),
+        "Config": config,
+        "State": {
+            name: state.get(name)
+            for name in (
+                "Status",
+                "Running",
+                "Pid",
+                "StartedAt",
+                "FinishedAt",
+            )
+        },
+        "Mounts": mounts,
+        "Networks": network.get("Networks"),
+    }
+
+
+def _network_identity(document: Mapping[str, object]) -> dict[str, object]:
+    return {
+        name: document.get(name)
+        for name in (
+            "Name",
+            "Id",
+            "Created",
+            "Scope",
+            "Driver",
+            "EnableIPv6",
+            "IPAM",
+            "Internal",
+            "Attachable",
+            "Ingress",
+            "ConfigOnly",
+            "Containers",
+            "Options",
+            "Labels",
+        )
+    }
+
+
+def _image_identity(document: Mapping[str, object]) -> dict[str, object]:
+    config = document.get("Config")
+    if not isinstance(config, dict):
+        raise AssertionError("sentinel image configuration was invalid")
+    return {
+        "Id": document.get("Id"),
+        "RepoTags": document.get("RepoTags"),
+        "RepoDigests": document.get("RepoDigests"),
+        "Created": document.get("Created"),
+        "Config": config,
+    }
+
+
+def _write_private(path: Path, payload: bytes) -> None:
+    path.write_bytes(payload)
+    path.chmod(0o600)
+
+
+def _candidate(
+    transaction: DeploymentStateTransaction,
+    image: ManagedImage,
+    *,
+    phase: int,
+) -> CandidateReceipt:
+    journal = transaction.journal()
+    tail = journal[-1] if journal else None
+    return CandidateReceipt(
+        observed_at=f"2026-07-29T00:00:0{phase}.000000Z",
+        compose_project=f"candidate-retention-{phase}",
+        compose_service="agent",
+        container_id=f"{phase + 1:x}" * 64,
+        image_reference=image.reference,
+        image_id=image.image_id,
+        oci_revision=image.revision,
+        baseline_journal_sequence=None if tail is None else tail.sequence,
+        baseline_journal_sha256=None if tail is None else tail.sha256,
+    )
+
+
+def _record_three_generations(
+    state_dir: Path,
+    environment_dir: Path,
+    images: Sequence[ManagedImage],
+    volume: PersistentVolumeIdentity,
+    *,
+    compose_project: str,
+) -> DeploymentStateStore:
+    store = DeploymentStateStore(state_dir)
+    adopted_environment = environment_dir / "adopted.env"
+    _write_private(
+        adopted_environment,
+        f'PRIVATE="{PRIVATE_CANARY}-adopted"\n'.encode(),
+    )
+    with store.transaction() as transaction:
+        transaction.adopt(
+            compose_project=compose_project,
+            compose_service="agent",
+            source_revision=images[0].revision,
+            image_reference=images[0].reference,
+            image_id=images[0].image_id,
+            oci_revision=images[0].revision,
+            environment_source=adopted_environment,
+            deployment_id="retention-adopted",
+            recorded_at="2026-07-29T00:00:00.000000Z",
+        )
+    for phase, image in enumerate(images[1:3], start=1):
+        environment_path = environment_dir / f"promoted-{phase}.env"
+        _write_private(
+            environment_path,
+            f'PRIVATE="{PRIVATE_CANARY}-promoted-{phase}"\n'.encode(),
+        )
+        with store.transaction() as transaction:
+            pending = transaction.begin_promotion(
+                compose_project=compose_project,
+                compose_service="agent",
+                source_revision=image.revision,
+                image_reference=image.reference,
+                image_id=image.image_id,
+                oci_revision=image.revision,
+                environment_source=environment_path,
+                candidate=_candidate(transaction, image, phase=phase),
+                persistent_volumes=(volume,),
+                transaction_id=f"retention-promoted-{phase}",
+                recorded_at=f"2026-07-29T00:00:0{phase}.000000Z",
+            )
+            transaction.commit_promotion(
+                pending.transaction_id,
+                persistent_volumes=(volume,),
+            )
+    return store
+
+
+def _state_tree(path: Path) -> dict[str, tuple[object, ...]]:
+    result: dict[str, tuple[object, ...]] = {}
+    for selected in sorted((path, *path.rglob("*"))):
+        relative = "." if selected == path else selected.relative_to(path).as_posix()
+        metadata = selected.lstat()
+        mode = stat.S_IMODE(metadata.st_mode)
+        if stat.S_ISDIR(metadata.st_mode):
+            result[relative] = (
+                "directory",
+                mode,
+                metadata.st_ino,
+                metadata.st_mtime_ns,
+            )
+        elif stat.S_ISREG(metadata.st_mode):
+            payload = selected.read_bytes()
+            result[relative] = (
+                "file",
+                mode,
+                metadata.st_ino,
+                metadata.st_mtime_ns,
+                len(payload),
+                hashlib.sha256(payload).hexdigest(),
+            )
+        else:
+            raise AssertionError("deployment state contains a special path")
+    return result
+
+
+def _present_references(
+    docker: str,
+    environment: Mapping[str, str],
+    images: Sequence[ManagedImage],
+) -> frozenset[str]:
+    return frozenset(
+        image.reference
+        for image in images
+        if _inspect_optional(
+            docker,
+            environment,
+            "image",
+            image.reference,
+        )
+        is not None
+    )
+
+
+def _builder_cache_identity(
+    docker: str,
+    environment: Mapping[str, str],
+) -> tuple[BuilderCacheIdentity, ...]:
+    result = _run(
+        [docker, "buildx", "du", "--format=json"],
+        environment=environment,
+        timeout=60,
+    )
+    lines = tuple(line for line in result.stdout.splitlines() if line)
+    if not lines:
+        raise AssertionError("BuildKit cache sentinel was unavailable")
+    expected_fields = {
+        "CreatedAt",
+        "Description",
+        "ID",
+        "LastUsedAt",
+        "Mutable",
+        "Parents",
+        "Reclaimable",
+        "Shared",
+        "Size",
+        "Type",
+        "UsageCount",
+    }
+    identities: list[BuilderCacheIdentity] = []
+    for line in lines:
+        try:
+            document = json.loads(line)
+        except json.JSONDecodeError:
+            raise AssertionError("BuildKit cache identity was invalid") from None
+        if not isinstance(document, dict) or set(document) != expected_fields:
+            raise AssertionError("BuildKit cache identity was invalid")
+        identifier = document["ID"]
+        parents = document["Parents"]
+        parent_identities = () if parents is None else parents
+        created_at = document["CreatedAt"]
+        mutable = document["Mutable"]
+        reclaimable = document["Reclaimable"]
+        size = document["Size"]
+        record_type = document["Type"]
+        description = document["Description"]
+        usage_count = document["UsageCount"]
+        last_used_at = document["LastUsedAt"]
+        if (
+            not isinstance(identifier, str)
+            or not identifier
+            or not isinstance(parent_identities, (list, tuple))
+            or not all(
+                isinstance(parent, str) and parent for parent in parent_identities
+            )
+            or not isinstance(created_at, str)
+            or not created_at
+            or not isinstance(mutable, bool)
+            or not isinstance(reclaimable, bool)
+            or not isinstance(document["Shared"], bool)
+            or not isinstance(size, str)
+            or not isinstance(record_type, str)
+            or not record_type
+            or not isinstance(description, str)
+            or type(usage_count) is not int
+            or not (
+                last_used_at is None
+                or isinstance(last_used_at, str)
+                and bool(last_used_at)
+            )
+        ):
+            raise AssertionError("BuildKit cache identity was invalid")
+        identities.append(
+            (
+                identifier,
+                tuple(parent_identities),
+                created_at,
+                mutable,
+                reclaimable,
+                size,
+                record_type,
+                description,
+                usage_count,
+                last_used_at,
+            )
+        )
+    if len({identity[0] for identity in identities}) != len(identities):
+        raise AssertionError("BuildKit cache identity was ambiguous")
+    return tuple(sorted(identities))
+
+
+def _apply_retention(
+    store: DeploymentStateStore,
+    docker: str,
+    environment: Mapping[str, str],
+    *,
+    image_repository: str,
+    target_reference: str,
+) -> tuple[RetentionPlan, RetentionPlan]:
+    with store.transaction() as transaction:
+        planned = plan_image_retention(
+            transaction,
+            docker=Path(docker),
+            environment=environment,
+            repository=MANAGED_REPOSITORY,
+            target_reference=target_reference,
+            image_repository=image_repository,
+        )
+        applied, admitted, _removed_decisions = apply_image_retention(
+            transaction,
+            docker=Path(docker),
+            environment=environment,
+            repository=MANAGED_REPOSITORY,
+            target_reference=target_reference,
+            image_repository=image_repository,
+        )
+    if not admitted:
+        raise AssertionError("retention did not reserve the target pull slot")
+    return planned, applied
+
+
+def _workflow_job() -> dict[str, object]:
+    document = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    if not isinstance(document, dict):
+        raise AssertionError("Docker workflow was invalid")
+    jobs = document.get("jobs")
+    if not isinstance(jobs, dict):
+        raise AssertionError("Docker workflow jobs were invalid")
+    job = jobs.get("deployment-retention")
+    if not isinstance(job, dict):
+        raise AssertionError("deployment-retention job was unavailable")
+    return job
+
+
+def test_hosted_retention_job_is_exact_and_isolated() -> None:
+    """Run only the opted-in real-Docker node through an isolated pytest boundary."""
+    job = _workflow_job()
+    steps = job.get("steps")
+    assert isinstance(steps, list)
+    matches = [
+        step
+        for step in steps
+        if isinstance(step, dict)
+        and step.get("name") == "Run bounded VM image-retention proof"
+    ]
+    assert len(matches) == 1
+    execution = matches[0]
+    assert set(job) == {"name", "runs-on", "timeout-minutes", "env", "steps"}
+    assert job["name"] == "Validate bounded VM image retention"
+    assert job["runs-on"] == "ubuntu-latest"
+    assert job["timeout-minutes"] == 30
+    assert job["env"] == {
+        RUN_ENVIRONMENT_NAME: "1",
+        PREFIX_ENVIRONMENT_NAME: "adk-retention-${{ github.run_id }}",
+    }
+    assert [step.get("name") for step in steps if isinstance(step, dict)] == [
+        "Checkout repository",
+        "Install uv",
+        "Install Python",
+        "Install locked dependencies",
+        "Run bounded VM image-retention proof",
+    ]
+    assert set(execution) == {"name", "env", "run"}
+    assert execution["env"] == {
+        "PYTEST_ADDOPTS": "",
+        "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
+        "PYTEST_PLUGINS": "",
+        "PYTHONDONTWRITEBYTECODE": "1",
+    }
+    run = execution.get("run")
+    assert isinstance(run, str)
+    assert " ".join(run.split()) == (
+        "uv run --locked --no-sync pytest "
+        "--noconftest --confcutdir=tests "
+        "-o addopts= -p no:cacheprovider "
+        "tests/test_deployment_retention_runtime.py::"
+        "test_real_docker_retention_reserves_one_exact_pull_slot "
+        "-q --tb=line --disable-warnings --show-capture=no"
+    )
+
+
+def test_runtime_cleanup_is_exact_owned_and_never_forced() -> None:
+    """Keep test cleanup inside the exact resources created by this proof."""
+    cleanup = inspect.getsource(_cleanup_target)
+    ownership = inspect.getsource(_owned_document)
+
+    assert cleanup.index("_owned_document(") < cleanup.index("command =")
+    assert "_owned_document(docker, environment, target)" in cleanup
+    assert "expected_owner" in ownership
+    assert "expected_id" in ownership
+    assert '"--no-prune"' in cleanup
+    assert '"--force"' not in cleanup
+    assert '"image", "prune"' not in cleanup
+    assert '"builder", "prune"' not in cleanup
+    assert '"buildx", "prune"' not in cleanup
+    assert '"system", "prune"' not in cleanup
+
+
+@pytest.mark.skipif(
+    os.environ.get(RUN_ENVIRONMENT_NAME) != "1",
+    reason="real deployment-retention Docker proof is opt-in",
+)
+def test_real_docker_retention_reserves_one_exact_pull_slot(
+    tmp_path: Path,
+) -> None:
+    """Delete one owned digest, pull the target, and preserve every sentinel."""
+    environment = _base_environment()
+    docker = _require_docker(environment)
+    prefix = _resource_prefix()
+    registry_name = f"{prefix}-registry"
+    running_container = f"{prefix}-running"
+    stopped_container = f"{prefix}-stopped"
+    sentinel_network = f"{prefix}-network"
+    sentinel_volume = f"{prefix}-volume"
+    foreign_tag = f"{prefix}-foreign:keep"
+    derivative_context = tmp_path / "derivative"
+    state_dir = tmp_path / "deployment-state"
+    environment_dir = tmp_path / "environments"
+    environment_dir.mkdir(mode=0o700)
+    cleanup_targets: list[CleanupTarget] = []
+    primary_error: BaseException | None = None
+
+    try:
+        registry_image_id = _ensure_registry_image(
+            docker,
+            environment,
+            cleanup_targets,
+        )
+        endpoint = _start_registry(
+            docker,
+            environment,
+            cleanup_targets,
+            name=registry_name,
+            image_id=registry_image_id,
+            owner=prefix,
+        )
+        repository = f"{endpoint}/{prefix}/agent"
+        _write_derivative_context(derivative_context)
+        images = tuple(
+            _publish_managed_image(
+                docker,
+                environment,
+                cleanup_targets,
+                context=derivative_context,
+                repository=repository,
+                phase=phase,
+                owner=prefix,
+                keep_local=phase < 8,
+            )
+            for phase in range(9)
+        )
+        assert len({image.image_id for image in images}) == 9
+        assert len({image.reference for image in images}) == 9
+        assert len({image.revision for image in images}) == 9
+        assert _present_references(docker, environment, images) == frozenset(
+            image.reference for image in images[:8]
+        )
+
+        _assert_absent(docker, environment, "image", foreign_tag)
+        _run(
+            [docker, "image", "tag", registry_image_id, foreign_tag],
+            environment=environment,
+            timeout=30,
+        )
+        cleanup_targets.append(
+            CleanupTarget(
+                kind="image",
+                reference=foreign_tag,
+                expected_id=registry_image_id,
+            )
+        )
+
+        sentinel_resources: tuple[tuple[ResourceKind, str], ...] = (
+            ("network", sentinel_network),
+            ("volume", sentinel_volume),
+            ("container", running_container),
+            ("container", stopped_container),
+        )
+        for kind, name in sentinel_resources:
+            _assert_absent(docker, environment, kind, name)
+        cleanup_targets.append(
+            CleanupTarget(
+                kind="network",
+                reference=sentinel_network,
+                expected_owner=prefix,
+            )
+        )
+        _run(
+            [
+                docker,
+                "network",
+                "create",
+                "--label",
+                f"{OWNER_LABEL}={prefix}",
+                sentinel_network,
+            ],
+            environment=environment,
+            timeout=30,
+        )
+        cleanup_targets.append(
+            CleanupTarget(
+                kind="volume",
+                reference=sentinel_volume,
+                expected_owner=prefix,
+            )
+        )
+        _run(
+            [
+                docker,
+                "volume",
+                "create",
+                "--label",
+                f"{OWNER_LABEL}={prefix}",
+                sentinel_volume,
+            ],
+            environment=environment,
+            timeout=30,
+        )
+        cleanup_targets.append(
+            CleanupTarget(
+                kind="container",
+                reference=stopped_container,
+                expected_owner=prefix,
+            )
+        )
+        _run(
+            [
+                docker,
+                "container",
+                "create",
+                "--name",
+                stopped_container,
+                "--label",
+                f"{OWNER_LABEL}={prefix}",
+                "--network",
+                "none",
+                "--entrypoint",
+                "/bin/true",
+                images[6].reference,
+            ],
+            environment=environment,
+            timeout=30,
+        )
+        cleanup_targets.append(
+            CleanupTarget(
+                kind="container",
+                reference=running_container,
+                expected_owner=prefix,
+            )
+        )
+        _run(
+            [
+                docker,
+                "container",
+                "create",
+                "--name",
+                running_container,
+                "--label",
+                f"{OWNER_LABEL}={prefix}",
+                "--network",
+                sentinel_network,
+                "--mount",
+                f"type=volume,source={sentinel_volume},target=/sentinel",
+                "--entrypoint",
+                "/bin/sh",
+                images[7].reference,
+                "-c",
+                (f"printf %s {VOLUME_SENTINEL} > /sentinel/value; exec sleep 600"),
+            ],
+            environment=environment,
+            timeout=30,
+        )
+        _run(
+            [docker, "container", "start", running_container],
+            environment=environment,
+            timeout=30,
+        )
+        running_document = _container_document(
+            docker,
+            environment,
+            running_container,
+        )
+        running_state = running_document.get("State")
+        if (
+            not isinstance(running_state, dict)
+            or running_state.get("Running") is not True
+        ):
+            raise AssertionError("managed sentinel container did not start")
+        if (
+            _run(
+                [
+                    docker,
+                    "container",
+                    "exec",
+                    running_container,
+                    "cat",
+                    "/sentinel/value",
+                ],
+                environment=environment,
+                timeout=30,
+            ).stdout
+            != VOLUME_SENTINEL
+        ):
+            raise AssertionError("managed sentinel volume data was invalid")
+
+        volume = _recorded_volume(
+            docker,
+            environment,
+            sentinel_volume,
+        )
+        store = _record_three_generations(
+            state_dir,
+            environment_dir,
+            images,
+            volume,
+            compose_project=f"retention-{uuid.uuid4().hex[:12]}",
+        )
+        with store.transaction() as transaction:
+            current = transaction.current()
+            assert current is not None
+            assert current.state.image_reference == images[2].reference
+            assert [entry.event for entry in transaction.journal()] == [
+                "adopted",
+                "promoted",
+                "promoted",
+            ]
+            assert transaction.pending() is None
+
+        state_identity = _state_tree(state_dir)
+        running_identity = _container_identity(running_document)
+        stopped_identity = _container_identity(
+            _container_document(docker, environment, stopped_container)
+        )
+        network_document = _inspect_optional(
+            docker,
+            environment,
+            "network",
+            sentinel_network,
+        )
+        if network_document is None:
+            raise AssertionError("sentinel network was unavailable")
+        network_identity = _network_identity(network_document)
+        volume_identity = _volume_identity(
+            _volume_document(docker, environment, sentinel_volume)
+        )
+        foreign_document = _inspect_optional(
+            docker,
+            environment,
+            "image",
+            foreign_tag,
+        )
+        if foreign_document is None:
+            raise AssertionError("foreign sentinel image was unavailable")
+        foreign_identity = _image_identity(foreign_document)
+        registry_identity = _container_identity(
+            _container_document(docker, environment, registry_name)
+        )
+
+        protected_images = (*images[:3], images[6], images[7])
+        protected_image_identities = {
+            image.reference: _image_identity(
+                _managed_image_document(
+                    docker,
+                    environment,
+                    image.reference,
+                    owner=prefix,
+                    revision=image.revision,
+                )
+            )
+            for image in protected_images
+        }
+        before = _present_references(docker, environment, images)
+        builder_cache_identity = _builder_cache_identity(docker, environment)
+        expected_deleted = min(image.reference for image in images[3:6])
+        planned, applied = _apply_retention(
+            store,
+            docker,
+            environment,
+            image_repository=repository,
+            target_reference=images[8].reference,
+        )
+        assert planned.delete_references == (expected_deleted,)
+        assert planned.admitted_count == 9
+        assert not planned.admitted
+        assert applied.delete_references == ()
+        assert applied.admitted_count == 8
+        assert applied.admitted
+        assert _builder_cache_identity(docker, environment) == builder_cache_identity
+        after_retention = _present_references(docker, environment, images)
+        assert before - after_retention == {expected_deleted}
+        assert after_retention - before == set()
+        assert len(after_retention) == 7
+        for protected in (*images[:3], images[6], images[7]):
+            assert protected.reference in after_retention
+        assert images[8].reference not in after_retention
+
+        _run(
+            [docker, "image", "pull", images[8].reference],
+            environment=environment,
+            timeout=180,
+        )
+        target_document = _managed_image_document(
+            docker,
+            environment,
+            images[8].reference,
+            owner=prefix,
+            revision=images[8].revision,
+        )
+        assert _resource_identity("image", target_document) == images[8].image_id
+        expected_present = {image.reference for image in images}
+        expected_present.remove(expected_deleted)
+        assert _present_references(
+            docker,
+            environment,
+            images,
+        ) == frozenset(expected_present)
+        assert len(_present_references(docker, environment, images)) == 8
+
+        before_admission = _state_tree(state_dir)
+        with store.transaction() as transaction:
+            plan = enforce_pull_admission(
+                transaction,
+                docker=Path(docker),
+                environment=environment,
+                repository=MANAGED_REPOSITORY,
+                target_reference=images[8].reference,
+                image_repository=repository,
+            )
+        assert isinstance(plan, RetentionPlan)
+        assert _state_tree(state_dir) == before_admission == state_identity
+
+        assert {
+            image.reference: _image_identity(
+                _managed_image_document(
+                    docker,
+                    environment,
+                    image.reference,
+                    owner=prefix,
+                    revision=image.revision,
+                )
+            )
+            for image in protected_images
+        } == protected_image_identities
+        assert (
+            _container_identity(
+                _container_document(docker, environment, running_container)
+            )
+            == running_identity
+        )
+        assert (
+            _container_identity(
+                _container_document(docker, environment, stopped_container)
+            )
+            == stopped_identity
+        )
+        final_network = _inspect_optional(
+            docker,
+            environment,
+            "network",
+            sentinel_network,
+        )
+        assert final_network is not None
+        assert _network_identity(final_network) == network_identity
+        assert (
+            _volume_identity(_volume_document(docker, environment, sentinel_volume))
+            == volume_identity
+        )
+        assert (
+            _run(
+                [
+                    docker,
+                    "container",
+                    "exec",
+                    running_container,
+                    "cat",
+                    "/sentinel/value",
+                ],
+                environment=environment,
+                timeout=30,
+            ).stdout
+            == VOLUME_SENTINEL
+        )
+        final_foreign = _inspect_optional(
+            docker,
+            environment,
+            "image",
+            foreign_tag,
+        )
+        assert final_foreign is not None
+        assert _image_identity(final_foreign) == foreign_identity
+        assert (
+            _container_identity(_container_document(docker, environment, registry_name))
+            == registry_identity
+        )
+    except BaseException as error:
+        primary_error = error
+        raise
+    finally:
+        _report_cleanup_failures(
+            _execute_cleanup(docker, environment, cleanup_targets),
+            primary_error,
+        )

--- a/tests/test_deployment_retention_runtime.py
+++ b/tests/test_deployment_retention_runtime.py
@@ -16,6 +16,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
+from unittest.mock import create_autospec, patch
 from urllib.error import URLError
 from urllib.request import ProxyHandler, build_opener
 
@@ -215,15 +216,20 @@ def _inspect_optional(
         timeout=30,
     )
     if result.returncode != 0:
-        if any(
-            marker in result.stderr
-            for marker in (
-                "No such image",
-                "No such container",
-                "No such network",
-                "No such object",
-                "No such volume",
-            )
+        exact_absence_errors = {
+            "container": (
+                f"Error response from daemon: No such container: {reference}\n"
+            ),
+            "image": f"Error response from daemon: No such image: {reference}\n",
+            "network": f"Error response from daemon: network {reference} not found\n",
+            "volume": (
+                f"Error response from daemon: get {reference}: no such volume\n"
+            ),
+        }
+        if (
+            result.returncode == 1
+            and result.stdout in {"[]", "[]\n"}
+            and result.stderr == exact_absence_errors[kind]
         ):
             return None
         raise AssertionError(f"Docker {kind} inspection failed")
@@ -1016,6 +1022,72 @@ def _workflow_job() -> dict[str, object]:
     if not isinstance(job, dict):
         raise AssertionError("deployment-retention job was unavailable")
     return job
+
+
+@pytest.mark.parametrize(
+    ("kind", "stderr"),
+    [
+        (
+            "container",
+            "Error response from daemon: No such container: fixture\n",
+        ),
+        ("image", "Error response from daemon: No such image: fixture\n"),
+        ("network", "Error response from daemon: network fixture not found\n"),
+        ("volume", "Error response from daemon: get fixture: no such volume\n"),
+    ],
+)
+def test_optional_inspection_accepts_exact_docker_absence(
+    kind: ResourceKind,
+    stderr: str,
+) -> None:
+    """Match the reference-bound absence output emitted by Docker inspect."""
+    result = subprocess.CompletedProcess(
+        ["docker", kind, "inspect", "fixture"],
+        1,
+        stdout="[]\n",
+        stderr=stderr,
+    )
+    runner = create_autospec(_run, spec_set=True, return_value=result)
+
+    with patch(f"{__name__}._run", runner):
+        assert _inspect_optional("docker", {}, kind, "fixture") is None
+
+    runner.assert_called_once_with(
+        ["docker", kind, "inspect", "fixture"],
+        environment={},
+        check=False,
+        timeout=30,
+    )
+
+
+@pytest.mark.parametrize(
+    ("returncode", "stdout", "stderr"),
+    [
+        (1, "", "Error response from daemon: network fixture not found\n"),
+        (1, "[]\n", "Error response from daemon: network other not found\n"),
+        (1, "[]\n", "Error response from daemon: No such network: fixture\n"),
+        (2, "[]\n", "Error response from daemon: network fixture not found\n"),
+    ],
+)
+def test_optional_inspection_rejects_ambiguous_absence(
+    returncode: int,
+    stdout: str,
+    stderr: str,
+) -> None:
+    """Fail closed when Docker's status, identity, or JSON output disagrees."""
+    result = subprocess.CompletedProcess(
+        ["docker", "network", "inspect", "fixture"],
+        returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+    runner = create_autospec(_run, spec_set=True, return_value=result)
+
+    with (
+        patch(f"{__name__}._run", runner),
+        pytest.raises(AssertionError, match="network inspection failed"),
+    ):
+        _inspect_optional("docker", {}, "network", "fixture")
 
 
 def test_hosted_retention_job_is_exact_and_isolated() -> None:

--- a/tests/test_deployment_retention_runtime.py
+++ b/tests/test_deployment_retention_runtime.py
@@ -709,8 +709,20 @@ def _container_identity(document: Mapping[str, object]) -> dict[str, object]:
         and isinstance(config, dict)
         and isinstance(network, dict)
         and isinstance(mounts, list)
+        and all(isinstance(mount, dict) for mount in mounts)
     ):
         raise AssertionError("sentinel container identity was invalid")
+    canonical_mounts = tuple(
+        sorted(
+            mounts,
+            key=lambda mount: json.dumps(
+                mount,
+                ensure_ascii=True,
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+        )
+    )
     return {
         "Id": document.get("Id"),
         "Name": document.get("Name"),
@@ -728,7 +740,7 @@ def _container_identity(document: Mapping[str, object]) -> dict[str, object]:
                 "FinishedAt",
             )
         },
-        "Mounts": mounts,
+        "Mounts": canonical_mounts,
         "Networks": network.get("Networks"),
     }
 
@@ -1178,6 +1190,49 @@ def test_builder_cache_identity_rejects_invalid_last_used_age(
         pytest.raises(AssertionError, match="cache identity was invalid"),
     ):
         _builder_cache_identity("docker", {})
+
+
+def test_container_identity_canonicalizes_mount_order() -> None:
+    """Treat Docker's top-level mount array as an unordered resource set."""
+    mounts = [
+        {
+            "Type": "volume",
+            "Name": "sentinel-volume",
+            "Source": "/var/lib/docker/volumes/sentinel/_data",
+            "Destination": "/sentinel",
+            "Driver": "local",
+            "Mode": "z",
+            "RW": True,
+            "Propagation": "",
+        },
+        {
+            "Type": "volume",
+            "Name": "anonymous-volume",
+            "Source": "/var/lib/docker/volumes/anonymous/_data",
+            "Destination": "/var/lib/registry",
+            "Driver": "local",
+            "Mode": "",
+            "RW": True,
+            "Propagation": "",
+        },
+    ]
+    document = {
+        "State": {},
+        "Config": {},
+        "NetworkSettings": {"Networks": {}},
+        "Mounts": mounts,
+    }
+    reordered = {**document, "Mounts": list(reversed(mounts))}
+    changed = {
+        **document,
+        "Mounts": [mounts[0], {**mounts[1], "RW": False}],
+    }
+
+    identity = _container_identity(document)
+    assert _container_identity(reordered) == identity
+    assert _container_identity(changed) != identity
+    with pytest.raises(AssertionError, match="container identity was invalid"):
+        _container_identity({**document, "Mounts": [*mounts, "invalid"]})
 
 
 def test_hosted_retention_job_is_exact_and_isolated() -> None:

--- a/tests/test_deployment_retention_workflow.py
+++ b/tests/test_deployment_retention_workflow.py
@@ -1,0 +1,151 @@
+"""Static contracts for bounded VM image-retention integration."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import cast
+
+import yaml  # type: ignore[import-untyped]
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "docker-publish.yml"
+BOOTSTRAP_PATH = ROOT / "scripts" / "deployment_bootstrap.sh"
+DEPLOYMENT_GUIDE_PATH = ROOT / "docs" / "DEPLOYMENT.md"
+RETENTION_MODULE = "src/agent/deployment_retention.py"
+
+
+def _workflow() -> dict[str, object]:
+    document = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    assert isinstance(document, dict)
+    return document
+
+
+def _steps(job: str) -> list[dict[str, object]]:
+    jobs = _workflow()["jobs"]
+    assert isinstance(jobs, dict)
+    selected = jobs[job]
+    assert isinstance(selected, dict)
+    steps = selected["steps"]
+    assert isinstance(steps, list)
+    return cast(list[dict[str, object]], steps)
+
+
+def _step(job: str, name: str) -> dict[str, object]:
+    matches = [step for step in _steps(job) if step.get("name") == name]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def _run_text(job: str, name: str) -> str:
+    command = _step(job, name)["run"]
+    assert isinstance(command, str)
+    return command
+
+
+def test_published_image_has_stable_repository_ownership_label() -> None:
+    """Bind retention ownership to the repository that built the image."""
+    build = _step("build", "Build and push Docker image")
+    configuration = build["with"]
+    assert isinstance(configuration, dict)
+    labels = configuration["labels"]
+    assert isinstance(labels, str)
+
+    assert (
+        "io.queryplanner.adk.repository=${{ github.repository }}" in labels.splitlines()
+    )
+
+
+def test_bootstrap_binds_retention_module_to_the_exact_release() -> None:
+    """Verify the module before either local source use or remote execution."""
+    prepare = _run_text("deploy", "Prepare private deployment transport")
+    bootstrap = BOOTSTRAP_PATH.read_text(encoding="utf-8")
+
+    assert RETENTION_MODULE in prepare
+    assert 'git ls-tree "$DEPLOY_SHA" -- "$SOURCE_PATH"' in prepare
+    assert bootstrap.count(RETENTION_MODULE) == 2
+    assert 'ls-tree "$DEPLOY_SHA" -- "$TARGET_PATH"' in bootstrap
+    assert '[ ! -f "$RELEASE_DIR/$TARGET_PATH" ]' in bootstrap
+    assert '[ -L "$RELEASE_DIR/$TARGET_PATH" ]' in bootstrap
+
+
+def test_retention_blocks_before_promotion_with_only_safe_inputs() -> None:
+    """Run retention first and keep production secrets out of its boundary."""
+    script = _run_text("deploy", "Run locked transactional deployment")
+    retention_start = script.index('RETENTION_COMMAND="')
+    retention_result = script.index("RETENTION_STATUS=$?")
+    retention_gate = script.index('if [ "$RETENTION_STATUS" -ne 0 ]')
+    promotion_start = script.index('CONTROLLER_COMMAND="')
+    promotion_result = script.index("CONTROLLER_STATUS=$?")
+    retention = script[retention_start:promotion_start]
+    promotion = script[promotion_start:promotion_result]
+
+    assert script.index("BOOTSTRAP_STATUS=${PIPESTATUS[0]}") < retention_start
+    assert retention_start < retention_result < retention_gate < promotion_start
+    assert 'exit "$RETENTION_STATUS"' in script[retention_gate:promotion_start]
+    assert (
+        'runpy.run_module(\\"agent.deployment_retention\\", '
+        'run_name=\\"__main__\\", alter_sys=True)'
+    ) in retention
+    assert "python3 -I -S -B" in retention
+    assert "exec flock -n" in retention
+    assert "env -i" in retention
+    assert "--state-dir" in retention
+    assert '--repository \\"${{ github.repository }}\\"' in retention
+    assert '--target-reference \\"$IMAGE_REPOSITORY@$IMAGE_DIGEST\\"' in retention
+    assert "--apply" in retention
+    assert '"$RETENTION_COMMAND" < /dev/null' in retention
+    assert "10m" in retention
+    assert "incomplete" not in promotion
+
+    for forbidden in (
+        "AGENT_NAME",
+        "DATABASE_URL",
+        "OPENROUTER_API_KEY",
+        "GOOGLE_API_KEY",
+        "LANGFUSE_SECRET_KEY",
+        "SSH_PRIVATE_KEY",
+        "PAYLOAD_FILE",
+        "--environment-stdin",
+        "docker image",
+        " prune",
+        "--force",
+    ):
+        assert forbidden not in retention
+
+    assert (
+        script.count(
+            'runpy.run_module(\\"agent.deployment_promotion\\", '
+            'run_name=\\"__main__\\", alter_sys=True)'
+        )
+        == 1
+    )
+    assert '--repository \\"${{ github.repository }}\\"' in promotion
+    assert "--environment-stdin" in promotion
+
+
+def test_deployment_guide_documents_the_bounded_policy_and_dry_run() -> None:
+    """Keep cache limits and pre-pull failure semantics operator-visible."""
+    document = DEPLOYMENT_GUIDE_PATH.read_text(encoding="utf-8")
+    normalized = " ".join(document.split())
+    blocks = re.findall(r"(?ms)^```bash[ \t]*\n(.*?)^```[ \t]*$", document)
+    dry_runs = [
+        block for block in blocks if "-m agent.deployment_retention enforce" in block
+    ]
+
+    assert len(dry_runs) == 1
+    assert "--apply" not in dry_runs[0]
+    for fragment in (
+        "hard maximum of eight managed digest references",
+        "reduces the cache to seven",
+        "reserves the eighth slot",
+        "two newest distinct prior",
+        "three-generation local rollback cache",
+        "at most five exact",
+        "incomplete nonzero result",
+        "workflow stops before the target pull",
+        "An unreachable plan fails without deleting anything",
+        "exact digest with `--no-prune`",
+        "retention failure does not roll back",
+    ):
+        assert fragment in normalized

--- a/tests/test_deployment_workflow.py
+++ b/tests/test_deployment_workflow.py
@@ -167,6 +167,7 @@ def _git_harness(
         "src/agent/compose_env.py": "VALUE = 'compose'\n",
         "src/agent/deployment_adoption.py": "VALUE = 'adoption'\n",
         "src/agent/deployment_promotion.py": "VALUE = 'promotion'\n",
+        "src/agent/deployment_retention.py": "VALUE = 'retention'\n",
         "src/agent/deployment_state.py": "VALUE = 'state'\n",
     }
     for relative, content in tracked.items():
@@ -543,7 +544,7 @@ def test_openssh_transport_is_strict_direct_and_lease_gated() -> None:
     assert "CONTROLLER_FILE" not in script
     assert "REMOTE_CLEANUP_ALLOWED=0" not in controller
     assert "124|137|143|255" in script
-    assert script.count("checking the lease") == 2
+    assert script.count("checking the lease") == 3
     assert "timeout --signal=TERM --kill-after=30s 8m" in script
     assert "timeout --signal=TERM --kill-after=30s 30m" in script
     assert "timeout --signal=TERM --kill-after=15s 2m" in script


### PR DESCRIPTION
## What

Add a bounded, repository-owned Docker image retention policy for single-VM
deployments and enforce its capacity contract around every promotion pull.

## Why

Immutable digest deployments accumulate images indefinitely on a long-lived VM.
The deployment path needs deterministic reclamation without global pruning,
mutable references, or risk to rollback generations and unrelated Docker data.

## How

- Label published images with a stable repository ownership identity.
- Reserve one of eight managed-image slots before pulling an absent target.
- Keep the target, current and two prior generations, and all container images.
- Re-plan and verify every exact digest deletion under the deployment lock.
- Repeat strict read-only admission before and after the promotion pull.
- Emit deterministic keep, delete, and verified-removal reasons.
- Add unit, workflow, and isolated hosted real-Docker proofs.
- Document the fixed ceiling, five-delete batch, and operator dry run.

## Tests

- [x] `uv sync --locked`
- [x] `uv run ruff format --check`
- [x] `uv run ruff check --no-fix --output-format=github`
- [x] `uv run mypy .`
- [x] `uv run pytest --cov=src --cov-report=xml --cov-report=term-missing`
      (1,201 passed, 10 skipped, 100% statement and branch coverage)
- [x] GitHub Actions: Validate atomic VM promotion and rollback
- [x] GitHub Actions: Validate bounded VM image retention

## Related Issues

Closes #127

Part of #111
